### PR TITLE
n8n-auto-pr (N8N - 607342)

### DIFF
--- a/packages/cli/src/modules/data-store/data-store-column.repository.ts
+++ b/packages/cli/src/modules/data-store/data-store-column.repository.ts
@@ -62,7 +62,7 @@ export class DataStoreColumnRepository extends Repository<DataStoreColumn> {
 				throw new UnexpectedError('QueryRunner is not available');
 			}
 
-			await this.dataStoreRowsRepository.ensureTableAndAddColumn(
+			await this.dataStoreRowsRepository.addColumn(
 				dataStoreId,
 				column,
 				queryRunner,

--- a/packages/cli/src/modules/data-store/data-store-rows.repository.ts
+++ b/packages/cli/src/modules/data-store/data-store-rows.repository.ts
@@ -123,19 +123,14 @@ export class DataStoreRowsRepository {
 		await createTable.execute(queryRunner);
 	}
 
-	async ensureTableAndAddColumn(
+	async addColumn(
 		dataStoreId: string,
 		column: DataStoreColumn,
 		queryRunner: QueryRunner,
 		dbType: DataSourceOptions['type'],
 	) {
 		const tableName = toTableName(dataStoreId);
-		const tableExists = await queryRunner.hasTable(tableName);
-		if (!tableExists) {
-			await this.createTableWithColumns(tableName, [column], queryRunner);
-		} else {
-			await queryRunner.manager.query(addColumnQuery(tableName, column, dbType));
-		}
+		await queryRunner.manager.query(addColumnQuery(tableName, column, dbType));
 	}
 
 	async dropColumnFromTable(

--- a/packages/cli/src/modules/data-store/data-store.repository.ts
+++ b/packages/cli/src/modules/data-store/data-store.repository.ts
@@ -38,10 +38,6 @@ export class DataStoreRepository extends Repository<DataStore> {
 				throw new UnexpectedError('QueryRunner is not available');
 			}
 
-			if (columns.length === 0) {
-				return;
-			}
-
 			// insert columns
 			const columnEntities = columns.map((col, index) =>
 				em.create(DataStoreColumn, {
@@ -51,9 +47,12 @@ export class DataStoreRepository extends Repository<DataStore> {
 					index: col.index ?? index,
 				}),
 			);
-			await em.insert(DataStoreColumn, columnEntities);
 
-			// create user table
+			if (columnEntities.length > 0) {
+				await em.insert(DataStoreColumn, columnEntities);
+			}
+
+			// create user table (will create empty table with just id column if no columns)
 			await this.dataStoreRowsRepository.createTableWithColumns(
 				tableName,
 				columnEntities,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Always create the user table when a data store is created, even if no columns are provided. Addresses N8N-607342 by guaranteeing table existence so column operations are simpler and more reliable.

- **New Features**
  - Create an empty user table (id only) on createDataStore, even with no columns.
  - Simplify addColumn: the table is assumed to exist; adding to empty or populated tables works, and existing rows get nulls for the new column.
  - Updated tests to cover creation without columns and adding columns in both empty and populated tables.

<!-- End of auto-generated description by cubic. -->

