### PR TITLE
n8n-auto-pr (N8N - 385831)

### DIFF
--- a/packages/nodes-base/nodes/Code/Pyodide.ts
+++ b/packages/nodes-base/nodes/Code/Pyodide.ts
@@ -30,10 +30,10 @@ export async function LoadPyodide(packageCacheDir: string): Promise<PyodideInter
 		await pyodideInstance.runPythonAsync(`
 import os
 
-def blocked_system(*args, **kwargs):
-    raise RuntimeError("os.system is blocked for security reasons.")
+def blocked_function(*args, **kwargs):
+    raise RuntimeError("Blocked for security reasons")
 
-os.system = blocked_system
+os.system = blocked_function
 
 from importlib.abc import MetaPathFinder
 from importlib.machinery import ModuleSpec
@@ -42,6 +42,15 @@ from typing import Sequence, Optional
 
 from _pyodide_core import jsproxy_typedict
 from js import Object
+
+Object.constructor.constructor = blocked_function
+
+import sys
+class blocked_module:
+    def __getattr__(self, name):
+        blocked_function()
+
+sys.modules['js'] = blocked_module()
 `);
 	}
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Blocked access to the JavaScript object constructor and the js module in Pyodide to improve security.

- **Bug Fixes**
  - Replaced os.system block with a generic function.
  - Prevented use of Object.constructor.constructor.
  - Blocked access to the js module by replacing it with a dummy module.

<!-- End of auto-generated description by cubic. -->

