### PR TITLE
n8n-auto-pr (N8N - 240081)

### DIFF
--- a/packages/frontend/editor-ui/src/init.test.ts
+++ b/packages/frontend/editor-ui/src/init.test.ts
@@ -18,9 +18,10 @@ import { EnterpriseEditionFeature } from '@/constants';
 import { useUIStore } from '@/stores/ui.store';
 
 const showMessage = vi.fn();
+const showToast = vi.fn();
 
 vi.mock('@/composables/useToast', () => ({
-	useToast: () => ({ showMessage }),
+	useToast: () => ({ showMessage, showToast }),
 }));
 
 vi.mock('@/stores/users.store', () => ({
@@ -88,6 +89,23 @@ describe('Init', () => {
 			await initializeCore();
 
 			expect(settingsStoreSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it('should throw an error if settings initialization fails', async () => {
+			const error = new Error('Settings initialization failed');
+
+			vi.spyOn(settingsStore, 'initialize').mockImplementation(() => {
+				throw error;
+			});
+
+			await initializeCore();
+
+			expect(showToast).toHaveBeenCalledWith(
+				expect.objectContaining({
+					title: 'Error connecting to n8n',
+					type: 'error',
+				}),
+			);
 		});
 
 		it('should initialize authentication hooks', async () => {

--- a/packages/frontend/editor-ui/src/init.ts
+++ b/packages/frontend/editor-ui/src/init.ts
@@ -43,13 +43,25 @@ export async function initializeCore() {
 	const ssoStore = useSSOStore();
 	const uiStore = useUIStore();
 
+	const toast = useToast();
+	const i18n = useI18n();
+
 	registerAuthenticationHooks();
 
 	/**
 	 * Initialize stores
 	 */
 
-	await settingsStore.initialize();
+	try {
+		await settingsStore.initialize();
+	} catch (error) {
+		toast.showToast({
+			title: i18n.baseText('startupError'),
+			message: i18n.baseText('startupError.message'),
+			type: 'error',
+			duration: 0,
+		});
+	}
 
 	ssoStore.initialize({
 		authenticationMethod: settingsStore.userManagement

--- a/packages/frontend/editor-ui/src/stores/settings.store.ts
+++ b/packages/frontend/editor-ui/src/stores/settings.store.ts
@@ -21,12 +21,9 @@ import type { IDataObject, WorkflowSettings } from 'n8n-workflow';
 import { defineStore } from 'pinia';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { makeRestApiRequest } from '@n8n/rest-api-client';
-import { useToast } from '@/composables/useToast';
-import { useI18n } from '@n8n/i18n';
 import { useLocalStorage } from '@vueuse/core';
 
 export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
-	const i18n = useI18n();
 	const initialized = ref(false);
 	const settings = ref<FrontendSettings>({} as FrontendSettings);
 	const moduleSettings = ref<FrontendModuleSettings>({});
@@ -265,23 +262,11 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 			return;
 		}
 
-		const { showToast } = useToast();
-		try {
-			await getSettings();
+		await getSettings();
 
-			initialized.value = true;
+		initialized.value = true;
 
-			await getModuleSettings();
-		} catch (e) {
-			showToast({
-				title: i18n.baseText('startupError'),
-				message: i18n.baseText('startupError.message'),
-				type: 'error',
-				duration: 0,
-			});
-
-			throw e;
-		}
+		await getModuleSettings();
 	};
 
 	const stopShowingSetupPage = () => {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Moved error handling for settings initialization from the settings store to the core initialization logic. Now, startup errors show a toast notification from the main init flow instead of inside the store.

- **Refactors**
 - Removed toast and i18n dependencies from the settings store.
 - Added error toast display to the core initialization function.

<!-- End of auto-generated description by cubic. -->

