### PR TITLE
n8n-auto-pr (N8N - 614880)

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/ai-workflow-builder-agent.service.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/ai-workflow-builder-agent.service.ts
@@ -30,6 +30,7 @@ export class AiWorkflowBuilderService {
 		private readonly nodeTypes: INodeTypes,
 		private readonly client?: AiAssistantClient,
 		private readonly logger?: Logger,
+		private readonly instanceUrl?: string,
 	) {
 		this.parsedNodeTypes = this.getNodeTypes();
 	}
@@ -162,6 +163,7 @@ export class AiWorkflowBuilderService {
 			tracer: this.tracingClient
 				? new LangChainTracer({ client: this.tracingClient, projectName: 'n8n-workflow-builder' })
 				: undefined,
+			instanceUrl: this.instanceUrl,
 		});
 
 		return this.agent;

--- a/packages/@n8n/ai-workflow-builder.ee/src/chains/parameter-updater.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/chains/parameter-updater.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 
 import { LLMServiceError } from '../errors';
 import type { ParameterUpdaterOptions } from '../types/config';
+import { instanceUrlPrompt } from './prompts/instance-url';
 import { ParameterUpdatePromptBuilder } from './prompts/prompt-builder';
 
 export const parametersSchema = z
@@ -39,7 +40,6 @@ const workflowContextPrompt = `
 <current_execution_nodes_schemas>
 {execution_schema}
 </current_execution_nodes_schemas>
-
 
 <selected_node>
 Name: {node_name}
@@ -100,6 +100,10 @@ export const createParameterUpdaterChain = (
 					type: 'text',
 					text: nodeDefinitionPrompt,
 					cache_control: { type: 'ephemeral' },
+				},
+				{
+					type: 'text',
+					text: instanceUrlPrompt,
 				},
 			],
 		],

--- a/packages/@n8n/ai-workflow-builder.ee/src/chains/prompts/instance-url.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/chains/prompts/instance-url.ts
@@ -1,0 +1,12 @@
+export const instanceUrlPrompt = `
+<instance_url>
+The n8n instance base URL is: {instanceUrl}
+
+This URL is essential for webhook nodes and chat triggers as it provides the base URL for:
+- Webhook URLs that external services need to call
+- Chat trigger URLs for conversational interfaces
+- Any node that requires the full instance URL to generate proper callback URLs
+
+When working with webhook or chat trigger nodes, use this URL as the base for constructing proper endpoint URLs.
+</instance_url>
+`;

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/prompts/main-agent.prompt.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/prompts/main-agent.prompt.ts
@@ -1,5 +1,7 @@
 import { ChatPromptTemplate } from '@langchain/core/prompts';
 
+import { instanceUrlPrompt } from '@/chains/prompts/instance-url';
+
 const systemPrompt = `You are an AI assistant specialized in creating and editing n8n workflows. Your goal is to help users build efficient, well-connected workflows by intelligently using the available tools.
 
 <prime_directive>
@@ -329,7 +331,9 @@ update_node_parameters({{
 }})
 
 Then tell the user: "I've set up the Gmail Tool node with dynamic AI parameters - it will automatically determine recipients and subjects based on context."
