### PR TITLE
n8n-auto-pr (N8N - 453828)

### DIFF
--- a/packages/@n8n/backend-common/src/modules/module-registry.ts
+++ b/packages/@n8n/backend-common/src/modules/module-registry.ts
@@ -58,7 +58,8 @@ export class ModuleRegistry {
 			modulesDir = path.join(n8nRoot, dir, 'modules');
 		} catch {
 			// local dev
-			modulesDir = path.resolve(__dirname, '../../../../cli/dist/modules');
+			// n8n binary is inside the bin folder, so we need to go up two levels
+			modulesDir = path.resolve(process.argv[1], '../../dist/modules');
 		}
 
 		for (const moduleName of modules ?? this.eligibleModules) {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated the module loading path for local development to handle different binary locations more reliably. This makes module resolution work even when the binary is inside a bin folder.

<!-- End of auto-generated description by cubic. -->

