### PR TITLE
n8n-auto-pr (N8N - 443387)

### DIFF
--- a/packages/frontend/editor-ui/src/stores/versions.store.ts
+++ b/packages/frontend/editor-ui/src/stores/versions.store.ts
@@ -15,6 +15,7 @@ import { useToast } from '@/composables/useToast';
 import { useUIStore } from '@/stores/ui.store';
 import { computed, ref } from 'vue';
 import { useSettingsStore } from './settings.store';
+import { useUsersStore } from './users.store';
 import { useStorage } from '@/composables/useStorage';
 import { jsonParse } from 'n8n-workflow';
 import { useTelemetry } from '@/composables/useTelemetry';
@@ -52,6 +53,7 @@ export const useVersionsStore = defineStore(STORES.VERSIONS, () => {
 	const { showToast, showMessage } = useToast();
 	const uiStore = useUIStore();
 	const settingsStore = useSettingsStore();
+	const usersStore = useUsersStore();
 	const readWhatsNewArticlesStorage = useStorage(LOCAL_STORAGE_READ_WHATS_NEW_ARTICLES);
 	const lastDismissedWhatsNewCalloutStorage = useStorage(LOCAL_STORAGE_DISMISSED_WHATS_NEW_CALLOUT);
 
@@ -169,9 +171,22 @@ export const useVersionsStore = defineStore(STORES.VERSIONS, () => {
 	};
 
 	const shouldShowWhatsNewCallout = (): boolean => {
-		return !whatsNewArticles.value.every((item) =>
+		const createdAt = usersStore.currentUser?.createdAt;
+		let hasNewArticle = false;
+		if (createdAt) {
+			const userCreatedAt = new Date(createdAt).getTime();
+			hasNewArticle = whatsNewArticles.value.some((item) => {
+				const updatedAt = item.updatedAt ? new Date(item.updatedAt).getTime() : 0;
+				return updatedAt > userCreatedAt;
+			});
+		} else {
+			hasNewArticle = true;
+		}
+		const allArticlesDismissed = whatsNewArticles.value.every((item) =>
 			lastDismissedWhatsNewCallout.value.includes(item.id),
 		);
+
+		return hasNewArticle && !allArticlesDismissed;
 	};
 
 	const fetchWhatsNew = async () => {
@@ -273,5 +288,7 @@ export const useVersionsStore = defineStore(STORES.VERSIONS, () => {
 		isWhatsNewArticleRead,
 		setWhatsNewArticleRead,
 		closeWhatsNewCallout,
+		shouldShowWhatsNewCallout,
+		dismissWhatsNewCallout,
 	};
 });


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated the logic for showing the "What's New" callout so new users only see notifications for articles published after their account was created.

- **Bug Fixes**
 - Added checks to prevent showing old "What's New" articles to new users.
 - Improved tests to cover different user scenarios for the callout.

<!-- End of auto-generated description by cubic. -->

