### PR TITLE
n8n-auto-pr (N8N - 616076)

### DIFF
--- a/packages/cli/src/modules/data-store/__tests__/data-store.service.test.ts
+++ b/packages/cli/src/modules/data-store/__tests__/data-store.service.test.ts
@@ -1174,24 +1174,6 @@ describe('dataStore', () => {
 			await expect(result).rejects.toThrow(DataStoreNotFoundError);
 		});
 
-		it('rejects on empty column list', async () => {
-			// ARRANGE
-			const { id: dataStoreId } = await dataStoreService.createDataStore(project1.id, {
-				name: 'dataStore',
-				columns: [],
-			});
-
-			// ACT
-			const result = dataStoreService.insertRows(dataStoreId, project1.id, [{}, {}]);
-
-			// ASSERT
-			await expect(result).rejects.toThrow(
-				new DataStoreValidationError(
-					'No columns found for this data store or data store not found',
-				),
-			);
-		});
-
 		it('fails on type mismatch', async () => {
 			// ARRANGE
 			const { id: dataStoreId } = await dataStoreService.createDataStore(project1.id, {
@@ -1209,6 +1191,29 @@ describe('dataStore', () => {
 			await expect(result).rejects.toThrow(
 				new DataStoreValidationError("value 'true' does not match column type 'number'"),
 			);
+		});
+
+		it('inserts rows into an existing table with no columns', async () => {
+			// ARRANGE
+			const { id: dataStoreId } = await dataStoreService.createDataStore(project1.id, {
+				name: 'dataStore',
+				columns: [],
+			});
+
+			// ACT
+			const rows = [{}, {}, {}];
+			const result = await dataStoreService.insertRows(dataStoreId, project1.id, rows);
+
+			// ASSERT
+			expect(result).toEqual([1, 2, 3]);
+
+			const { count, data } = await dataStoreService.getManyRowsAndCount(
+				dataStoreId,
+				project1.id,
+				{},
+			);
+			expect(count).toEqual(3);
+			expect(data).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
 		});
 	});
 

--- a/packages/cli/src/modules/data-store/data-store.service.ts
+++ b/packages/cli/src/modules/data-store/data-store.service.ts
@@ -210,12 +210,6 @@ export class DataStoreService {
 		includeSystemColumns = false,
 	): Promise<void> {
 		const columns = await this.dataStoreColumnRepository.getColumns(dataStoreId);
-		if (columns.length === 0) {
-			throw new DataStoreValidationError(
-				'No columns found for this data store or data store not found',
-			);
-		}
-
 		this.validateRowsWithColumns(rows, columns, allowPartial, includeSystemColumns);
 	}
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Allow inserting rows into data stores with no defined columns. Empty object inserts now succeed and return generated IDs (rows contain only the system id). Addresses N8N-616076.

<!-- End of auto-generated description by cubic. -->

