### PR TITLE
n8n-auto-pr (N8N - 595042)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/transport/index.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/transport/index.test.ts
@@ -11,7 +11,7 @@ describe('GoogleGemini transport', () => {
 
 	it('should call httpRequestWithAuthentication with correct parameters', async () => {
 		executeFunctionsMock.getCredentials.mockResolvedValue({
-			url: 'https://custom-url.com',
+			host: 'https://custom-url.com',
 		});
 
 		await apiRequest.call(executeFunctionsMock, 'GET', '/v1beta/models', {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/transport/index.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/transport/index.ts
@@ -12,6 +12,11 @@ type RequestParameters = {
 	option?: IDataObject;
 };
 
+type GooglePalmApiCredentials = {
+	host: string;
+	apiKey: string;
+};
+
 export async function apiRequest(
 	this: IExecuteFunctions | ILoadOptionsFunctions,
 	method: IHttpRequestMethods,
@@ -20,12 +25,12 @@ export async function apiRequest(
 ) {
 	const { body, qs, option, headers } = parameters ?? {};
 
-	const credentials = await this.getCredentials('googlePalmApi');
+	const credentials = await this.getCredentials<GooglePalmApiCredentials>('googlePalmApi');
 
 	let url = `https://generativelanguage.googleapis.com${endpoint}`;
 
-	if (credentials.url) {
-		url = `${credentials?.url as string}${endpoint}`;
+	if (credentials.host) {
+		url = `${credentials.host}${endpoint}`;
 	}
 
 	const options = {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated Google Gemini node to use a custom host field from credentials, allowing users to set their own API endpoint.

- **Bug Fixes**
 - Fixed credential usage to reference "host" instead of "url" for endpoint selection.

<!-- End of auto-generated description by cubic. -->

