### PR TITLE
n8n-auto-pr (N8N - 239346)

### DIFF
--- a/packages/frontend/editor-ui/src/composables/useRunWorkflow.ts
+++ b/packages/frontend/editor-ui/src/composables/useRunWorkflow.ts
@@ -504,7 +504,8 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 			// Wait for websocket event to update the execution status to 'canceled'
 			const markedAsStopped = await retry(
 				async () => {
-					if (workflowsStore.workflowExecutionData?.status !== 'running') {
+					const execution = await workflowsStore.getExecution(executionId);
+					if (!['running', 'waiting'].includes(execution?.status as string)) {
 						workflowsStore.markExecutionAsStopped();
 						return true;
 					}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Improved workflow execution cancellation by checking for both "running" and "waiting" statuses before marking an execution as stopped.

- **Bug Fixes**
  - Fixed an issue where executions could be incorrectly marked as stopped if not in a cancelable state.
  - Updated tests to cover the new status checks.

<!-- End of auto-generated description by cubic. -->

