### PR TITLE
n8n-auto-pr (N8N - 504825)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/rerankers/RerankerCohere/RerankerCohere.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/rerankers/RerankerCohere/RerankerCohere.node.ts
@@ -70,16 +70,26 @@ export class RerankerCohere implements INodeType {
 					},
 				],
 			},
+			{
+				displayName: 'Top N',
+				name: 'topN',
+				type: 'number',
+				description: 'The maximum number of documents to return after reranking',
+				default: 3,
+			},
 		],
 	};
 
 	async supplyData(this: ISupplyDataFunctions, itemIndex: number): Promise<SupplyData> {
 		this.logger.debug('Supply data for reranking Cohere');
 		const modelName = this.getNodeParameter('modelName', itemIndex, 'rerank-v3.5') as string;
+		const topN = this.getNodeParameter('topN', itemIndex, 3) as number;
 		const credentials = await this.getCredentials<{ apiKey: string }>('cohereApi');
+
 		const reranker = new CohereRerank({
 			apiKey: credentials.apiKey,
 			model: modelName,
+			topN,
 		});
 
 		return {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added a "Top N" parameter to the Reranker Cohere node, allowing users to control how many documents are returned after reranking.

- **New Features**
  - Users can set the maximum number of documents to return.
  - Tests cover default, custom, and edge case values for the new parameter.

<!-- End of auto-generated description by cubic. -->

