### PR TITLE
n8n-auto-pr (N8N - 607278)

### DIFF
--- a/cypress/e2e/12-canvas.cy.ts
+++ b/cypress/e2e/12-canvas.cy.ts
@@ -448,4 +448,9 @@ describe('Canvas Node Manipulation and Navigation', () => {
 			NDVDialog.actions.close();
 		});
 	});
+
+	it('should open and close the about modal on keyboard shortcut', () => {
+		WorkflowPage.actions.hitOpenAbout();
+		cy.getByTestId('close-about-modal-button').click();
+	});
 });

--- a/cypress/pages/workflow.ts
+++ b/cypress/pages/workflow.ts
@@ -390,6 +390,9 @@ export class WorkflowPage extends BasePage {
 		hitDisableNodeShortcut: () => {
 			cy.get('body').type('d');
 		},
+		hitOpenAbout: () => {
+			cy.get('body').type(`{alt}{${META_KEY}}o`);
+		},
 		hitCopy: () => {
 			this.actions.hitComboShortcut(`{${META_KEY}}`, 'c');
 		},

--- a/packages/frontend/editor-ui/src/components/MainSidebar.vue
+++ b/packages/frontend/editor-ui/src/components/MainSidebar.vue
@@ -36,6 +36,7 @@ import VersionUpdateCTA from '@/components/VersionUpdateCTA.vue';
 import { TemplateClickSource, trackTemplatesClick } from '@/utils/experiments';
 import { I18nT } from 'vue-i18n';
 import { usePersonalizedTemplatesV2Store } from '@/experiments/templateRecoV2/stores/templateRecoV2.store';
+import { useKeybindings } from '@/composables/useKeybindings';
 
 const becomeTemplateCreatorStore = useBecomeTemplateCreatorStore();
 const cloudPlanStore = useCloudPlanStore();
@@ -58,6 +59,9 @@ const telemetry = useTelemetry();
 const pageRedirectionHelper = usePageRedirectionHelper();
 const { getReportingURL } = useBugReporting();
 
+useKeybindings({
+	ctrl_alt_o: () => handleSelect('about'),
+});
 useUserHelpers(router, route);
 
 // Template refs

--- a/packages/frontend/editor-ui/src/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/views/NodeView.vue
@@ -67,6 +67,7 @@ import {
 	VIEWS,
 	NDV_UI_OVERHAUL_EXPERIMENT,
 	WORKFLOW_SETTINGS_MODAL_KEY,
+	ABOUT_MODAL_KEY,
 } from '@/constants';
 import { useSourceControlStore } from '@/stores/sourceControl.store';
 import { useNodeCreatorStore } from '@/stores/nodeCreator.store';
@@ -139,6 +140,7 @@ import CanvasChatButton from '@/components/canvas/elements/buttons/CanvasChatBut
 import { useFocusPanelStore } from '@/stores/focusPanel.store';
 import { useAITemplatesStarterCollectionStore } from '@/experiments/aiTemplatesStarterCollection/stores/aiTemplatesStarterCollection.store';
 import { useReadyToRunWorkflowsStore } from '@/experiments/readyToRunWorkflows/stores/readyToRunWorkflows.store';
+import { useKeybindings } from '@/composables/useKeybindings';
 
 defineOptions({
 	name: 'NodeView',
@@ -254,6 +256,9 @@ const {
 const { extractWorkflow } = useWorkflowExtraction();
 const { applyExecutionData } = useExecutionDebugging();
 useClipboard({ onPaste: onClipboardPaste });
+useKeybindings({
+	ctrl_alt_o: () => uiStore.openModal(ABOUT_MODAL_KEY),
+});
 
 const isLoading = ref(true);
 const isBlankRedirect = ref(false);


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a global keyboard shortcut to open the About modal with Alt+Meta+O, and adds e2e coverage. Implements N8N-607278.

- **New Features**
  - Bind Alt+Meta+O via useKeybindings in NodeView and MainSidebar to open the About modal.
  - Add Cypress shortcut action (hitOpenAbout) and test to open and close the modal.

<!-- End of auto-generated description by cubic. -->

