### PR TITLE
n8n-auto-pr (N8N - 486776)

### DIFF
--- a/packages/frontend/editor-ui/src/utils/nodeIcon.test.ts
+++ b/packages/frontend/editor-ui/src/utils/nodeIcon.test.ts
@@ -57,6 +57,29 @@ describe('util: Node Icon', () => {
 				getNodeIconUrl(mock<IconNodeType>({ icon: 'foo', iconUrl: undefined })),
 			).toBeUndefined();
 		});
+
+		it('should return the iconUrl from nodeType when using https', () => {
+			expect(
+				getNodeIconUrl(
+					mock<IconNodeType>({
+						iconUrl: 'https://my-site.com/icon.svg',
+					}),
+				),
+			).toBe('https://my-site.com/icon.svg');
+		});
+
+		it('should return the iconUrl from nodeType when using https with themed values', () => {
+			expect(
+				getNodeIconUrl(
+					mock<IconNodeType>({
+						iconUrl: {
+							light: 'https://my-site.com/light-icon.svg',
+							dark: 'https://my-site.com/dark-icon.svg',
+						},
+					}),
+				),
+			).toBe('https://my-site.com/light-icon.svg');
+		});
 	});
 
 	describe('getBadgeIconUrl', () => {

--- a/packages/frontend/editor-ui/src/utils/nodeIcon.ts
+++ b/packages/frontend/editor-ui/src/utils/nodeIcon.ts
@@ -73,13 +73,25 @@ export function getNodeIconSource(nodeType?: IconNodeType | null): NodeIconSourc
 		}
 	}
 
-	if (nodeType.name && isNodePreviewKey(nodeType.name) && typeof nodeType.iconUrl === 'string') {
-		// If node type is a node preview it would have full icon url
-		return {
-			type: 'file',
-			src: nodeType.iconUrl,
-			badge: undefined,
-		};
+	if (nodeType.name && isNodePreviewKey(nodeType.name)) {
+		// Handle both string and object iconUrl for preview nodes
+		if (typeof nodeType.iconUrl === 'string') {
+			return {
+				type: 'file',
+				src: nodeType.iconUrl,
+				badge: undefined,
+			};
+		} else if (nodeType.iconUrl && typeof nodeType.iconUrl === 'object') {
+			// Use getThemedValue to get the appropriate theme URL
+			const themedUrl = getThemedValue(nodeType.iconUrl, useUIStore().appliedTheme);
+			if (themedUrl) {
+				return {
+					type: 'file',
+					src: themedUrl,
+					badge: undefined,
+				};
+			}
+		}
 	}
 
 	const iconUrl = getNodeIconUrl(nodeType);


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed an issue where themed icon URLs were not loading correctly for node preview components.

- **Bug Fixes**
 - Updated logic to support both string and object iconUrl values for preview nodes.
 - Added tests to cover themed icon URL cases.

<!-- End of auto-generated description by cubic. -->

