### PR TITLE
n8n-auto-pr (N8N - 474964)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/LmChatAwsBedrock.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/LmChatAwsBedrock.node.ts
@@ -20,7 +20,7 @@ export class LmChatAwsBedrock implements INodeType {
 		name: 'lmChatAwsBedrock',
 		icon: 'file:bedrock.svg',
 		group: ['transform'],
-		version: 1,
+		version: [1, 1.1],
 		description: 'Language Model AWS Bedrock',
 		defaults: {
 			name: 'AWS Bedrock Chat Model',
@@ -57,13 +57,44 @@ export class LmChatAwsBedrock implements INodeType {
 		properties: [
 			getConnectionHintNoticeField([NodeConnectionTypes.AiChain, NodeConnectionTypes.AiChain]),
 			{
+				displayName: 'Model Source',
+				name: 'modelSource',
+				type: 'options',
+				displayOptions: {
+					show: {
+						'@version': [{ _cnd: { gte: 1.1 } }],
+					},
+				},
+				options: [
+					{
+						name: 'On-Demand Models',
+						value: 'onDemand',
+						description: 'Standard foundation models with on-demand pricing',
+					},
+					{
+						name: 'Inference Profiles',
+						value: 'inferenceProfile',
+						description:
+							'Cross-region inference profiles (required for models like Claude Sonnet 4 and others)',
+					},
+				],
+				default: 'onDemand',
+				description: 'Choose between on-demand foundation models or inference profiles',
+			},
+			{
 				displayName: 'Model',
 				name: 'model',
 				type: 'options',
 				allowArbitraryValues: true, // Hide issues when model name is specified in the expression and does not match any of the options
 				description:
 					'The model which will generate the completion. <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/foundation-models.html">Learn more</a>.',
+				displayOptions: {
+					hide: {
+						modelSource: ['inferenceProfile'],
+					},
+				},
 				typeOptions: {
+					loadOptionsDependsOn: ['modelSource'],
 					loadOptions: {
 						routing: {
 							request: {
@@ -84,6 +115,62 @@ export class LmChatAwsBedrock implements INodeType {
 											name: '={{$responseItem.modelName}}',
 											description: '={{$responseItem.modelArn}}',
 											value: '={{$responseItem.modelId}}',
+										},
+									},
+									{
+										type: 'sort',
+										properties: {
+											key: 'name',
+										},
+									},
+								],
+							},
+						},
+					},
+				},
+				routing: {
+					send: {
+						type: 'body',
+						property: 'model',
+					},
+				},
+				default: '',
+			},
+			{
+				displayName: 'Model',
+				name: 'model',
+				type: 'options',
+				allowArbitraryValues: true,
+				description:
+					'The inference profile which will generate the completion. <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-use.html">Learn more</a>.',
+				displayOptions: {
+					show: {
+						modelSource: ['inferenceProfile'],
+					},
+				},
+				typeOptions: {
+					loadOptionsDependsOn: ['modelSource'],
+					loadOptions: {
+						routing: {
+							request: {
+								method: 'GET',
+								url: '/inference-profiles?maxResults=1000',
+							},
+							output: {
+								postReceive: [
+									{
+										type: 'rootProperty',
+										properties: {
+											property: 'inferenceProfileSummaries',
+										},
+									},
+									{
+										type: 'setKeyValue',
+										properties: {
+											name: '={{$responseItem.inferenceProfileName}}',
+											description:
+												'={{$responseItem.description || $responseItem.inferenceProfileArn}}',
+											value: '={{$responseItem.inferenceProfileId}}',
 										},
 									},
 									{


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added support for AWS Bedrock inference profiles in the AWS Bedrock Chat Model node, allowing users to select between on-demand models and inference profiles.

- **New Features**
  - Added a "Model Source" option to choose between on-demand models and inference profiles.
  - Enabled model selection based on the chosen source, including dynamic loading of available inference profiles.

<!-- End of auto-generated description by cubic. -->

