### PR TITLE
n8n-auto-pr (N8N - 258164)

### DIFF
--- a/packages/cli/src/__tests__/credential-types.test.ts
+++ b/packages/cli/src/__tests__/credential-types.test.ts
@@ -117,5 +117,26 @@ describe('CredentialTypes', () => {
 
 			expect(credentialTypes.getParentTypes('unknownCredential')).toBeEmptyArray();
 		});
+
+		test('Should not mutate the original extends array', () => {
+			const knownCredentials = {
+				childType: { extends: ['parentType'] },
+				parentType: { extends: ['grandparentType'] },
+				grandparentType: { extends: [] },
+			};
+
+			const credentialTypes = new CredentialTypes(
+				mock<LoadNodesAndCredentials>({ knownCredentials }),
+			);
+
+			const originalExtends = knownCredentials.childType.extends;
+			const originalLength = originalExtends.length;
+
+			credentialTypes.getParentTypes('childType');
+			credentialTypes.getParentTypes('childType');
+			credentialTypes.getParentTypes('childType');
+
+			expect(originalExtends).toHaveLength(originalLength);
+		});
 	});
 });

--- a/packages/cli/src/credential-types.ts
+++ b/packages/cli/src/credential-types.ts
@@ -25,11 +25,15 @@ export class CredentialTypes implements ICredentialTypes {
 	 */
 	getParentTypes(typeName: string): string[] {
 		const extendsArr = this.loadNodesAndCredentials.knownCredentials[typeName]?.extends ?? [];
-		if (extendsArr.length) {
-			extendsArr.forEach((type) => {
-				extendsArr.push(...this.getParentTypes(type));
-			});
+
+		if (extendsArr.length === 0) return [];
+
+		const extendsArrCopy = [...extendsArr];
+
+		for (const type of extendsArrCopy) {
+			extendsArrCopy.push(...this.getParentTypes(type));
 		}
-		return extendsArr;
+
+		return extendsArrCopy;
 	}
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed a bug where calling getParentTypes could change the original extends array for credential types.

- **Bug Fixes**
  - getParentTypes now works on a copy of the extends array to prevent unwanted mutations.
  - Added a test to ensure the original extends array stays unchanged after multiple calls.

<!-- End of auto-generated description by cubic. -->

