### PR TITLE
n8n-auto-pr (N8N - 645777)

### DIFF
--- a/packages/nodes-base/nodes/DataTable/common/constants.ts
+++ b/packages/nodes-base/nodes/DataTable/common/constants.ts
@@ -5,8 +5,13 @@ export const ALL_FILTERS = 'allFilters';
 
 export type FilterType = typeof ANY_FILTER | typeof ALL_FILTERS;
 
-export type FieldEntry = {
-	keyName: string;
-	condition: 'eq' | 'neq' | 'like' | 'ilike' | 'gt' | 'gte' | 'lt' | 'lte';
-	keyValue: DataStoreColumnJsType;
-};
+export type FieldEntry =
+	| {
+			keyName: string;
+			condition: 'isEmpty' | 'isNotEmpty';
+	  }
+	| {
+			keyName: string;
+			condition: 'eq' | 'neq' | 'like' | 'ilike' | 'gt' | 'gte' | 'lt' | 'lte';
+			keyValue: DataStoreColumnJsType;
+	  };

--- a/packages/nodes-base/nodes/DataTable/common/methods.ts
+++ b/packages/nodes-base/nodes/DataTable/common/methods.ts
@@ -75,6 +75,8 @@ export async function getConditionsForColumn(this: ILoadOptionsFunctions) {
 	const baseConditions: INodePropertyOptions[] = [
 		{ name: 'Equals', value: 'eq' },
 		{ name: 'Not Equals', value: 'neq' },
+		{ name: 'Is Empty', value: 'isEmpty' },
+		{ name: 'Is Not Empty', value: 'isNotEmpty' },
 	];
 
 	const comparableConditions: INodePropertyOptions[] = [

--- a/packages/nodes-base/nodes/DataTable/common/selectMany.ts
+++ b/packages/nodes-base/nodes/DataTable/common/selectMany.ts
@@ -78,6 +78,11 @@ export function getSelectFields(
 							name: 'keyValue',
 							type: 'string',
 							default: '',
+							displayOptions: {
+								hide: {
+									condition: ['isEmpty', 'isNotEmpty'],
+								},
+							},
 						},
 					],
 				},
@@ -89,13 +94,14 @@ export function getSelectFields(
 
 export function getSelectFilter(ctx: IExecuteFunctions, index: number) {
 	const fields = ctx.getNodeParameter('filters.conditions', index, []);
-	const matchType = ctx.getNodeParameter('matchType', index, []);
+	const matchType = ctx.getNodeParameter('matchType', index, 'anyFilter');
+	const node = ctx.getNode();
 
 	if (!isMatchType(matchType)) {
-		throw new NodeOperationError(ctx.getNode(), 'unexpected match type');
+		throw new NodeOperationError(node, 'unexpected match type');
 	}
 	if (!isFieldArray(fields)) {
-		throw new NodeOperationError(ctx.getNode(), 'unexpected fields input');
+		throw new NodeOperationError(node, 'unexpected fields input');
 	}
 
 	return buildGetManyFilter(fields, matchType);

--- a/packages/nodes-base/nodes/DataTable/common/utils.ts
+++ b/packages/nodes-base/nodes/DataTable/common/utils.ts
@@ -72,7 +72,7 @@ export async function getDataTableAggregateProxy(
 
 export function isFieldEntry(obj: unknown): obj is FieldEntry {
 	if (obj === null || typeof obj !== 'object') return false;
-	return 'keyName' in obj && 'condition' in obj && 'keyValue' in obj;
+	return 'keyName' in obj && 'condition' in obj; // keyValue is optional
 }
 
 export function isMatchType(obj: unknown): obj is FilterType {
@@ -83,11 +83,28 @@ export function buildGetManyFilter(
 	fieldEntries: FieldEntry[],
 	matchType: FilterType,
 ): ListDataStoreContentFilter {
-	const filters = fieldEntries.map((x) => ({
-		columnName: x.keyName,
-		condition: x.condition,
-		value: x.keyValue,
-	}));
+	const filters = fieldEntries.map((x) => {
+		switch (x.condition) {
+			case 'isEmpty':
+				return {
+					columnName: x.keyName,
+					condition: 'eq' as const,
+					value: null,
+				};
+			case 'isNotEmpty':
+				return {
+					columnName: x.keyName,
+					condition: 'neq' as const,
+					value: null,
+				};
+			default:
+				return {
+					columnName: x.keyName,
+					condition: x.condition,
+					value: x.keyValue,
+				};
+		}
+	});
 	return { type: matchType === 'allFilters' ? 'and' : 'or', filters };
 }
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add “Is Empty” and “Is Not Empty” filters to the Data Table node so users can filter rows without entering a value. Addresses N8N-645777 by mapping these to consistent API filters.

- **New Features**
  - Added “Is Empty” and “Is Not Empty” to the condition dropdown and hide the value input when selected.
  - Translate these conditions to eq/null and neq/null in buildGetManyFilter for API calls.
  - Updated FieldEntry typing and guards to support value-less conditions.
  - Added unit tests for translation, mixed conditions, and no-regression on existing operators.

- **Bug Fixes**
  - Default matchType to anyFilter when missing and improve error context with the node reference.

<!-- End of auto-generated description by cubic. -->

