### PR TITLE
n8n-auto-pr (N8N - 632027)

### DIFF
--- a/packages/cli/src/modules/data-table/__tests__/data-store.service.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/data-store.service.test.ts
@@ -2937,5 +2937,77 @@ describe('dataStore', () => {
 				);
 			});
 		});
+		it('retrieves supports filter by null', async () => {
+			// ARRANGE
+			const { id: dataStoreId } = await dataStoreService.createDataStore(project1.id, {
+				name: 'dataStore',
+				columns: [
+					{ name: 'c1', type: 'string' },
+					{ name: 'c2', type: 'boolean' },
+				],
+			});
+
+			const rows = [
+				{ c1: null, c2: true },
+				{ c1: 'Marco', c2: true },
+				{ c1: null, c2: false },
+				{ c1: 'Polo', c2: false },
+			];
+
+			const ids = await dataStoreService.insertRows(dataStoreId, project1.id, rows);
+			expect(ids).toEqual([1, 2, 3, 4].map((id) => ({ id })));
+
+			// ACT
+			const result = await dataStoreService.getManyRowsAndCount(dataStoreId, project1.id, {
+				filter: {
+					type: 'and',
+					filters: [{ columnName: 'c1', condition: 'eq', value: null }],
+				},
+			});
+
+			// ASSERT
+			expect(result.count).toEqual(2);
+			// Assuming IDs are auto-incremented starting from 1
+			expect(result.data).toMatchObject([
+				{ c1: null, c2: true, id: 1 },
+				{ c1: null, c2: false, id: 3 },
+			]);
+		});
+		it('retrieves supports filter by not null', async () => {
+			// ARRANGE
+			const { id: dataStoreId } = await dataStoreService.createDataStore(project1.id, {
+				name: 'dataStore',
+				columns: [
+					{ name: 'c1', type: 'string' },
+					{ name: 'c2', type: 'boolean' },
+				],
+			});
+
+			const rows = [
+				{ c1: null, c2: true },
+				{ c1: 'Marco', c2: true },
+				{ c1: null, c2: false },
+				{ c1: 'Polo', c2: false },
+			];
+
+			const ids = await dataStoreService.insertRows(dataStoreId, project1.id, rows);
+			expect(ids).toEqual([1, 2, 3, 4].map((id) => ({ id })));
+
+			// ACT
+			const result = await dataStoreService.getManyRowsAndCount(dataStoreId, project1.id, {
+				filter: {
+					type: 'and',
+					filters: [{ columnName: 'c1', condition: 'neq', value: null }],
+				},
+			});
+
+			// ASSERT
+			expect(result.count).toEqual(2);
+			// Assuming IDs are auto-incremented starting from 1
+			expect(result.data).toMatchObject([
+				{ c1: 'Marco', c2: true, id: 2 },
+				{ c1: 'Polo', c2: false, id: 4 },
+			]);
+		});
 	});
 });

--- a/packages/cli/src/modules/data-table/data-store-rows.repository.ts
+++ b/packages/cli/src/modules/data-table/data-store-rows.repository.ts
@@ -51,6 +51,15 @@ function getConditionAndParams(
 	const paramName = `filter_${index}`;
 	const column = `${quoteIdentifier('dataStore', dbType)}.${quoteIdentifier(filter.columnName, dbType)}`;
 
+	if (filter.value === null) {
+		switch (filter.condition) {
+			case 'eq':
+				return [`${column} IS NULL`, {}];
+			case 'neq':
+				return [`${column} IS NOT NULL`, {}];
+		}
+	}
+
 	switch (filter.condition) {
 		case 'eq':
 			return [`${column} = :${paramName}`, { [paramName]: filter.value }];


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes Data Table getManyRows to support filtering on null values with eq and neq. Queries like c1 eq null and c1 neq null now return correct rows and counts. Addresses N8N-632027.

- **Bug Fixes**
  - Map eq null to IS NULL and neq null to IS NOT NULL in SQL generation.
  - Added tests for null and not-null filters to prevent regressions.

<!-- End of auto-generated description by cubic. -->

