### PR TITLE
n8n-auto-pr (N8N - 607522)

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
@@ -223,6 +223,19 @@ describe('getFileSystemHelperFunctions', () => {
 			);
 		});
 
+		it('should not reveal if file exists if it is within restricted path', async () => {
+			process.env[RESTRICT_FILE_ACCESS_TO] = '/allowed/path';
+
+			const error = new Error('ENOENT');
+			// @ts-expect-error undefined property
+			error.code = 'ENOENT';
+			(fsAccess as jest.Mock).mockRejectedValueOnce(error);
+
+			await expect(helperFunctions.createReadStream('/blocked/path')).rejects.toThrow(
+				'Access to the file is not allowed',
+			);
+		});
+
 		it('should create a read stream if file access is permitted', async () => {
 			const filePath = '/allowed/path';
 			(fsAccess as jest.Mock).mockResolvedValueOnce({});


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Prevents leaking whether a file exists outside allowed paths by enforcing path checks before any filesystem access. Aligns with N8N-607522 to block path probing and provide a clear, safe error.

- **Bug Fixes**
  - Check isFilePathBlocked before fsAccess in createReadStream; throw NodeOperationError with allowed paths hint.
  - Safely handle ENOENT in isFilePathBlocked using typed error check and fallback to resolve().
  - Add test to ensure files within restricted paths do not reveal existence.

<!-- End of auto-generated description by cubic. -->

