### PR TITLE
n8n-auto-pr (N8N - 392087)

### DIFF
--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/Modes/NodesMode.vue
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/Modes/NodesMode.vue
@@ -277,6 +277,7 @@ function arrowLeft() {
 
 function onKeySelect(activeItemId: string) {
 	const mergedItems = flattenCreateElements([
+		...(globalCallouts.value ?? []),
 		...(activeViewStack.value.items ?? []),
 		...(globalSearchItemsDiff.value ?? []),
 		...(moreFromCommunity.value ?? []),
@@ -290,13 +291,13 @@ function onKeySelect(activeItemId: string) {
 
 registerKeyHook('MainViewArrowRight', {
 	keyboardKeys: ['ArrowRight', 'Enter'],
-	condition: (type) => ['subcategory', 'node', 'link', 'view'].includes(type),
+	condition: (type) => ['subcategory', 'node', 'link', 'view', 'openTemplate'].includes(type),
 	handler: onKeySelect,
 });
 
 registerKeyHook('MainViewArrowLeft', {
 	keyboardKeys: ['ArrowLeft'],
-	condition: (type) => ['subcategory', 'node', 'link', 'view'].includes(type),
+	condition: (type) => ['subcategory', 'node', 'link', 'view', 'openTemplate'].includes(type),
 	handler: arrowLeft,
 });
 </script>

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/utils.ts
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/utils.ts
@@ -314,6 +314,7 @@ export function getRootSearchCallouts(search: string, { isRagStarterCalloutVisib
 	const ragKeywords = ['rag', 'vec', 'know'];
 	if (isRagStarterCalloutVisible && ragKeywords.some((x) => search.toLowerCase().startsWith(x))) {
 		results.push({
+			uuid: 'rag-starter-template',
 			key: 'rag-starter-template',
 			type: 'openTemplate',
 			properties: {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed keyboard navigation for the RAG callout in the node search, allowing users to select it with arrow keys and Enter.

<!-- End of auto-generated description by cubic. -->

