### PR TITLE
n8n-auto-pr (N8N - 601090)

### DIFF
--- a/packages/nodes-base/nodes/Grist/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Grist/GenericFunctions.ts
@@ -67,10 +67,14 @@ export function parseSortProperties(sortProperties: GristSortProperties) {
 	}, '');
 }
 
+export function isSafeInteger(val: number) {
+	return !isNaN(val) && val > Number.MIN_VALUE && val < Number.MAX_VALUE;
+}
+
 export function parseFilterProperties(filterProperties: GristFilterProperties) {
 	return filterProperties.reduce<{ [key: string]: Array<string | number> }>((acc, cur) => {
 		acc[cur.field] = acc[cur.field] ?? [];
-		const values = isNaN(Number(cur.values)) ? cur.values : Number(cur.values);
+		const values = isSafeInteger(Number(cur.values)) ? Number(cur.values) : cur.values;
 		acc[cur.field].push(values);
 		return acc;
 	}, {});


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Prevents precision loss in Grist filter parsing by only converting string values to numbers when safely within JS numeric bounds. Addresses N8N-601090.

- Bug Fixes
  - Added isSafeInteger helper to guard numeric conversion.
  - Updated parseFilterProperties to use the guard instead of a simple isNaN check.
  - Preserves large IDs and precise values as strings so filters work correctly.

<!-- End of auto-generated description by cubic. -->

