### PR TITLE
n8n-auto-pr (N8N - 616011)

### DIFF
--- a/packages/frontend/editor-ui/src/stores/nodeTypes.store.ts
+++ b/packages/frontend/editor-ui/src/stores/nodeTypes.store.ts
@@ -339,8 +339,6 @@ export const useNodeTypesStore = defineStore(STORES.NODE_TYPES, () => {
 	const getNodeTypes = async () => {
 		const nodeTypes = await nodeTypesApi.getNodeTypes(rootStore.baseUrl);
 
-		await fetchCommunityNodePreviews();
-
 		if (nodeTypes.length) {
 			setNodeTypes(nodeTypes);
 		}
@@ -440,6 +438,7 @@ export const useNodeTypesStore = defineStore(STORES.NODE_TYPES, () => {
 		isConfigurableNode,
 		communityNodesAndActions,
 		communityNodeType,
+		fetchCommunityNodePreviews,
 		getResourceMapperFields,
 		getLocalResourceMapperFields,
 		getNodeParameterActionResult,

--- a/packages/frontend/editor-ui/src/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/views/NodeView.vue
@@ -343,6 +343,8 @@ async function initializeData() {
 
 	try {
 		await Promise.all(loadPromises);
+		//We don't need to await this as community node previews are not critical and needed only in nodes search panel
+		void nodeTypesStore.fetchCommunityNodePreviews();
 	} catch (error) {
 		toast.showError(
 			error,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Load community node previews in the background so the editor doesn’t wait on them. This speeds up initial load and avoids stalls when previews are slow (addresses N8N-616011).

- **Performance**
  - Removed awaiting community preview fetch during node types load.
  - Exposed fetchCommunityNodePreviews from the store and trigger it post-initialization without await.
  - Previews populate later in the node search panel without blocking the UI.

<!-- End of auto-generated description by cubic. -->

