### PR TITLE
n8n-auto-pr (N8N - 602449)

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/test/update-node-parameters.tool.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/test/update-node-parameters.tool.test.ts
@@ -192,7 +192,7 @@ describe('UpdateNodeParametersTool', () => {
 			});
 		});
 
-		it('should merge parameters instead of replacing them', async () => {
+		it('should be able to remove parameters', async () => {
 			const existingWorkflow = createWorkflow([
 				createNode({
 					id: 'node1',
@@ -208,9 +208,10 @@ describe('UpdateNodeParametersTool', () => {
 			]);
 			setupWorkflowState(mockGetCurrentTaskInput, existingWorkflow);
 
-			// Mock chain response - only updating URL
+			// Mock chain response - removing authentication
 			mockChain.invoke.mockResolvedValue({
 				parameters: {
+					method: 'GET',
 					url: 'https://api.example.com/v2',
 				},
 			});
@@ -218,19 +219,17 @@ describe('UpdateNodeParametersTool', () => {
 			const mockConfig = createToolConfig('update_node_parameters', 'test-call-3');
 
 			const result = await updateNodeParametersTool.invoke(
-				buildUpdateNodeInput('node1', ['Update URL to v2 endpoint']),
+				buildUpdateNodeInput('node1', ['Update URL to v2 endpoint', 'Remove authentication']),
 				mockConfig,
 			);
 
 			const content = parseToolResult<ParsedToolContent>(result);
 
-			// Should keep existing parameters and only update URL
+			// Should remove authentication and keep other parameters
 			expectNodeUpdated(content, 'node1', {
 				parameters: expect.objectContaining({
 					method: 'GET', // preserved
 					url: 'https://api.example.com/v2', // updated
-					authentication: 'genericCredentialType', // preserved
-					genericAuthType: 'httpBasicAuth', // preserved
 				}),
 			});
 		});

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/update-node-parameters.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/update-node-parameters.tool.ts
@@ -18,7 +18,6 @@ import {
 	extractNodeParameters,
 	formatChangesForPrompt,
 	updateNodeWithParameters,
-	mergeParameters,
 	fixExpressionPrefixes,
 } from './utils/parameter-update.utils';
 import type { UpdateNodeParametersOutput } from '../types/tools';
@@ -140,16 +139,12 @@ export function createUpdateNodeParametersTool(
 					}
 
 					// Fix expression prefixes in the new parameters
-					const fixedParameters = fixExpressionPrefixes(newParameters.parameters);
-
-					// Merge the new parameters with existing ones
-					const updatedParameters = mergeParameters(
-						currentParameters,
-						fixedParameters as INodeParameters,
-					);
+					const fixedParameters = fixExpressionPrefixes(
+						newParameters.parameters,
+					) as INodeParameters;
 
 					// Create updated node
-					const updatedNode = updateNodeWithParameters(node, updatedParameters);
+					const updatedNode = updateNodeWithParameters(node, fixedParameters);
 
 					// Build success message
 					const message = buildSuccessMessage(node, changes);
@@ -159,7 +154,7 @@ export function createUpdateNodeParametersTool(
 						nodeId,
 						nodeName: node.name,
 						nodeType: node.type,
-						updatedParameters,
+						updatedParameters: fixedParameters,
 						appliedChanges: changes,
 						message,
 					};


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
UpdateNodeParameters now replaces node parameters instead of merging them. This allows removing fields (e.g., authentication) and fixes stale values; addresses N8N-602449.

- **Bug Fixes**
  - Removed mergeParameters; pass fixed parameters directly to updateNodeWithParameters.
  - Updated test to confirm parameters can be removed and only provided keys are kept.

<!-- End of auto-generated description by cubic. -->

