### PR TITLE
n8n-auto-pr (N8N - 629411)

### DIFF
--- a/packages/frontend/editor-ui/src/constants.ts
+++ b/packages/frontend/editor-ui/src/constants.ts
@@ -984,3 +984,10 @@ export const AI_NODES_PACKAGE_NAME = '@n8n/n8n-nodes-langchain';
 export const AI_ASSISTANT_MAX_CONTENT_LENGTH = 100; // in kilobytes
 
 export const RUN_DATA_DEFAULT_PAGE_SIZE = 25;
+
+/**
+ * Performance Optimizations
+ */
+
+export const LOGS_EXECUTION_DATA_THROTTLE_DURATION = 1000;
+export const CANVAS_EXECUTION_DATA_THROTTLE_DURATION = 500;

--- a/packages/frontend/editor-ui/src/features/logs/composables/useLogsExecutionData.ts
+++ b/packages/frontend/editor-ui/src/features/logs/composables/useLogsExecutionData.ts
@@ -9,7 +9,7 @@ import { parse } from 'flatted';
 import { useToast } from '@/composables/useToast';
 import type { LatestNodeInfo, LogEntry } from '../logs.types';
 import { isChatNode } from '@/utils/aiUtils';
-import { PLACEHOLDER_EMPTY_WORKFLOW_ID } from '@/constants';
+import { LOGS_EXECUTION_DATA_THROTTLE_DURATION, PLACEHOLDER_EMPTY_WORKFLOW_ID } from '@/constants';
 
 export function useLogsExecutionData() {
 	const nodeHelpers = useNodeHelpers();
@@ -62,7 +62,9 @@ export function useLogsExecutionData() {
 		);
 	});
 
-	const updateInterval = computed(() => ((entries.value?.length ?? 0) > 1 ? 1000 : 0));
+	const updateInterval = computed(() =>
+		(entries.value?.length ?? 0) > 1 ? LOGS_EXECUTION_DATA_THROTTLE_DURATION : 0,
+	);
 
 	function resetExecutionData() {
 		execData.value = undefined;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Throttle execution data updates for the canvas and logs to reduce recomputations and smooth the UI during live runs. Adds configurable throttle durations and replaces an expensive computed with a throttled watcher.

- **Refactors**
  - Add LOGS_EXECUTION_DATA_THROTTLE_DURATION (1000 ms) and CANVAS_EXECUTION_DATA_THROTTLE_DURATION (500 ms).
  - Switch nodeExecutionRunDataOutputMapById to ref + throttledWatch in useCanvasMapping; import from @vueuse/core.
  - Use LOGS_EXECUTION_DATA_THROTTLE_DURATION for logs updateInterval instead of a hardcoded 1000 ms.

<!-- End of auto-generated description by cubic. -->

