### PR TITLE
n8n-auto-pr (N8N - 606944)

### DIFF
--- a/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequest.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequest.test.ts
@@ -106,6 +106,7 @@ describe('Test HTTP Request Node', () => {
 				completed: false,
 				userId: 15,
 			});
+		nock(baseUrl).get('/html').reply(200, '<html><body><h1>Test</h1></body></html>');
 
 		//PUT
 		nock(baseUrl).put('/todos/10', { userId: '42' }).reply(200, {

--- a/packages/nodes-base/nodes/HttpRequest/test/node/workflow.use_error_output.json
+++ b/packages/nodes-base/nodes/HttpRequest/test/node/workflow.use_error_output.json
@@ -3,51 +3,93 @@
 	"nodes": [
 		{
 			"parameters": {},
-			"id": "6e15f2de-79fe-41f3-b76e-53ebfa2e4437",
+			"id": "6707decf-7ae3-46f1-8603-b0fe4844f240",
 			"name": "When clicking ‘Execute workflow’",
 			"type": "n8n-nodes-base.manualTrigger",
 			"typeVersion": 1,
-			"position": [-60, 580]
+			"position": [16, 560]
 		},
 		{
 			"parameters": {},
-			"id": "af1bb989-3c6d-4323-8e88-649e45d64c00",
+			"id": "09b63a84-789d-4a31-b546-849ba47ed689",
 			"name": "Success path",
 			"type": "n8n-nodes-base.noOp",
 			"typeVersion": 1,
-			"position": [460, 460]
-		},
-		{
-			"parameters": {},
-			"id": "43c4ee19-6a9d-4b1d-aefa-2c24abe45189",
-			"name": "Error path",
-			"type": "n8n-nodes-base.noOp",
-			"typeVersion": 1,
-			"position": [460, 700]
+			"position": [464, 272]
 		},
 		{
 			"parameters": {
 				"method": "POST",
-				"url": "https://webhook.site/e18fe8f9-ec77-4574-a40d-8ae054191e1e",
+				"url": "https://dummyjson.com/todos/1",
 				"sendBody": true,
 				"specifyBody": "json",
 				"jsonBody": "{\n  \"q\": \"abc\",\n}",
 				"options": {}
 			},
-			"id": "31641920-7f43-473f-ad96-b121122802bb",
-			"name": "HTTP Request",
+			"id": "c6841eb1-7913-4c8d-8c9d-b88a908125ed",
+			"name": "Invalid JSON Body",
 			"type": "n8n-nodes-base.httpRequest",
 			"typeVersion": 4.2,
-			"position": [180, 580],
+			"position": [240, 368],
 			"alwaysOutputData": false,
 			"onError": "continueErrorOutput"
+		},
+		{
+			"parameters": {},
+			"id": "21750b7e-c18a-43a5-a068-f8aa85d1cadf",
+			"name": "Success path1",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [464, 656]
+		},
+		{
+			"parameters": {
+				"url": "https://dummyjson.com/html",
+				"options": {
+					"response": {
+						"response": {
+							"responseFormat": "json"
+						}
+					}
+				}
+			},
+			"id": "ae2891f0-1968-4f57-a1a0-87d6f6dab57d",
+			"name": "Invalid JSON Response",
+			"type": "n8n-nodes-base.httpRequest",
+			"typeVersion": 4.2,
+			"position": [240, 752],
+			"alwaysOutputData": false,
+			"onError": "continueErrorOutput"
+		},
+		{
+			"parameters": {},
+			"id": "baa75f00-e0dd-40b2-b718-1e8311549a05",
+			"name": "Request body error",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [464, 464]
+		},
+		{
+			"parameters": {},
+			"id": "4733c47f-38c8-44a8-9d77-d9e733777cbf",
+			"name": "Response body error",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [464, 848]
 		}
 	],
 	"pinData": {
-		"Error path": [
+		"Request body error": [
 			{
 				"json": {
 					"error": "JSON parameter needs to be valid JSON"
+				}
+			}
+		],
+		"Response body error": [
+			{
+				"json": {
+					"error": "Response body is not valid JSON. Change \"Response Format\" to \"Text\""
 				}
 			}
 		]
@@ -57,14 +99,19 @@
 			"main": [
 				[
 					{
-						"node": "HTTP Request",
+						"node": "Invalid JSON Body",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "Invalid JSON Response",
 						"type": "main",
 						"index": 0
 					}
 				]
 			]
 		},
-		"HTTP Request": {
+		"Invalid JSON Body": {
 			"main": [
 				[
 					{
@@ -75,7 +122,25 @@
 				],
 				[
 					{
-						"node": "Error path",
+						"node": "Request body error",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Invalid JSON Response": {
+			"main": [
+				[
+					{
+						"node": "Success path1",
+						"type": "main",
+						"index": 0
+					}
+				],
+				[
+					{
+						"node": "Response body error",
 						"type": "main",
 						"index": 0
 					}
@@ -87,11 +152,10 @@
 	"settings": {
 		"executionOrder": "v1"
 	},
-	"versionId": "f445a6e9-818f-4b70-8b4f-e2a68fc5d6e4",
+	"versionId": "c7026310-8c4f-4889-a45b-befebacc7dde",
 	"meta": {
-		"templateCredsSetupCompleted": true,
-		"instanceId": "be251a83c052a9862eeac953816fbb1464f89dfbf79d7ac490a8e336a8cc8bfd"
+		"instanceId": "27cc9b56542ad45b38725555722c50a1c3fee1670bbb67980558314ee08517c4"
 	},
-	"id": "f3rDILaMkFqisP3P",
+	"id": "2Zd3If2j9PglrHri",
 	"tags": []
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes the HTTP Request node so it correctly continues execution and routes errors to the error output when continueOnFail is enabled. Also improves handling of invalid JSON in request bodies and responses to show clear errors. Addresses N8N-606944.

- **Bug Fixes**
  - Wrap per-item processing in try/catch to respect continueOnFail/onError and avoid failing the whole node.
  - When a request fails or parsing throws, push an error item (with sanitized error) instead of throwing.
  - Surface clear errors for invalid JSON responses and bodies; HTML/text responses no longer break JSON mode.
  - Better hint for 429 responses to use batching settings.
  - Tests: added HTML endpoint mock and updated workflow fixture to verify error-output behavior for invalid JSON in body and response.

<!-- End of auto-generated description by cubic. -->

