### PR TITLE
n8n-auto-pr (N8N - 625653)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "test:affected": "turbo run test --affected --concurrency=1",
     "test:with:docker": "pnpm --filter=n8n-playwright test:container:standard",
     "test:show:report": "pnpm --filter=n8n-playwright exec playwright show-report",
-    "watch": "turbo run watch",
+    "watch": "turbo run watch --concurrency=30",
     "webhook": "./packages/cli/bin/n8n webhook",
     "worker": "./packages/cli/bin/n8n worker"
   },


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Make watch mode run with Turbo using --concurrency=30 to speed up dev rebuilds across packages. Addresses N8N-625653 by improving the feedback loop with no runtime impact.

<!-- End of auto-generated description by cubic. -->