-</handling_uncertainty>`;
+</handling_uncertainty>
+
+`;
 
 const responsePatterns = `
 <response_patterns>
@@ -391,6 +395,10 @@ export const mainAgentPrompt = ChatPromptTemplate.fromMessages([
 				type: 'text',
 				text: systemPrompt,
 				cache_control: { type: 'ephemeral' },
+			},
+			{
+				type: 'text',
+				text: instanceUrlPrompt,
 			},
 			{
 				type: 'text',

--- a/packages/@n8n/ai-workflow-builder.ee/src/workflow-builder-agent.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/workflow-builder-agent.ts
@@ -40,6 +40,7 @@ export interface WorkflowBuilderAgentConfig {
 	checkpointer?: MemorySaver;
 	tracer?: LangChainTracer;
 	autoCompactThresholdTokens?: number;
+	instanceUrl?: string;
 }
 
 export interface ChatPayload {
@@ -59,6 +60,7 @@ export class WorkflowBuilderAgent {
 	private logger?: Logger;
 	private tracer?: LangChainTracer;
 	private autoCompactThresholdTokens: number;
+	private instanceUrl?: string;
 
 	constructor(config: WorkflowBuilderAgentConfig) {
 		this.parsedNodeTypes = config.parsedNodeTypes;
@@ -69,6 +71,7 @@ export class WorkflowBuilderAgent {
 		this.tracer = config.tracer;
 		this.autoCompactThresholdTokens =
 			config.autoCompactThresholdTokens ?? DEFAULT_AUTO_COMPACT_THRESHOLD_TOKENS;
+		this.instanceUrl = config.instanceUrl;
 	}
 
 	private createWorkflow() {
@@ -78,7 +81,12 @@ export class WorkflowBuilderAgent {
 			createAddNodeTool(this.parsedNodeTypes),
 			createConnectNodesTool(this.parsedNodeTypes, this.logger),
 			createRemoveNodeTool(this.logger),
-			createUpdateNodeParametersTool(this.parsedNodeTypes, this.llmComplexTask, this.logger),
+			createUpdateNodeParametersTool(
+				this.parsedNodeTypes,
+				this.llmComplexTask,
+				this.logger,
+				this.instanceUrl,
+			),
 		];
 
 		// Create a map for quick tool lookup
@@ -98,6 +106,7 @@ export class WorkflowBuilderAgent {
 				...state,
 				executionData: state.workflowContext?.executionData ?? {},
 				executionSchema: state.workflowContext?.executionSchema ?? [],
+				instanceUrl: this.instanceUrl,
 			});
 			const response = await this.llmSimpleTask.bindTools(tools).invoke(prompt);
 

--- a/packages/cli/src/services/ai-workflow-builder.service.ts
+++ b/packages/cli/src/services/ai-workflow-builder.service.ts
@@ -9,6 +9,7 @@ import type { IUser } from 'n8n-workflow';
 import { N8N_VERSION } from '@/constants';
 import { License } from '@/license';
 import { NodeTypes } from '@/node-types';
+import { UrlService } from '@/services/url.service';
 
 /**
  * This service wraps the actual AiWorkflowBuilderService to avoid circular dependencies.
@@ -23,6 +24,7 @@ export class WorkflowBuilderService {
 		private readonly license: License,
 		private readonly config: GlobalConfig,
 		private readonly logger: Logger,
+		private readonly urlService: UrlService,
 	) {}
 
 	private async getService(): Promise<AiWorkflowBuilderService> {
@@ -43,7 +45,12 @@ export class WorkflowBuilderService {
 				});
 			}
 
-			this.service = new AiWorkflowBuilderService(this.nodeTypes, client, this.logger);
+			this.service = new AiWorkflowBuilderService(
+				this.nodeTypes,
+				client,
+				this.logger,
+				this.urlService.getInstanceBaseUrl(),
+			);
 		}
 		return this.service;
 	}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Pass the n8n instance base URL into the Workflow Builder so it can generate correct webhook and chat trigger URLs when creating or updating nodes. This reduces broken callbacks and improves first-run success. (Linear: N8N-614880)

- **New Features**
  - Provide instanceUrl from CLI UrlService to AiWorkflowBuilderService and WorkflowBuilderAgent.
  - Add instanceUrl to agent and parameter-updater prompts so tools can construct proper endpoint URLs.
  - Include instanceUrl in update-node-parameters tool inputs for LLM-driven parameter updates.

- **Refactors**
  - Extract parameter update logic into processParameterUpdates for clarity and reuse.
  - Strengthen validation of LLM responses and keep expression prefix fixes centralized.
  - Pass instanceUrl through agent state to tools.

<!-- End of auto-generated description by cubic. -->

