### PR TITLE
n8n-auto-pr (N8N - 318167)

### DIFF
--- a/packages/nodes-base/nodes/Evaluation/test/evaluationTriggerUtils.test.ts
+++ b/packages/nodes-base/nodes/Evaluation/test/evaluationTriggerUtils.test.ts
@@ -62,6 +62,7 @@ describe('getFilteredResults', () => {
 				rangeDefinition: 'specifyRange',
 				headerRow: 1,
 				firstDataRow: startingRow,
+				includeHeadersWithEmptyCells: true,
 			},
 		);
 

--- a/packages/nodes-base/nodes/Evaluation/utils/evaluationTriggerUtils.ts
+++ b/packages/nodes-base/nodes/Evaluation/utils/evaluationTriggerUtils.ts
@@ -54,6 +54,7 @@ export async function getFilteredResults(
 			rangeDefinition: 'specifyRange',
 			headerRow: 1,
 			firstDataRow: startingRow,
+			includeHeadersWithEmptyCells: true,
 		},
 	);
 
@@ -104,7 +105,7 @@ export async function getResults(
 		this.getNode().typeVersion,
 		[],
 		undefined,
-		rangeOptions,
+		{ ...rangeOptions, includeHeadersWithEmptyCells: true },
 	);
 
 	return operationResult;

--- a/packages/nodes-base/nodes/Google/Sheet/test/v2/helpers/GoogleSheet.test.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/test/v2/helpers/GoogleSheet.test.ts
@@ -100,6 +100,28 @@ describe('GoogleSheet', () => {
 				{ name: 'Jane', age: '25' },
 			]);
 		});
+
+		it('should handle empty columns when includeHeadersWithEmptyCells is true', () => {
+			const data = [
+				['name', 'age'],
+				['John', '30'],
+				['MARY', ''],
+				['Jane', '25'],
+			];
+			const result = googleSheet.convertSheetDataArrayToObjectArray(
+				data,
+				1,
+				['name', 'age'],
+				false,
+				true,
+			);
+
+			expect(result).toEqual([
+				{ name: 'John', age: '30' },
+				{ name: 'MARY', age: '' },
+				{ name: 'Jane', age: '25' },
+			]);
+		});
 	});
 
 	describe('lookupValues', () => {

--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/utils/readOperation.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/utils/readOperation.ts
@@ -33,6 +33,9 @@ export async function readSheet(
 		dataLocationOnSheetOptions.rangeDefinition = 'detectAutomatically';
 	}
 
+	const includeHeadersWithEmptyCells =
+		(additionalOptions?.includeHeadersWithEmptyCells as boolean) ?? false;
+
 	const range = rangeString ?? getRangeString(sheetName, dataLocationOnSheetOptions);
 
 	const valueRenderMode = (outputFormattingOption.general ||
@@ -95,7 +98,12 @@ export async function readSheet(
 			combineFilters,
 		});
 	} else {
-		responseData = sheet.structureArrayDataByColumn(inputData, keyRowIndex, dataStartRowIndex);
+		responseData = sheet.structureArrayDataByColumn(
+			inputData,
+			keyRowIndex,
+			dataStartRowIndex,
+			includeHeadersWithEmptyCells,
+		);
 	}
 
 	returnData.push(

--- a/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheet.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheet.ts
@@ -317,21 +317,27 @@ export class GoogleSheet {
 	 * Returns the given sheet data in a structured way
 	 */
 	convertSheetDataArrayToObjectArray(
-		data: SheetRangeData,
+		sheet: SheetRangeData,
 		startRow: number,
 		columnKeys: string[],
 		addEmpty?: boolean,
+		includeHeadersWithEmptyCells?: boolean,
 	): IDataObject[] {
 		const returnData = [];
 
-		for (let rowIndex = startRow; rowIndex < data.length; rowIndex++) {
+		for (let rowIndex = startRow; rowIndex < sheet.length; rowIndex++) {
 			const item: IDataObject = {};
-			for (let columnIndex = 0; columnIndex < data[rowIndex].length; columnIndex++) {
+
+			const rowCount = sheet[rowIndex].length;
+			const columnCount = includeHeadersWithEmptyCells ? columnKeys.length : rowCount;
+
+			for (let columnIndex = 0; columnIndex < columnCount; columnIndex++) {
 				const key = columnKeys[columnIndex];
 				if (key) {
-					item[key] = data[rowIndex][columnIndex];
+					item[key] = sheet[rowIndex][columnIndex] || '';
 				}
 			}
+
 			if (Object.keys(item).length || addEmpty === true) {
 				returnData.push(item);
 			}
@@ -348,6 +354,7 @@ export class GoogleSheet {
 		inputData: string[][],
 		keyRow: number,
 		dataStartRow: number,
+		includeHeadersWithEmptyCells?: boolean,
 	): IDataObject[] {
 		const keys: string[] = [];
 
@@ -361,7 +368,13 @@ export class GoogleSheet {
 			keys.push(inputData[keyRow][columnIndex] || `col_${columnIndex}`);
 		}
 
-		return this.convertSheetDataArrayToObjectArray(inputData, dataStartRow, keys);
+		return this.convertSheetDataArrayToObjectArray(
+			inputData,
+			dataStartRow,
+			keys,
+			false,
+			includeHeadersWithEmptyCells,
+		);
 	}
 
 	testFilter(inputData: string[][], keyRow: number, dataStartRow: number): string[] {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Google Sheets node now includes all header columns, even if some columns have empty cells, when reading data. This ensures data rows always match the header structure.

- **Bug Fixes**
  - Fixed data parsing to include headers with empty cells.
  - Updated tests to cover cases with empty columns.

<!-- End of auto-generated description by cubic. -->

