### PR TITLE
n8n-auto-pr (N8N - 609726)

### DIFF
--- a/packages/cli/src/services/__tests__/credentials-tester.service.test.ts
+++ b/packages/cli/src/services/__tests__/credentials-tester.service.test.ts
@@ -1,19 +1,22 @@
 import mock from 'jest-mock-extended/lib/Mock';
-import type { ICredentialType, INodeType } from 'n8n-workflow';
+import type { ICredentialType, INodeType, IWorkflowExecuteAdditionalData } from 'n8n-workflow';
 
 import type { CredentialTypes } from '@/credential-types';
+import type { CredentialsHelper } from '@/credentials-helper';
 import type { NodeTypes } from '@/node-types';
 import { CredentialsTester } from '@/services/credentials-tester.service';
+import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
 
 describe('CredentialsTester', () => {
 	const credentialTypes = mock<CredentialTypes>();
 	const nodeTypes = mock<NodeTypes>();
+	const credentialsHelper = mock<CredentialsHelper>();
 	const credentialsTester = new CredentialsTester(
 		mock(),
 		mock(),
 		credentialTypes,
 		nodeTypes,
-		mock(),
+		credentialsHelper,
 	);
 
 	beforeEach(() => {
@@ -35,5 +38,109 @@ describe('CredentialsTester', () => {
 		if (typeof testFn !== 'function') fail();
 
 		expect(testFn.name).toBe('oauth2CredTest');
+	});
+
+	describe('testCredentials', () => {
+		let mockTestFunction: jest.Mock;
+
+		beforeEach(() => {
+			mockTestFunction = jest.fn();
+			credentialTypes.getByName.mockReturnValue(mock<ICredentialType>({ test: undefined }));
+			credentialTypes.getSupportedNodes.mockReturnValue(['testCredentials']);
+			credentialTypes.getParentTypes.mockReturnValue([]);
+			nodeTypes.getByName.mockReturnValue(
+				mock<INodeType>({
+					methods: {
+						credentialTest: {
+							testCredentialsFunction: mockTestFunction,
+						},
+					},
+					description: {
+						credentials: [{ name: 'testCredentials', testedBy: 'testCredentialsFunction' }],
+					},
+				}),
+			);
+			jest
+				.spyOn(WorkflowExecuteAdditionalData, 'getBase')
+				.mockResolvedValue({} as IWorkflowExecuteAdditionalData);
+		});
+
+		it('should redact secrets in error messages', async () => {
+			mockTestFunction.mockResolvedValue({
+				status: 'Error',
+				message: 'Test failed for apiKey secret_api_key',
+			});
+
+			const computedCredentialsData = {
+				testNestedData: {
+					access_token: 'abc123',
+					secretData: {
+						apiKey: 'secret_api_key',
+					},
+				},
+			};
+			credentialsHelper.applyDefaultsAndOverwrites.mockResolvedValue(computedCredentialsData);
+
+			const rawCredentialsData = {
+				...computedCredentialsData,
+				testNestedData: {
+					...computedCredentialsData.testNestedData,
+					secretData: {
+						apiKey: '{{ $secrets.apiKey }}',
+					},
+				},
+			};
+			const redactedMessage = await credentialsTester.testCredentials(
+				'user-id',
+				'testCredentials',
+				{
+					id: 'credential-id',
+					name: 'credential-name',
+					type: 'oAuth2Api',
+					data: rawCredentialsData,
+				},
+			);
+
+			expect(redactedMessage.status).toBe('Error');
+			expect(redactedMessage.message).toBe('Test failed for apiKey *****key');
+		});
+
+		it('should not redact secrets with value shorter than 3 characters', async () => {
+			mockTestFunction.mockResolvedValue({
+				status: 'Error',
+				message: 'Test failed for apiKey se',
+			});
+
+			const computedCredentialsData = {
+				testNestedData: {
+					access_token: 'abc123',
+					secretData: {
+						apiKey: 'se',
+					},
+				},
+			};
+			credentialsHelper.applyDefaultsAndOverwrites.mockResolvedValue(computedCredentialsData);
+
+			const rawCredentialsData = {
+				...computedCredentialsData,
+				testNestedData: {
+					...computedCredentialsData.testNestedData,
+					apiKey: '{{ $secrets.apiKey }}',
+				},
+			};
+			const redactedMessage = await credentialsTester.testCredentials(
+				'user-id',
+				'testCredentials',
+				{
+					id: 'credential-id',
+					name: 'credential-name',
+					type: 'oAuth2Api',
+					data: rawCredentialsData,
+				},
+			);
+
+			expect(redactedMessage.status).toBe('Error');
+			expect(redactedMessage.message).toBe('Test failed for apiKey se');
+		});
 	});
 });

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -92,3 +92,33 @@ export const shouldAssignExecuteMethod = (nodeType: INodeType) => {
 		(!nodeType.methods || isDeclarativeNode)
 	);
 };
+
+/**
+ * Recursively gets all key paths of an object or array, filtered by the provided value filter.
+ * @param obj - The object or array to search.
+ * @param keys - The array to store matching keys.
+ * @param valueFilter - A function to filter values.
+ * @returns The array of matching key paths.
+ */
+export const getAllKeyPaths = (
+	obj: unknown,
+	currentPath = '',
+	paths: string[] = [],
+	valueFilter: (value: string) => boolean,
+): string[] => {
+	if (Array.isArray(obj)) {
+		obj.forEach((item, index) =>
+			getAllKeyPaths(item, `${currentPath}[${index}]`, paths, valueFilter),
+		);
+	} else if (obj && typeof obj === 'object') {
+		for (const [key, value] of Object.entries(obj)) {
+			const newPath = currentPath ? `${currentPath}.${key}` : key;
+			if (typeof value === 'string' && valueFilter(value)) {
+				paths.push(newPath);
+			} else {
+				getAllKeyPaths(value, newPath, paths, valueFilter);
+			}
+		}
+	}
+	return paths;
+};


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Prevents secret leaks in credential test error messages by masking values resolved from $secrets. Includes a recursive key-path utility and tests to validate redaction (addresses N8N-609726).

- **Bug Fixes**
  - Redacts secret values in CredentialsTester messages, masking all but the last 3 characters; values shorter than 3 chars are not masked.
  - Adds getAllKeyPaths to find secret value paths in nested objects and arrays.
  - Adds unit tests for the utility and the redaction behavior.

<!-- End of auto-generated description by cubic. -->

