### PR TITLE
n8n-auto-pr (N8N - 598914)

### DIFF
--- a/packages/@n8n/config/src/configs/executions.config.ts
+++ b/packages/@n8n/config/src/configs/executions.config.ts
@@ -27,6 +27,17 @@ class ConcurrencyConfig {
 }
 
 @Config
+class QueueRecoveryConfig {
+	/** How often (minutes) to check for queue recovery. */
+	@Env('N8N_EXECUTIONS_QUEUE_RECOVERY_INTERVAL')
+	interval: number = 180;
+
+	/** Size of batch of executions to check for queue recovery. */
+	@Env('N8N_EXECUTIONS_QUEUE_RECOVERY_BATCH')
+	batchSize: number = 100;
+}
+
+@Config
 export class ExecutionsConfig {
 	/** Whether to delete past executions on a rolling basis. */
 	@Env('EXECUTIONS_DATA_PRUNE')
@@ -56,4 +67,7 @@ export class ExecutionsConfig {
 
 	@Nested
 	concurrency: ConcurrencyConfig;
+
+	@Nested
+	queueRecovery: QueueRecoveryConfig;
 }

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -314,6 +314,10 @@ describe('GlobalConfig', () => {
 				productionLimit: -1,
 				evaluationLimit: -1,
 			},
+			queueRecovery: {
+				interval: 180,
+				batchSize: 100,
+			},
 		},
 		diagnostics: {
 			enabled: true,

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -70,21 +70,6 @@ export const schema = {
 			default: true,
 			env: 'EXECUTIONS_DATA_SAVE_MANUAL_EXECUTIONS',
 		},
-
-		queueRecovery: {
-			interval: {
-				doc: 'How often (minutes) to check for queue recovery',
-				format: Number,
-				default: 180,
-				env: 'N8N_EXECUTIONS_QUEUE_RECOVERY_INTERVAL',
-			},
-			batchSize: {
-				doc: 'Size of batch of executions to check for queue recovery',
-				format: Number,
-				default: 100,
-				env: 'N8N_EXECUTIONS_QUEUE_RECOVERY_BATCH',
-			},
-		},
 	},
 
 	userManagement: {

--- a/packages/cli/src/scaling/__tests__/scaling.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/scaling.service.test.ts
@@ -44,6 +44,12 @@ describe('ScalingService', () => {
 				queueMetricsInterval: 20,
 			},
 		},
+		executions: {
+			queueRecovery: {
+				interval: 180,
+				batchSize: 100,
+			},
+		},
 	});
 
 	const instanceSettings = Container.get(InstanceSettings);

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -17,7 +17,6 @@ import type { IExecuteResponsePromiseData } from 'n8n-workflow';
 import assert, { strict } from 'node:assert';
 
 import { ActiveExecutions } from '@/active-executions';
-import config from '@/config';
 import { HIGHEST_SHUTDOWN_PRIORITY } from '@/constants';
 import { EventService } from '@/events/event.service';
 import { assertNever } from '@/utils';
@@ -441,8 +440,8 @@ export class ScalingService {
 	// #region Queue recovery
 
 	private readonly queueRecoveryContext: QueueRecoveryContext = {
-		batchSize: config.getEnv('executions.queueRecovery.batchSize'),
-		waitMs: config.getEnv('executions.queueRecovery.interval') * 60 * 1000,
+		batchSize: this.globalConfig.executions.queueRecovery.batchSize,
+		waitMs: this.globalConfig.executions.queueRecovery.interval * 60 * 1000,
 	};
 
 	@OnLeaderTakeover()


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Ported queue recovery configuration to @n8n/config and updated ScalingService to read from GlobalConfig. Existing env vars and defaults are unchanged, so behavior stays the same.

- **Refactors**
  - Added executions.queueRecovery (interval, batchSize) to @n8n/config with envs N8N_EXECUTIONS_QUEUE_RECOVERY_INTERVAL and N8N_EXECUTIONS_QUEUE_RECOVERY_BATCH.
  - Removed queueRecovery from CLI schema to avoid duplication.
  - Switched ScalingService to use globalConfig instead of config.getEnv.
  - Updated tests to reflect the new config location.

<!-- End of auto-generated description by cubic. -->

