### PR TITLE
n8n-auto-pr (N8N - 316841)

### DIFF
--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -157,11 +157,12 @@ export class Server extends AbstractServer {
 		// ----------------------------------------
 
 		try {
-			if (this.licenseState.isOidcLicensed()) {
-				const { OidcService } = await import('@/sso.ee/oidc/oidc.service.ee');
-				await Container.get(OidcService).init();
-				await import('@/sso.ee/oidc/routes/oidc.controller.ee');
-			}
+			// in the short term, we load the OIDC module here to ensure it is initialized
+			// ideally we want to migrate this to a module and be able to load it dynamically
+			// when the license changes, but that requires some refactoring
+			const { OidcService } = await import('@/sso.ee/oidc/oidc.service.ee');
+			await Container.get(OidcService).init();
+			await import('@/sso.ee/oidc/routes/oidc.controller.ee');
 		} catch (error) {
 			this.logger.warn(`OIDC initialization failed: ${(error as Error).message}`);
 		}

--- a/packages/cli/src/sso.ee/oidc/routes/oidc.controller.ee.ts
+++ b/packages/cli/src/sso.ee/oidc/routes/oidc.controller.ee.ts
@@ -42,6 +42,7 @@ export class OidcController {
 	}
 
 	@Get('/login', { skipAuth: true })
+	@Licensed('feat:oidc')
 	async redirectToAuthProvider(_req: Request, res: Response) {
 		const authorizationURL = await this.oidcService.generateLoginUrl();
 
@@ -49,6 +50,7 @@ export class OidcController {
 	}
 
 	@Get('/callback', { skipAuth: true })
+	@Licensed('feat:oidc')
 	async callbackHandler(req: Request, res: Response) {
 		const fullUrl = `${this.urlService.getInstanceBaseUrl()}${req.originalUrl}`;
 		const callbackUrl = new URL(fullUrl);


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
OIDC is now always loaded at startup, and runtime license checks are added to OIDC login and callback routes.

<!-- End of auto-generated description by cubic. -->

