### PR TITLE
n8n-auto-pr (N8N - 424772)

### DIFF
--- a/packages/frontend/@n8n/chat/src/components/Input.vue
+++ b/packages/frontend/@n8n/chat/src/components/Input.vue
@@ -144,7 +144,7 @@ async function onSubmit(event: MouseEvent | KeyboardEvent) {
 }
 
 async function onSubmitKeydown(event: KeyboardEvent) {
-	if (event.shiftKey) {
+	if (event.shiftKey || event.isComposing) {
 		return;
 	}
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Stopped chat input from submitting when users are composing text with an input method editor (IME), preventing accidental sends for languages like Chinese.

<!-- End of auto-generated description by cubic. -->

