### PR TITLE
n8n-auto-pr (N8N - 625538)

### DIFF
--- a/packages/cli/src/modules/data-table/data-table.module.ts
+++ b/packages/cli/src/modules/data-table/data-table.module.ts
@@ -1,11 +1,20 @@
+import { Logger } from '@n8n/backend-common';
 import type { ModuleInterface } from '@n8n/decorators';
 import { BackendModule, OnShutdown } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 import { BaseEntity } from '@n8n/typeorm';
 
+const YELLOW = '\x1b[33m';
+const CLEAR = '\x1b[0m';
+const DATA_TABLE_WARNING_MESSAGE = `[Data Table] The data table module is experimental and subject to change.
+Any tables added before the official release may become inaccessible at any point. Use at your own risk.`;
+
 @BackendModule({ name: 'data-table' })
-export class DataTableModule implements ModuleInterface {
+export class DataStoreModule implements ModuleInterface {
 	async init() {
+		const logger = Container.get(Logger).scoped('data-table');
+		logger.warn(`${YELLOW}${DATA_TABLE_WARNING_MESSAGE}${CLEAR}`);
+
 		await import('./data-store.controller');
 		await import('./data-store-aggregate.controller');
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a startup warning for the experimental Data Table module, shown in yellow, to make clear that early tables may become inaccessible. Also scopes logging to data-table and renames the module class.

- **New Features**
  - Display a yellow warning on init using a scoped logger.

- **Refactors**
  - Rename exported class from DataTableModule to DataStoreModule.

<!-- End of auto-generated description by cubic. -->

