### PR TITLE
n8n-auto-pr (N8N - 385893)

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -12,7 +12,7 @@ jobs:
     name: Publish to NPM
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true
-    timeout-minutes: 10
+    timeout-minutes: 15
     permissions:
       id-token: write
     env:


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Increased the NPM publish job timeout from 10 to 15 minutes to prevent timeouts during releases.

<!-- End of auto-generated description by cubic. -->

