### PR TITLE
n8n-auto-pr (N8N - 620559)

### DIFF
--- a/packages/@n8n/task-runner/src/__tests__/task-runner-sentry.test.ts
+++ b/packages/@n8n/task-runner/src/__tests__/task-runner-sentry.test.ts
@@ -136,6 +136,7 @@ describe('TaskRunnerSentry', () => {
 				environment: 'local',
 				serverName: 'test',
 				serverType: 'task_runner',
+				withEventLoopBlockDetection: false,
 			});
 		});
 	});

--- a/packages/@n8n/task-runner/src/task-runner-sentry.ts
+++ b/packages/@n8n/task-runner/src/task-runner-sentry.ts
@@ -26,6 +26,7 @@ export class TaskRunnerSentry {
 			environment,
 			serverName: deploymentName,
 			beforeSendFilter: this.filterOutUserCodeErrors,
+			withEventLoopBlockDetection: false,
 		});
 	}
 

--- a/packages/cli/src/commands/base-command.ts
+++ b/packages/cli/src/commands/base-command.ts
@@ -90,6 +90,7 @@ export abstract class BaseCommand<F = never> {
 			release: `n8n@${N8N_VERSION}`,
 			serverName: deploymentName,
 			releaseDate: N8N_RELEASE_DATE,
+			withEventLoopBlockDetection: true,
 		});
 
 		process.once('SIGTERM', this.onTerminationSignal('SIGTERM'));

--- a/packages/core/src/errors/error-reporter.ts
+++ b/packages/core/src/errors/error-reporter.ts
@@ -15,6 +15,10 @@ type ErrorReporterInitOptions = {
 	environment: string;
 	serverName: string;
 	releaseDate?: Date;
+
+	/** Whether to enable event loop block detection, if Sentry is enabled. */
+	withEventLoopBlockDetection: boolean;
+
 	/**
 	 * Function to allow filtering out errors before they are sent to Sentry.
 	 * Return true if the error should be filtered out.
@@ -83,6 +87,7 @@ export class ErrorReporter {
 		environment,
 		serverName,
 		releaseDate,
+		withEventLoopBlockDetection,
 	}: ErrorReporterInitOptions) {
 		if (inTest) return;
 
@@ -126,7 +131,9 @@ export class ErrorReporter {
 			'ContextLines',
 		];
 
-		const eventLoopBlockIntegration = await this.getEventLoopBlockIntegration();
+		const eventLoopBlockIntegration = withEventLoopBlockDetection
+			? await this.getEventLoopBlockIntegration()
+			: [];
 
 		init({
 			dsn,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add a toggle to control Sentry event loop block detection, disabling it for the Task Runner to reduce noise while keeping it enabled in the CLI. Aligns with N8N-620559.

- **New Features**
  - Added withEventLoopBlockDetection to ErrorReporter to conditionally load the event loop block integration.
  - Enabled in the CLI (BaseCommand) and disabled in the Task Runner; updated the Task Runner test accordingly.

<!-- End of auto-generated description by cubic. -->

