### PR TITLE
n8n-auto-pr (N8N - 629028)

### DIFF
--- a/packages/workflow/src/tool-helpers.ts
+++ b/packages/workflow/src/tool-helpers.ts
@@ -6,5 +6,5 @@ import type { INode } from './interfaces';
  */
 export function nodeNameToToolName(nodeOrName: INode | string): string {
 	const name = typeof nodeOrName === 'string' ? nodeOrName : nodeOrName.name;
-	return name.replace(/[\s.?!=+#@&*()[\]{}:;,<>\/\\'"^%$_]+/g, '_');
+	return name.replace(/[^a-zA-Z0-9_-]+/g, '_');
 }

--- a/packages/workflow/test/tool-helpers.test.ts
+++ b/packages/workflow/test/tool-helpers.test.ts
@@ -49,6 +49,18 @@ describe('nodeNameToToolName', () => {
 		expect(nodeNameToToolName(getNodeWithName('Test#+*()[]{}:;,<>/\\\'"%$Node'))).toBe('Test_Node');
 	});
 
+	it('should replace emojis with underscores', () => {
+		expect(nodeNameToToolName(getNodeWithName('Test 😀 Node'))).toBe('Test_Node');
+	});
+
+	it('should replace multiple emojis with underscores', () => {
+		expect(nodeNameToToolName(getNodeWithName('🚀 Test 📊 Node 🎉'))).toBe('_Test_Node_');
+	});
+
+	it('should handle complex emoji sequences', () => {
+		expect(nodeNameToToolName(getNodeWithName('Test 👨‍💻 Node 🔥'))).toBe('Test_Node_');
+	});
+
 	describe('when passed a string directly', () => {
 		it('should replace spaces with underscores', () => {
 			expect(nodeNameToToolName('Test Node')).toBe('Test_Node');


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Sanitized tool names by replacing any non-alphanumeric characters with underscores, ensuring ASCII-safe, consistent tool IDs even when node names include Unicode (e.g., Chinese) or emojis.

- **Bug Fixes**
  - Updated nodeNameToToolName to allow only [A-Za-z0-9_-]; everything else becomes "_".
  - Added tests for emoji and complex emoji sequences.

<!-- End of auto-generated description by cubic. -->

