### PR TITLE
n8n-auto-pr (N8N - 645132)

### DIFF
--- a/packages/frontend/editor-ui/src/stores/roles.store.ts
+++ b/packages/frontend/editor-ui/src/stores/roles.store.ts
@@ -1,4 +1,4 @@
-import type { AllRolesMap } from '@n8n/permissions';
+import { type AllRolesMap, PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
 import { defineStore } from 'pinia';
 import { ref, computed } from 'vue';
 import * as rolesApi from '@n8n/rest-api-client/api/roles';
@@ -20,11 +20,11 @@ export const useRolesStore = defineStore('roles', () => {
 
 	const processedProjectRoles = computed<AllRolesMap['project']>(() =>
 		roles.value.project
-			.filter((role) => projectRoleOrderMap.value.has(role.slug))
+			.filter((role) => role.slug !== PROJECT_OWNER_ROLE_SLUG)
 			.sort(
 				(a, b) =>
-					(projectRoleOrderMap.value.get(a.slug) ?? 0) -
-					(projectRoleOrderMap.value.get(b.slug) ?? 0),
+					(projectRoleOrderMap.value.get(a.slug) ?? Number.MAX_SAFE_INTEGER) -
+					(projectRoleOrderMap.value.get(b.slug) ?? Number.MAX_SAFE_INTEGER),
 			),
 	);
 

--- a/packages/frontend/editor-ui/src/views/ProjectSettings.vue
+++ b/packages/frontend/editor-ui/src/views/ProjectSettings.vue
@@ -79,7 +79,7 @@ const projects = computed(() =>
 const projectRoles = computed(() =>
 	rolesStore.processedProjectRoles.map((role) => ({
 		...role,
-		displayName: projectRoleTranslations.value[role.slug],
+		displayName: projectRoleTranslations.value[role.slug] ?? role.displayName,
 	})),
 );
 const firstLicensedRole = computed(() => projectRoles.value.find((role) => role.licensed)?.slug);


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Show custom project roles in the Project Settings role dropdown and hide the Project Owner role. Adds a translation fallback so roles without translations show their own display names. Addresses N8N-645132.

- **New Features**
  - Exclude Project Owner and include custom roles in the dropdown; unknown roles are sorted last.
  - Fallback to role.displayName when a translation is missing.
  - Tests cover the dropdown rendering and options (Admin, Editor, Custom).

<!-- End of auto-generated description by cubic. -->

