### PR TITLE
n8n-auto-pr (N8N - 607329)

### DIFF
--- a/packages/cli/src/community-packages/community-packages.controller.ts
+++ b/packages/cli/src/community-packages/community-packages.controller.ts
@@ -25,8 +25,8 @@ const {
 } = RESPONSE_ERROR_MESSAGES;
 
 const isClientError = (error: Error) =>
-	[PACKAGE_VERSION_NOT_FOUND, PACKAGE_DOES_NOT_CONTAIN_NODES, PACKAGE_NOT_FOUND].some((msg) =>
-		error.message.includes(msg),
+	[PACKAGE_VERSION_NOT_FOUND, PACKAGE_DOES_NOT_CONTAIN_NODES, PACKAGE_NOT_FOUND].some(
+		(msg) => typeof error.message === 'string' && error.message.includes(msg),
 	);
 
 export function isNpmError(error: unknown): error is { code: number; stdout: string } {

--- a/packages/cli/src/execution-lifecycle/restore-binary-data-id.ts
+++ b/packages/cli/src/execution-lifecycle/restore-binary-data-id.ts
@@ -58,7 +58,7 @@ export async function restoreBinaryDataId(
 		const error = e instanceof Error ? e : new Error(`${e}`);
 		const logger = Container.get(Logger);
 
-		if (error.message.includes('ENOENT')) {
+		if (typeof error.message === 'string' && error.message.includes('ENOENT')) {
 			logger.warn('Failed to restore binary data ID - No such file or dir', {
 				executionId,
 				error,

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -80,7 +80,7 @@ export class WorkflowRunner {
 		if (
 			error instanceof ExecutionNotFoundError ||
 			error instanceof ExecutionCancelledError ||
-			error.message.includes('cancelled')
+			(typeof error.message === 'string' && error.message.includes('cancelled'))
 		) {
 			return;
 		}
@@ -422,6 +422,7 @@ export class WorkflowRunner {
 				} catch (error) {
 					if (
 						error instanceof Error &&
+						typeof error.message === 'string' &&
 						error.message.includes('job stalled more than maxStalledCount')
 					) {
 						error = new MaxStalledCountError(error);

--- a/packages/core/src/errors/error-reporter.ts
+++ b/packages/core/src/errors/error-reporter.ts
@@ -235,6 +235,7 @@ export class ErrorReporter {
 		return (
 			error instanceof Error &&
 			error.name === 'QueryFailedError' &&
+			typeof error.message === 'string' &&
 			['SQLITE_FULL', 'SQLITE_IOERR'].some((errMsg) => error.message.includes(errMsg))
 		);
 	}

--- a/packages/frontend/editor-ui/src/components/ButtonParameter/utils.ts
+++ b/packages/frontend/editor-ui/src/components/ButtonParameter/utils.ts
@@ -206,7 +206,7 @@ export async function generateCodeForAiTransform(prompt: string, path: string, r
 				code = generatedCode;
 				break;
 			} catch (e) {
-				if (e.message.includes('maximum context length')) {
+				if (typeof e.message === 'string' && e.message.includes('maximum context length')) {
 					reducePayloadSizeOrThrow(payload, e);
 					continue;
 				}

--- a/packages/frontend/editor-ui/src/stores/workflowHistory.store.ts
+++ b/packages/frontend/editor-ui/src/stores/workflowHistory.store.ts
@@ -93,7 +93,11 @@ export const useWorkflowHistoryStore = defineStore('workflowHistory', () => {
 		return await workflowsStore
 			.updateWorkflow(workflowId, updateData, true)
 			.catch(async (error) => {
-				if (error.httpStatusCode === 400 && error.message.includes('can not be activated')) {
+				if (
+					error.httpStatusCode === 400 &&
+					typeof error.message === 'string' &&
+					error.message.includes('can not be activated')
+				) {
 					return await workflowsStore.fetchWorkflow(workflowId);
 				} else {
 					throw new Error(error);

--- a/packages/nodes-base/nodes/Files/ExtractFromFile/actions/moveTo.operation.ts
+++ b/packages/nodes-base/nodes/Files/ExtractFromFile/actions/moveTo.operation.ts
@@ -161,7 +161,7 @@ export async function execute(
 			returnData.push(newItem);
 		} catch (error) {
 			let errorDescription;
-			if (error.message.includes('Unexpected token')) {
+			if (typeof error.message === 'string' && error.message.includes('Unexpected token')) {
 				error.message = "The file selected in 'Input Binary Field' is not in JSON format";
 				errorDescription =
 					"Try to change the operation or select a JSON file in 'Input Binary Field'";

--- a/packages/nodes-base/nodes/Files/ReadWriteFile/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Files/ReadWriteFile/helpers/utils.ts
@@ -10,22 +10,24 @@ export function errorMapper(
 	let message;
 	let description;
 
-	if (error.message.includes('Cannot create a string longer than')) {
-		message = 'The file is too large';
-		description =
-			'The binary file you are attempting to read exceeds 512MB, which is limit when using default binary data mode, try using the filesystem binary mode. More information <a href="https://docs.n8n.io/hosting/scaling/binary-data/" target="_blank">here</a>.';
-	} else if (error.message.includes('EACCES') && context?.operation === 'read') {
-		const path =
-			((error as unknown as IDataObject).path as string) || (context?.filePath as string);
-		message = `You don't have the permissions to access ${path}`;
-		description =
-			"Verify that the path specified in 'File(s) Selector' is correct, or change the file(s) permissions if needed";
-	} else if (error.message.includes('EACCES') && context?.operation === 'write') {
-		const path =
-			((error as unknown as IDataObject).path as string) || (context?.filePath as string);
-		message = `You don't have the permissions to write the file ${path}`;
-		description =
-			"Specify another destination folder in 'File Path and Name', or change the permissions of the parent folder";
+	if (typeof error.message === 'string') {
+		if (error.message.includes('Cannot create a string longer than')) {
+			message = 'The file is too large';
+			description =
+				'The binary file you are attempting to read exceeds 512MB, which is limit when using default binary data mode, try using the filesystem binary mode. More information <a href="https://docs.n8n.io/hosting/scaling/binary-data/" target="_blank">here</a>.';
+		} else if (error.message.includes('EACCES') && context?.operation === 'read') {
+			const path =
+				((error as unknown as IDataObject).path as string) || (context?.filePath as string);
+			message = `You don't have the permissions to access ${path}`;
+			description =
+				"Verify that the path specified in 'File(s) Selector' is correct, or change the file(s) permissions if needed";
+		} else if (error.message.includes('EACCES') && context?.operation === 'write') {
+			const path =
+				((error as unknown as IDataObject).path as string) || (context?.filePath as string);
+			message = `You don't have the permissions to write the file ${path}`;
+			description =
+				"Specify another destination folder in 'File Path and Name', or change the permissions of the parent folder";
+		}
 	}
 
 	return new NodeOperationError(this.getNode(), error, { itemIndex, message, description });

--- a/packages/workflow/src/telemetry-helpers.ts
+++ b/packages/workflow/src/telemetry-helpers.ts
@@ -458,7 +458,13 @@ export function generateNodesGraph(
 					}
 				}
 			} catch (e: unknown) {
-				if (!(e instanceof Error && e.message.includes('Unrecognized node type'))) {
+				if (
+					!(
+						e instanceof Error &&
+						typeof e.message === 'string' &&
+						e.message.includes('Unrecognized node type')
+					)
+				) {
 					throw e;
 				}
 			}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Hardened error handling across backend, frontend, and node code by verifying error.message is a string before checking substrings. Prevents crashes from non-standard errors during installs, execution, file ops, and telemetry (N8N-607329).

- **Bug Fixes**
  - Added message-type guards in community packages controller, binary data restore, workflow runner (cancel/stalled), DB error reporter, editor ButtonParameter, workflow history store, file nodes (read/write utils, extract/move), and telemetry graph builder.
  - Avoids TypeErrors when thrown values lack a string message, preserving existing behavior and user-facing messages.

<!-- End of auto-generated description by cubic. -->

