### PR TITLE
n8n-auto-pr (N8N - 633494)

### DIFF
--- a/packages/cli/src/modules/data-table/__tests__/data-store-filters.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/data-store-filters.test.ts
@@ -13,7 +13,7 @@ beforeAll(async () => {
 });
 
 beforeEach(async () => {
-	await testDb.truncate(['DataStore', 'DataStoreColumn']);
+	await testDb.truncate(['DataTable', 'DataTableColumn']);
 });
 
 afterAll(async () => {

--- a/packages/frontend/editor-ui/src/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/components/ParameterInput.vue
@@ -1150,7 +1150,7 @@ watch(remoteParameterOptionsLoading, () => {
 
 // Focus input field when changing between fixed and expression
 watch(isModelValueExpression, async (isExpression, wasExpression) => {
-	if (!props.isReadOnly && isExpression !== wasExpression) {
+	if (!props.isReadOnly && isFocused.value && isExpression !== wasExpression) {
 		await nextTick();
 		await setFocus();
 	}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes input focus behavior in ParameterInput when switching to expression mode and corrects table names in test setup. Addresses Linear N8N-633494 by preventing unwanted focus jumps.

- **Bug Fixes**
  - Editor: Only focus the inline expression editor if the field was focused before the switch; added tests for both focused and unfocused cases.
  - CLI tests: Use correct tables in truncate call (DataTable, DataTableColumn).

<!-- End of auto-generated description by cubic. -->

