### PR TITLE
n8n-auto-pr (N8N - 429870)

### DIFF
--- a/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocator.test.constants.ts
+++ b/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocator.test.constants.ts
@@ -103,3 +103,34 @@ export const TEST_NODE_SINGLE_MODE: INode = {
 		options: {},
 	},
 };
+
+export const TEST_PARAMETER_SKIP_CREDENTIALS_CHECK: INodeProperties = {
+	...TEST_PARAMETER_MULTI_MODE,
+	name: 'testParameterSkipCredentialsCheck',
+	modes: [
+		{
+			displayName: 'From List',
+			name: 'list',
+			type: 'list',
+			typeOptions: {
+				searchListMethod: 'testSearch',
+				searchable: true,
+				skipCredentialsCheckInRLC: true,
+			},
+		},
+	],
+};
+
+export const TEST_NODE_NO_CREDENTIALS: INode = {
+	...TEST_NODE_MULTI_MODE,
+	name: 'Test Node - No Credentials',
+	parameters: {
+		authentication: undefined,
+		resource: 'test',
+		operation: 'get',
+		testParameterSkipCredentialsCheck: TEST_MODEL_VALUE,
+		id: '',
+		options: {},
+	},
+	credentials: undefined,
+};

--- a/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocator.vue
+++ b/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocator.vue
@@ -186,8 +186,9 @@ const hasCredentialError = computed(() => {
 	);
 });
 
-const credentialsNotSet = computed(() => {
+const credentialsRequiredAndNotSet = computed(() => {
 	if (!props.node) return false;
+	if (skipCredentialsCheckInRLC.value) return false;
 	const nodeType = nodeTypesStore.getNodeType(props.node.type);
 	if (nodeType) {
 		const usesCredentials = nodeType.credentials !== undefined && nodeType.credentials.length > 0;
@@ -314,6 +315,10 @@ const currentQueryError = computed(() => {
 });
 
 const isSearchable = computed(() => !!getPropertyArgument(currentMode.value, 'searchable'));
+
+const skipCredentialsCheckInRLC = computed(
+	() => !!getPropertyArgument(currentMode.value, 'skipCredentialsCheckInRLC'),
+);
 
 const requiresSearchFilter = computed(
 	() => !!getPropertyArgument(currentMode.value, 'searchFilterRequired'),
@@ -666,7 +671,7 @@ async function loadResources() {
 	const paramsKey = currentRequestKey.value;
 	const cachedResponse = cachedResponses.value[paramsKey];
 
-	if (credentialsNotSet.value) {
+	if (credentialsRequiredAndNotSet.value) {
 		setResponse(paramsKey, { error: true });
 		return;
 	}
@@ -922,7 +927,7 @@ function removeOverride() {
 			<template #error>
 				<div :class="$style.errorContainer" data-test-id="rlc-error-container">
 					<n8n-text
-						v-if="credentialsNotSet || currentResponse.errorDetails"
+						v-if="credentialsRequiredAndNotSet || currentResponse.errorDetails"
 						color="text-dark"
 						align="center"
 						tag="div"
@@ -946,9 +951,12 @@ function removeOverride() {
 							{{ currentResponse.errorDetails.description }}
 						</N8nNotice>
 					</div>
-					<div v-if="hasCredentialError || credentialsNotSet" data-test-id="permission-error-link">
+					<div
+						v-if="hasCredentialError || credentialsRequiredAndNotSet"
+						data-test-id="permission-error-link"
+					>
 						<a
-							v-if="credentialsNotSet"
+							v-if="credentialsRequiredAndNotSet"
 							:class="$style['credential-link']"
 							@click="createNewCredential"
 						>

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1474,6 +1474,10 @@ export interface INodePropertyModeTypeOptions {
 	searchListMethod?: string; // Supported by: options
 	searchFilterRequired?: boolean;
 	searchable?: boolean;
+	/**
+	 * If true, the resource locator will not show an error if the credentials are not selected
+	 */
+	skipCredentialsCheckInRLC?: boolean;
 	allowNewResource?: {
 		label: string;
 		defaultName: string;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added a new option to skip the credentials check in the Resource Locator component, allowing list items to load even if credentials are not set.

- **New Features**
  - Introduced the `skipCredentialsCheckInRLC` flag for resource locator modes.
  - Updated UI and tests to support loading resources without requiring credentials when this flag is enabled.

<!-- End of auto-generated description by cubic. -->

