### PR TITLE
n8n-auto-pr (N8N - 612759)

### DIFF
--- a/packages/core/src/execution-engine/__tests__/workflow-execute-run-node.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute-run-node.test.ts
@@ -527,7 +527,7 @@ describe('WorkflowExecute.runNode - Real Implementation', () => {
 
 			// Verify that ErrorReporter.error was called due to invalid JSON data
 			expect(mockErrorReporter.error).toHaveBeenCalledWith(
-				'node execution returned incorrect data',
+				'node execution returned incorrect output',
 				expect.objectContaining({
 					shouldBeLogged: false,
 					extra: expect.objectContaining({

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -1196,7 +1196,7 @@ export class WorkflowExecute {
 			// Does not block the execution from continuing
 			const jsonCompatibleResult = isJsonCompatible(data, new Set(['pairedItem']));
 			if (!jsonCompatibleResult.isValid) {
-				Container.get(ErrorReporter).error('node execution returned incorrect data', {
+				Container.get(ErrorReporter).error('node execution returned incorrect output', {
 					shouldBeLogged: false,
 					extra: {
 						nodeName: node.name,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Renamed the invalid node output error from "incorrect data" to "incorrect output" for clearer reporting and improved Sentry grouping. Updated the corresponding unit test to match.

<!-- End of auto-generated description by cubic. -->

