### PR TITLE
n8n-auto-pr (N8N - 602675)

### DIFF
--- a/packages/@n8n/api-types/src/schemas/__tests__/insights.schema.test.ts
+++ b/packages/@n8n/api-types/src/schemas/__tests__/insights.schema.test.ts
@@ -69,24 +69,40 @@ describe('insightsSummarySchema', () => {
 });
 
 describe('insightsByWorkflowSchema', () => {
+	const validInsightsByWorkflow = {
+		count: 2,
+		data: [
+			{
+				workflowId: 'w1',
+				workflowName: 'Test Workflow',
+				projectId: 'p1',
+				projectName: 'Test Project',
+				total: 100,
+				succeeded: 90,
+				failed: 10,
+				failureRate: 0.56,
+				runTime: 300,
+				averageRunTime: 30.5,
+				timeSaved: 50,
+			},
+		],
+	};
+
 	test.each([
 		{
 			name: 'valid workflow insights',
+			value: validInsightsByWorkflow,
+			expected: true,
+		},
+		{
+			name: 'workflow insights with nullable workflow id and project id',
 			value: {
-				count: 2,
+				...validInsightsByWorkflow,
 				data: [
 					{
-						workflowId: 'w1',
-						workflowName: 'Test Workflow',
-						projectId: 'p1',
-						projectName: 'Test Project',
-						total: 100,
-						succeeded: 90,
-						failed: 10,
-						failureRate: 0.56,
-						runTime: 300,
-						averageRunTime: 30.5,
-						timeSaved: 50,
+						...validInsightsByWorkflow.data[0],
+						workflowId: null,
+						projectId: null,
 					},
 				],
 			},

--- a/packages/@n8n/api-types/src/schemas/insights.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/insights.schema.ts
@@ -48,9 +48,11 @@ export const insightsByWorkflowDataSchemas = {
 	data: z.array(
 		z
 			.object({
-				workflowId: z.string(),
+				// Workflow id will be null if the workflow has been deleted
+				workflowId: z.string().nullable(),
 				workflowName: z.string(),
-				projectId: z.string(),
+				// Project id will be null if the project has been deleted
+				projectId: z.string().nullable(),
 				projectName: z.string(),
 				total: z.number(),
 				succeeded: z.number(),

--- a/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
+++ b/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
@@ -30,9 +30,9 @@ const summaryParser = z
 
 const aggregatedInsightsByWorkflowParser = z
 	.object({
-		workflowId: z.string(),
+		workflowId: z.string().nullable(),
 		workflowName: z.string(),
-		projectId: z.string(),
+		projectId: z.string().nullable(),
 		projectName: z.string(),
 		total: z.union([z.number(), z.string()]).transform((value) => Number(value)),
 		succeeded: z.union([z.number(), z.string()]).transform((value) => Number(value)),

--- a/packages/frontend/editor-ui/src/features/insights/components/tables/InsightsTableWorkflows.vue
+++ b/packages/frontend/editor-ui/src/features/insights/components/tables/InsightsTableWorkflows.vue
@@ -168,21 +168,28 @@ watch(sortBy, (newValue) => {
 			@update:options="emit('update:options', $event)"
 		>
 			<template #[`item.workflowName`]="{ item }">
-				<router-link
-					:to="getWorkflowLink(item)"
-					:class="$style.link"
-					@click="trackWorkflowClick(item)"
+				<component
+					:is="item.workflowId ? 'router-link' : 'div'"
+					v-bind="
+						item.workflowId
+							? {
+									to: getWorkflowLink(item),
+									class: $style.link,
+									onClick: () => trackWorkflowClick(item),
+								}
+							: {}
+					"
 				>
 					<N8nTooltip :content="item.workflowName" placement="top">
 						<div :class="$style.ellipsis">
 							{{ item.workflowName }}
 						</div>
 					</N8nTooltip>
-				</router-link>
+				</component>
 			</template>
 			<template #[`item.timeSaved`]="{ item, value }">
 				<router-link
-					v-if="!item.timeSaved"
+					v-if="!item.timeSaved && item.workflowId"
 					:to="getWorkflowLink(item, { settings: 'true' })"
 					:class="$style.link"
 				>


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Handle deleted workflows and projects in Insights by Workflow so the table stays stable and avoids broken links (N8N-602675). Schema and parsing now accept null IDs, and the UI only links when an ID exists.

- **Bug Fixes**
  - Allow nullable workflowId and projectId in insightsByWorkflow schemas and repository parser.
  - Update table to render a plain label when workflowId is null and hide settings link when no ID.
  - Add tests for null workflowId/projectId cases.

<!-- End of auto-generated description by cubic. -->

