### PR TITLE
n8n-auto-pr (N8N - 558731)

### DIFF
--- a/packages/nodes-base/nodes/Webhook/Webhook.node.ts
+++ b/packages/nodes-base/nodes/Webhook/Webhook.node.ts
@@ -1,6 +1,6 @@
 /* eslint-disable n8n-nodes-base/node-execute-block-wrong-error-thrown */
 import { createWriteStream } from 'fs';
-import { stat } from 'fs/promises';
+import { rm, stat } from 'fs/promises';
 import isbot from 'isbot';
 import type {
 	IWebhookFunctions,
@@ -362,6 +362,9 @@ export class Webhook extends Node {
 					file.originalFilename ?? file.newFilename,
 					file.mimetype,
 				);
+
+				// Delete original file to prevent tmp directory from growing too large
+				await rm(file.filepath, { force: true });
 
 				count += 1;
 			}

--- a/packages/nodes-base/nodes/Webhook/test/Webhook.test.ts
+++ b/packages/nodes-base/nodes/Webhook/test/Webhook.test.ts
@@ -1,9 +1,13 @@
 import { NodeTestHarness } from '@nodes-testing/node-test-harness';
 import type { Request, Response } from 'express';
+import fs from 'fs/promises';
 import { mock } from 'jest-mock-extended';
 import type { IWebhookFunctions } from 'n8n-workflow';
 
 import { Webhook } from '../Webhook.node';
+
+jest.mock('fs/promises');
+const mockFs = jest.mocked(fs);
 
 describe('Test Webhook Node', () => {
 	new NodeTestHarness().setupTests();
@@ -33,11 +37,12 @@ describe('Test Webhook Node', () => {
 
 		it('should handle when files are present', async () => {
 			req.body = {
-				files: { file1: {} },
+				files: { file1: { filepath: '/tmp/test.txt' } },
 			};
 			const returnData = await node.webhook(context);
 			expect(returnData.workflowData?.[0][0].binary).not.toBeUndefined();
 			expect(context.nodeHelpers.copyBinaryFile).toHaveBeenCalled();
+			expect(mockFs.rm).toHaveBeenCalledWith('/tmp/test.txt', { force: true });
 		});
 	});
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Webhook node now deletes temporary uploaded files after processing to prevent the tmp directory from growing too large.

- **Bug Fixes**
 - Removes temp files after webhook calls.
 - Adds tests to confirm file deletion.

<!-- End of auto-generated description by cubic. -->

