### PR TITLE
n8n-auto-pr (N8N - 449357)

### DIFF
--- a/packages/frontend/editor-ui/src/components/SourceControlPullModal.ee.vue
+++ b/packages/frontend/editor-ui/src/components/SourceControlPullModal.ee.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import { useLoadingService } from '@/composables/useLoadingService';
+import { useTelemetry } from '@/composables/useTelemetry';
 import { useToast } from '@/composables/useToast';
 import { SOURCE_CONTROL_PULL_MODAL_KEY, VIEWS, WORKFLOW_DIFF_MODAL_KEY } from '@/constants';
 import { sourceControlEventBus } from '@/event-bus/source-control';
@@ -31,6 +32,7 @@ const props = defineProps<{
 	data: { eventBus: EventBus; status: SourceControlledFile[] };
 }>();
 
+const telemetry = useTelemetry();
 const loadingService = useLoadingService();
 const uiStore = useUIStore();
 const toast = useToast();
@@ -108,6 +110,10 @@ async function pullWorkfolder() {
 const workflowDiffEventBus = createEventBus();
 
 function openDiffModal(id: string) {
+	telemetry.track('User clicks compare workflows', {
+		workflow_id: id,
+		context: 'source_control_pull',
+	});
 	uiStore.openModalWithData({
 		name: WORKFLOW_DIFF_MODAL_KEY,
 		data: { eventBus: workflowDiffEventBus, workflowId: id, direction: 'pull' },

--- a/packages/frontend/editor-ui/src/components/SourceControlPushModal.ee.vue
+++ b/packages/frontend/editor-ui/src/components/SourceControlPushModal.ee.vue
@@ -566,6 +566,10 @@ function castProject(project: ProjectListItem) {
 const workflowDiffEventBus = createEventBus();
 
 function openDiffModal(id: string) {
+	telemetry.track('User clicks compare workflows', {
+		workflow_id: id,
+		context: 'source_control_push',
+	});
 	uiStore.openModalWithData({
 		name: WORKFLOW_DIFF_MODAL_KEY,
 		data: { eventBus: workflowDiffEventBus, workflowId: id, direction: 'push' },


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added telemetry tracking to workflow diff and source control modals to capture user interactions like comparing workflows, navigating changes, and viewing node details.

- **New Features**
  - Tracks when users open the workflow diff, switch tabs, navigate changes, and view node changes in both pull and push modals.

<!-- End of auto-generated description by cubic. -->

