### PR TITLE
n8n-auto-pr (N8N - 453856)

### DIFF
--- a/packages/frontend/editor-ui/src/components/SourceControlPushModal.ee.vue
+++ b/packages/frontend/editor-ui/src/components/SourceControlPushModal.ee.vue
@@ -864,7 +864,7 @@ function openDiffModal(id: string) {
 					:placeholder="
 						i18n.baseText('settings.sourceControl.modals.push.commitMessage.placeholder')
 					"
-					@keydown.enter="onCommitKeyDownEnter"
+					@keydown.enter.stop="onCommitKeyDownEnter"
 				/>
 				<N8nButton
 					data-test-id="source-control-push-modal-submit"


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed the commit and push dialog so pressing Enter in the commit message field only triggers a commit when allowed, and prevents accidental form submissions.

- **Bug Fixes**
  - Enter key now only submits when the commit message is filled and files are selected.
  - Added tests to cover Enter key behavior in the push modal.

<!-- End of auto-generated description by cubic. -->

