### PR TITLE
n8n-auto-pr (N8N - 677118)

### DIFF
--- a/packages/frontend/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/Canvas.vue
@@ -35,7 +35,7 @@ import type {
 	ViewportTransform,
 	XYPosition,
 } from '@vue-flow/core';
-import { MarkerType, PanelPosition, useVueFlow, VueFlow } from '@vue-flow/core';
+import { getRectOfNodes, MarkerType, PanelPosition, useVueFlow, VueFlow } from '@vue-flow/core';
 import { MiniMap } from '@vue-flow/minimap';
 import { onKeyDown, onKeyUp, useThrottleFn } from '@vueuse/core';
 import { NodeConnectionTypes } from 'n8n-workflow';
@@ -149,6 +149,7 @@ const {
 	removeSelectedNodes,
 	viewportRef,
 	fitView,
+	fitBounds,
 	zoomIn,
 	zoomOut,
 	zoomTo,
@@ -635,6 +636,10 @@ function onClickPane(event: MouseEvent) {
 	emit('click:pane', getProjectedPosition(event));
 }
 
+async function onFitBounds(nodes: GraphNode[]) {
+	await fitBounds(getRectOfNodes(nodes), { padding: 2 });
+}
+
 async function onFitView() {
 	await fitView({ maxZoom: defaultZoom, padding: 0.2 });
 }
@@ -768,8 +773,10 @@ async function onTidyUp(payload: CanvasEventBusEvents['tidyUp']) {
 
 	emit('tidy-up', { result, target, source: payload.source }, { trackEvents: payload.trackEvents });
 
-	if (!applyOnSelection) {
-		await nextTick();
+	await nextTick();
+	if (applyOnSelection) {
+		await onFitBounds(selectedNodes.value);
+	} else {
 		await onFitView();
 	}
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes canvas focus after Tidy up. When Tidy up runs on a selection, the viewport now fits the selected nodes; otherwise it fits the whole canvas. Addresses N8N-677118.

- **Bug Fixes**
  - Added getRectOfNodes + fitBounds to focus on selected nodes (with small padding).
  - Preserved existing behavior for non-selection via fitView.
  - Applied updates after layout with nextTick to avoid flicker.

<!-- End of auto-generated description by cubic. -->

