### PR TITLE
n8n-auto-pr (N8N - 420829)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/LmChatAwsBedrock.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/LmChatAwsBedrock.node.ts
@@ -60,6 +60,7 @@ export class LmChatAwsBedrock implements INodeType {
 				displayName: 'Model',
 				name: 'model',
 				type: 'options',
+				allowArbitraryValues: true, // Hide issues when model name is specified in the expression and does not match any of the options
 				description:
 					'The model which will generate the completion. <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/foundation-models.html">Learn more</a>.',
 				typeOptions: {

--- a/packages/frontend/editor-ui/src/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/components/ParameterInput.vue
@@ -417,17 +417,19 @@ const getIssues = computed<string[]>(() => {
 		['options', 'multiOptions'].includes(props.parameter.type) &&
 		!remoteParameterOptionsLoading.value &&
 		remoteParameterOptionsLoadingIssues.value === null &&
-		parameterOptions.value
+		parameterOptions.value &&
+		(!isModelValueExpression.value || props.expressionEvaluated !== null)
 	) {
-		// Check if the value resolves to a valid option
-		// Currently it only displays an error in the node itself in
+		// Check if the value resolves to a valid option.
+		// For expressions do not validate if there is no evaluated value.
+		// Currently, it only displays an error in the node itself in
 		// case the value is not valid. The workflow can still be executed
 		// and the error is not displayed on the node in the workflow
 		const validOptions = parameterOptions.value.map((options) => options.value);
 
 		let checkValues: string[] = [];
 
-		if (!shouldSkipParamValidation(displayValue.value)) {
+		if (!shouldSkipParamValidation(props.parameter, displayValue.value)) {
 			if (Array.isArray(displayValue.value)) {
 				checkValues = checkValues.concat(displayValue.value);
 			} else {

--- a/packages/frontend/editor-ui/src/composables/useNodeSettingsParameters.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useNodeSettingsParameters.test.ts
@@ -14,11 +14,11 @@ import { mockedStore } from '@/__tests__/utils';
 import type { INodeUi } from '@/Interface';
 
 describe('useNodeSettingsParameters', () => {
-	describe('setValue', () => {
-		beforeEach(() => {
-			setActivePinia(createTestingPinia());
-		});
+	beforeEach(() => {
+		setActivePinia(createTestingPinia());
+	});
 
+	describe('setValue', () => {
 		afterEach(() => {
 			vi.clearAllMocks();
 		});

--- a/packages/frontend/editor-ui/src/utils/nodeSettingsUtils.ts
+++ b/packages/frontend/editor-ui/src/utils/nodeSettingsUtils.ts
@@ -359,6 +359,13 @@ export function parseFromExpression(
 	return null;
 }
 
-export function shouldSkipParamValidation(value: string | number | boolean | null) {
-	return typeof value === 'string' && value.includes(CUSTOM_API_CALL_KEY);
+export function shouldSkipParamValidation(
+	parameter: INodeProperties,
+	value: NodeParameterValueType,
+) {
+	return (
+		(typeof value === 'string' && value.includes(CUSTOM_API_CALL_KEY)) ||
+		(['options', 'multiOptions'].includes(parameter.type) &&
+			Boolean(parameter.allowArbitraryValues))
+	);
 }

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1466,6 +1466,8 @@ export interface INodeProperties {
 	// allows to skip validation during execution or set custom validation/casting logic inside node
 	// inline error messages would still be shown in UI
 	ignoreValidationDuringExecution?: boolean;
+	// for type: options | multiOptions – skip validation of the value (e.g. when value is not in the list and specified via expression)
+	allowArbitraryValues?: boolean;
 }
 
 export interface INodePropertyModeTypeOptions {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added support for arbitrary model names in the AWS Bedrock Chat node, so users can specify custom models without validation errors.

- **Bug Fixes**
  - Updated parameter validation to allow values not present in the options list when allowArbitraryValues is set.
  - Improved tests and logic to handle custom option values for options and multiOptions parameters.

<!-- End of auto-generated description by cubic. -->

