### PR TITLE
n8n-auto-pr (N8N - 399246)

### DIFF
--- a/.github/workflows/sync-public-api-docs.yml
+++ b/.github/workflows/sync-public-api-docs.yml
@@ -96,9 +96,9 @@ jobs:
           author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
           signoff: false
 
-          # Create a unique branch and delete after we're done
-          branch: 'chore/openapi-sync-${{ github.run_id }}-${{ github.run_attempt }}'
-          delete-branch: true
+          # Create a single branch for multiple PRs
+          branch: 'chore/sync-public-api-schema'
+          delete-branch: false
 
           title: 'chore: Update Public API schema'
           body: |


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated the docs sync workflow to use a single branch for public API schema updates instead of creating a new branch and PR each time. This prevents multiple open PRs for the same update.

<!-- End of auto-generated description by cubic. -->

