### PR TITLE
n8n-auto-pr (N8N - 555524)

### DIFF
--- a/packages/cli/BREAKING-CHANGES.md
+++ b/packages/cli/BREAKING-CHANGES.md
@@ -2,6 +2,16 @@
 
 This list shows all the versions which include breaking changes and how to upgrade.
 
+# 1.107.0
+
+## What changed?
+
+The CLI flag `--reinstallMissingPackages`, deprecated a year ago in version 1.154.0, has been removed.
+
+### When is action necessary?
+
+If you are using this flag, please switch to the environment variable `N8N_REINSTALL_MISSING_PACKAGES`.
+
 ## 1.103.0
 
 ### What changed?

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -33,7 +33,6 @@ import { ExecutionsPruningService } from '@/services/pruning/executions-pruning.
 import { UrlService } from '@/services/url.service';
 import { WaitTracker } from '@/wait-tracker';
 import { WorkflowRunner } from '@/workflow-runner';
-import { CommunityPackagesConfig } from '@/community-packages/community-packages.config';
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const open = require('open');
@@ -44,12 +43,6 @@ const flagsSchema = z.object({
 		.boolean()
 		.describe(
 			'runs the webhooks via a hooks.n8n.cloud tunnel server. Use only for testing and development!',
-		)
-		.optional(),
-	reinstallMissingPackages: z
-		.boolean()
-		.describe(
-			'Attempts to self heal n8n if packages with nodes are missing. Might drastically increase startup times.',
 		)
 		.optional(),
 });
@@ -176,22 +169,6 @@ export class Start extends BaseCommand<z.infer<typeof flagsSchema>> {
 			const scopedLogger = this.logger.scoped('scaling');
 			scopedLogger.debug('Starting main instance in scaling mode');
 			scopedLogger.debug(`Host ID: ${this.instanceSettings.hostId}`);
-		}
-
-		const { flags } = this;
-		const communityPackagesConfig = Container.get(CommunityPackagesConfig);
-		// cli flag overrides the config env variable
-		if (flags.reinstallMissingPackages) {
-			if (communityPackagesConfig.enabled) {
-				this.logger.warn(
-					'`--reinstallMissingPackages` is deprecated: Please use the env variable `N8N_REINSTALL_MISSING_PACKAGES` instead',
-				);
-				communityPackagesConfig.reinstallMissing = true;
-			} else {
-				this.logger.warn(
-					'`--reinstallMissingPackages` was passed, but community packages are disabled',
-				);
-			}
 		}
 
 		if (process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS === 'true') {

--- a/packages/cli/src/community-packages/community-packages.service.ts
+++ b/packages/cli/src/community-packages/community-packages.service.ts
@@ -67,8 +67,6 @@ type PackageJson = {
 
 @Service()
 export class CommunityPackagesService {
-	reinstallMissingPackages = false;
-
 	missingPackages: string[] = [];
 
 	private readonly downloadFolder = this.instanceSettings.nodesDownloadDir;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed the deprecated CLI flag `--reinstallMissingPackages`. Users should now use the `N8N_REINSTALL_MISSING_PACKAGES` environment variable instead.

- **Migration**
 - Update any scripts or workflows using the old flag to use the environment variable.

<!-- End of auto-generated description by cubic. -->

