### PR TITLE
n8n-auto-pr (N8N - 687386)

### DIFF
--- a/packages/@n8n/config/src/configs/runners.config.ts
+++ b/packages/@n8n/config/src/configs/runners.config.ts
@@ -69,4 +69,19 @@ export class TaskRunnersConfig {
 	 */
 	@Env('N8N_RUNNERS_INSECURE_MODE')
 	insecureMode: boolean = false;
+
+	/**
+	 * Whether to enable the Python task runner (beta). This will replace the
+	 * Pyodide option with the native Python option in the Code node. Expects a
+	 * Python task runner to be available, typically in a sidecar container.
+	 *
+	 * Actions required:
+	 * - Any Code node set to the legacy `python` parameter will need to be manually
+	 * updated to use the new `pythonNative` parameter.
+	 * - Any Code node script relying on Pyodide syntax is likely to need to be manually
+	 * adjusted to account for breaking changes:
+	 * https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.code/#python-native-beta
+	 */
+	@Env('N8N_NATIVE_PYTHON_RUNNER')
+	isNativePythonRunnerEnabled: boolean = false;
 }

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -260,6 +260,7 @@ describe('GlobalConfig', () => {
 			taskTimeout: 300,
 			heartbeatInterval: 30,
 			insecureMode: false,
+			isNativePythonRunnerEnabled: false,
 		},
 		sentry: {
 			backendDsn: '',

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -132,7 +132,8 @@ export class FrontendService {
 			versionCli: N8N_VERSION,
 			concurrency: this.globalConfig.executions.concurrency.productionLimit,
 			isNativePythonRunnerEnabled:
-				this.globalConfig.taskRunners.enabled && process.env.N8N_NATIVE_PYTHON_RUNNER === 'true',
+				this.globalConfig.taskRunners.enabled &&
+				this.globalConfig.taskRunners.isNativePythonRunnerEnabled,
 			authCookie: {
 				secure: this.globalConfig.auth.cookie.secure,
 			},

--- a/packages/cli/src/task-runners/task-runner-module.ts
+++ b/packages/cli/src/task-runners/task-runner-module.ts
@@ -118,7 +118,7 @@ export class TaskRunnerModule {
 
 		await this.jsRunnerProcess.start();
 
-		if (process.env.N8N_NATIVE_PYTHON_RUNNER === 'true') {
+		if (this.runnerConfig.isNativePythonRunnerEnabled) {
 			const { PyTaskRunnerProcess } = await import('@/task-runners/task-runner-process-py');
 			this.pyRunnerProcess = Container.get(PyTaskRunnerProcess);
 			this.pyRunnerProcessRestartLoopDetector = new TaskRunnerProcessRestartLoopDetector(

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/composables/useActionsGeneration.ts
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/composables/useActionsGeneration.ts
@@ -111,9 +111,9 @@ function operationsCategory(nodeTypeDescription: INodeTypeDescription): ActionTy
 				nodeTypeDescription,
 			);
 			if (customParsedItems) {
-				// temporary filter until native Python runner is GA
+				// temporary until native Python runner is GA
 				return useSettingsStore().isNativePythonRunnerEnabled
-					? customParsedItems
+					? customParsedItems.filter((item) => item.actionKey !== 'language_python')
 					: customParsedItems.filter((item) => item.actionKey !== 'language_pythonNative');
 			}
 		}

--- a/packages/frontend/editor-ui/src/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/components/ParameterInput.vue
@@ -241,9 +241,13 @@ const parameterOptions = computed(() => {
 	const options = hasRemoteMethod.value ? remoteParameterOptions.value : props.parameter.options;
 	const safeOptions = (options ?? []).filter(isValidParameterOption);
 
-	// temporary filter until native Python runner is GA
-	if (props.parameter.name === 'language' && !settingsStore.isNativePythonRunnerEnabled) {
-		return safeOptions.filter((o) => o.value !== 'pythonNative');
+	// temporary until native Python runner is GA
+	if (props.parameter.name === 'language') {
+		if (settingsStore.isNativePythonRunnerEnabled) {
+			return safeOptions.filter((o) => o.value !== 'python');
+		} else {
+			return safeOptions.filter((o) => o.value !== 'pythonNative');
+		}
 	}
 
 	return safeOptions;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add a config flag to enable the native Python task runner (beta) and route Code node Python execution to it; the UI hides the Pyodide option when enabled. This aligns with Linear N8N-687386 and replaces ad-hoc env checks with a typed config.

- **New Features**
  - New TaskRunnersConfig.isNativePythonRunnerEnabled (env: N8N_NATIVE_PYTHON_RUNNER) controls starting the Python runner and frontend visibility.
  - Code node: when enabled, both “python” and “pythonNative” execute on the native Python runner; throws if “pythonNative” is selected without a Python runner.
  - Frontend language options toggle: when enabled, “pythonNative” is shown and “python” is hidden; when disabled, the reverse.

- **Migration**
  - Ensure task runners are enabled and deploy a Python runner sidecar.
  - Set N8N_NATIVE_PYTHON_RUNNER=true to switch UI and execution to native Python.
  - Review scripts that relied on Pyodide and update for native Python compatibility: https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.code/#python-native-beta
  - Existing nodes set to “python” will run on the native runner when enabled; update them to “pythonNative” to match the UI.

<!-- End of auto-generated description by cubic. -->

