### PR TITLE
n8n-auto-pr (N8N - 625119)

### DIFF
--- a/packages/frontend/editor-ui/src/components/MainSidebar.vue
+++ b/packages/frontend/editor-ui/src/components/MainSidebar.vue
@@ -367,7 +367,7 @@ function onResize() {
 }
 
 async function onResizeEnd() {
-	if (window.outerWidth < 900) {
+	if (window.innerWidth < 900) {
 		uiStore.sidebarMenuCollapsed = true;
 	} else {
 		uiStore.sidebarMenuCollapsed = uiStore.sidebarMenuCollapsedPreference;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes sidebar auto-collapse on resize by using window.innerWidth instead of outerWidth. This bases the check on the viewport width, preventing unexpected collapses/expands and addressing N8N-625119.

<!-- End of auto-generated description by cubic. -->

