### PR TITLE
n8n-auto-pr (N8N - 677045)

### DIFF
--- a/packages/frontend/editor-ui/src/components/NodeDetailsView.vue
+++ b/packages/frontend/editor-ui/src/components/NodeDetailsView.vue
@@ -891,6 +891,9 @@ $main-panel-width: 360px;
 	position: fixed;
 	top: var(--spacing-xs);
 	left: var(--spacing-l);
+	display: flex;
+	align-items: center;
+	gap: var(--spacing-3xs);
 
 	span {
 		color: var(--color-ndv-back-font);
@@ -898,10 +901,6 @@ $main-panel-width: 360px;
 
 	&:hover {
 		cursor: pointer;
-	}
-
-	> * {
-		margin-right: var(--spacing-3xs);
 	}
 }
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fix alignment of the “Back to canvas” icon and label in Node Details View. Uses a flex layout with vertical centering and gap-based spacing, replacing manual margins for consistent spacing.

<!-- End of auto-generated description by cubic. -->

