### PR TITLE
n8n-auto-pr (N8N - 235477)

### DIFF
--- a/packages/frontend/editor-ui/src/init.test.ts
+++ b/packages/frontend/editor-ui/src/init.test.ts
@@ -137,7 +137,6 @@ describe('Init', () => {
 
 		it('should not init authenticated features if user is not logged in', async () => {
 			const cloudStoreSpy = vi.spyOn(cloudPlanStore, 'initialize');
-			const templatesTestSpy = vi.spyOn(settingsStore, 'testTemplatesEndpoint');
 			const sourceControlSpy = vi.spyOn(sourceControlStore, 'getPreferences');
 			const nodeTranslationSpy = vi.spyOn(nodeTypesStore, 'getNodeTranslationHeaders');
 			vi.mocked(useUsersStore).mockReturnValue({ currentUser: null } as ReturnType<
@@ -146,14 +145,12 @@ describe('Init', () => {
 
 			await initializeAuthenticatedFeatures();
 			expect(cloudStoreSpy).not.toHaveBeenCalled();
-			expect(templatesTestSpy).not.toHaveBeenCalled();
 			expect(sourceControlSpy).not.toHaveBeenCalled();
 			expect(nodeTranslationSpy).not.toHaveBeenCalled();
 		});
 
 		it('should init authenticated features only once if user is logged in', async () => {
 			const cloudStoreSpy = vi.spyOn(cloudPlanStore, 'initialize');
-			const templatesTestSpy = vi.spyOn(settingsStore, 'testTemplatesEndpoint');
 			const sourceControlSpy = vi.spyOn(sourceControlStore, 'getPreferences');
 			const nodeTranslationSpy = vi.spyOn(nodeTypesStore, 'getNodeTranslationHeaders');
 			vi.mocked(useUsersStore).mockReturnValue({ currentUser: { id: '123' } } as ReturnType<
@@ -163,7 +160,6 @@ describe('Init', () => {
 			await initializeAuthenticatedFeatures();
 
 			expect(cloudStoreSpy).toHaveBeenCalled();
-			expect(templatesTestSpy).toHaveBeenCalled();
 			expect(sourceControlSpy).toHaveBeenCalled();
 			expect(nodeTranslationSpy).toHaveBeenCalled();
 

--- a/packages/frontend/editor-ui/src/init.ts
+++ b/packages/frontend/editor-ui/src/init.ts
@@ -121,12 +121,6 @@ export async function initializeAuthenticatedFeatures(
 		}
 	}
 
-	if (settingsStore.isTemplatesEnabled) {
-		try {
-			await settingsStore.testTemplatesEndpoint();
-		} catch (e) {}
-	}
-
 	if (rootStore.defaultLocale !== 'en') {
 		await nodeTypesStore.getNodeTranslationHeaders();
 	}

--- a/packages/frontend/editor-ui/src/views/TemplatesSearchView.vue
+++ b/packages/frontend/editor-ui/src/views/TemplatesSearchView.vue
@@ -301,6 +301,11 @@ onMounted(async () => {
 
 	restoreSearchFromRoute();
 
+	// Check if templates are enabled and check if the local templates store is available
+	if (settingsStore.isTemplatesEnabled) {
+		settingsStore.testTemplatesEndpoint().catch(() => {});
+	}
+
 	setTimeout(() => {
 		// Check if there is scroll position saved in route and scroll to it
 		const scrollOffset = route.meta?.scrollOffset;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Moved the templates endpoint health check from global initialization to the Templates Search view to avoid unnecessary calls.

- **Refactors**
  - Removed the health check from the main app init and related tests.
  - Now the check runs only when the Templates Search view loads.

<!-- End of auto-generated description by cubic. -->

