### PR TITLE
n8n-auto-pr (N8N - 689644)

### DIFF
--- a/packages/frontend/editor-ui/src/features/logs/components/ChatMessagesPanel.vue
+++ b/packages/frontend/editor-ui/src/features/logs/components/ChatMessagesPanel.vue
@@ -267,7 +267,7 @@ async function copySessionId() {
 	--chat--message--user--border: none;
 	--chat--input--padding: var(--spacing-xs);
 	--chat--color-typing: var(--color-text-light);
-	--chat--textarea--max-height: calc(var(--panel-height) * 0.3);
+	--chat--textarea--max-height: calc(var(--logs-panel-height) * 0.3);
 	--chat--message--pre--background: var(--color-foreground-light);
 	--chat--textarea--height: calc(
 		var(--chat--input--padding) * 2 + var(--chat--input--font-size) *

--- a/packages/frontend/editor-ui/src/features/logs/composables/useLogsPanelLayout.ts
+++ b/packages/frontend/editor-ui/src/features/logs/composables/useLogsPanelLayout.ts
@@ -11,6 +11,9 @@ import {
 	LOCAL_STORAGE_PANEL_WIDTH,
 } from '@/features/logs/logs.constants';
 
+const INITIAL_POPUP_HEIGHT = 400;
+const COLLAPSED_PANEL_HEIGHT = 32;
+
 export function useLogsPanelLayout(
 	workflowName: ComputedRef<string>,
 	popOutContainer: Readonly<ShallowRef<HTMLElement | null>>,
@@ -61,7 +64,7 @@ export function useLogsPanelLayout(
 		popOutWindow: popOutWindow,
 	} = usePopOutWindow({
 		title: popOutWindowTitle,
-		initialHeight: 400,
+		initialHeight: INITIAL_POPUP_HEIGHT,
 		initialWidth: window.document.body.offsetWidth * 0.8,
 		container: popOutContainer,
 		content: popOutContent,
@@ -109,15 +112,25 @@ export function useLogsPanelLayout(
 	}
 
 	watch(
-		[() => logsStore.state, resizer.size],
+		[() => logsStore.state, resizer.size, isPoppedOut],
 		([state, height]) => {
-			logsStore.setHeight(
+			const updatedHeight =
 				state === LOGS_PANEL_STATE.FLOATING
 					? 0
 					: state === LOGS_PANEL_STATE.ATTACHED
 						? height
-						: 32 /* collapsed panel height */,
-			);
+						: COLLAPSED_PANEL_HEIGHT;
+
+			if (state === LOGS_PANEL_STATE.FLOATING) {
+				popOutWindow?.value?.document.documentElement.style.setProperty(
+					'--logs-panel-height',
+					'100vh',
+				);
+			} else {
+				document.documentElement.style.setProperty('--logs-panel-height', `${updatedHeight}px`);
+			}
+
+			logsStore.setHeight(updatedHeight);
 		},
 		{ immediate: true },
 	);


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes chat input resizing in the Logs panel and pop-out so long messages don’t overflow. The textarea now scales with the panel height across all states (N8N-689644).

- **Bug Fixes**
  - Use --logs-panel-height to cap the chat textarea at 30% of the panel height (replaces --panel-height).
  - Keep --logs-panel-height in sync with layout: attached = resizer height, collapsed = 32px, popped-out = 100vh in the pop-out window (adds height constants).

<!-- End of auto-generated description by cubic. -->

