### PR TITLE
n8n-auto-pr (N8N - 689728)

### DIFF
--- a/packages/@n8n/db/src/repositories/__tests__/execution.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/execution.repository.test.ts
@@ -1,31 +1,14 @@
-import { Container, type Constructable } from '@n8n/di';
-import { DataSource, EntityManager, In, LessThan, type EntityMetadata } from '@n8n/typeorm';
-import { mock } from 'jest-mock-extended';
-import type { Class } from 'n8n-core';
-import type { DeepPartial } from 'ts-essentials';
+import { Container } from '@n8n/di';
+import { In, LessThan, And, Not } from '@n8n/typeorm';
 
 import { ExecutionEntity } from '../../entities';
+import { mockEntityManager } from '../../utils/test-utils/mock-entity-manager';
 import { ExecutionRepository } from '../execution.repository';
 
-const mockInstance = <T>(
-	serviceClass: Constructable<T>,
-	data: DeepPartial<T> | undefined = undefined,
-) => {
-	const instance = mock<T>(data);
-	Container.set(serviceClass, instance);
-	return instance;
-};
-
-const mockEntityManager = (entityClass: Class) => {
-	const entityManager = mockInstance(EntityManager);
-	const dataSource = mockInstance(DataSource, {
-		manager: entityManager,
-		getMetadata: () => mock<EntityMetadata>({ target: entityClass }),
-	});
-	Object.assign(entityManager, { connection: dataSource });
-	return entityManager;
-};
-
+/**
+ * TODO: add tests for all the other methods
+ * TODO: getExecutionsForPublicApi -> add test cases for the `includeData` toggle
+ */
 describe('ExecutionRepository', () => {
 	const entityManager = mockEntityManager(ExecutionEntity);
 	const executionRepository = Container.get(ExecutionRepository);
@@ -35,10 +18,29 @@ describe('ExecutionRepository', () => {
 	});
 
 	describe('getExecutionsForPublicApi', () => {
-		test('should get executions matching the filter parameters', async () => {
-			const limit = 10;
+		const defaultLimit = 10;
+		const defaultQuery = {
+			select: [
+				'id',
+				'mode',
+				'retryOf',
+				'retrySuccessId',
+				'startedAt',
+				'stoppedAt',
+				'workflowId',
+				'waitTill',
+				'finished',
+				'status',
+			],
+			where: {},
+			order: { id: 'DESC' },
+			take: defaultLimit,
+			relations: ['executionData'],
+		};
+
+		test('should get executions matching all filter parameters', async () => {
 			const params = {
-				limit: 10,
+				limit: defaultLimit,
 				lastId: '3',
 				workflowIds: ['3', '4'],
 			};
@@ -48,28 +50,67 @@ describe('ExecutionRepository', () => {
 			const result = await executionRepository.getExecutionsForPublicApi(params);
 
 			expect(entityManager.find).toHaveBeenCalledWith(ExecutionEntity, {
-				select: [
-					'id',
-					'mode',
-					'retryOf',
-					'retrySuccessId',
-					'startedAt',
-					'stoppedAt',
-					'workflowId',
-					'waitTill',
-					'finished',
-					'status',
-				],
+				...defaultQuery,
 				where: {
 					id: LessThan(params.lastId),
 					workflowId: In(params.workflowIds),
 				},
-				order: { id: 'DESC' },
-				take: limit,
-				relations: ['executionData'],
 			});
 			expect(result.length).toBe(mockEntities.length);
 			expect(result[0].id).toEqual(mockEntities[0].id);
+		});
+
+		test('should get executions matching the workflowIds filter', async () => {
+			const params = {
+				limit: 10,
+				workflowIds: ['3', '4'],
+			};
+			const mockEntities = [{ id: '1' }, { id: '2' }];
+
+			entityManager.find.mockResolvedValueOnce(mockEntities);
+			const result = await executionRepository.getExecutionsForPublicApi(params);
+
+			expect(entityManager.find).toHaveBeenCalledWith(ExecutionEntity, {
+				...defaultQuery,
+				where: {
+					workflowId: In(params.workflowIds),
+				},
+			});
+			expect(result.length).toBe(mockEntities.length);
+			expect(result[0].id).toEqual(mockEntities[0].id);
+		});
+
+		describe('with id filters', () => {
+			test.each`
+				lastId       | excludedExecutionsIds | expectedIdCondition
+				${'5'}       | ${['2', '3']}         | ${And(LessThan('5'), Not(In(['2', '3'])))}
+				${'5'}       | ${[]}                 | ${LessThan('5')}
+				${'5'}       | ${undefined}          | ${LessThan('5')}
+				${undefined} | ${['2', '3']}         | ${Not(In(['2', '3']))}
+				${undefined} | ${[]}                 | ${undefined}
+				${undefined} | ${undefined}          | ${undefined}
+			`(
+				'should find with id less than "$lastId" and not in "$excludedExecutionsIds"',
+				async ({ lastId, excludedExecutionsIds, expectedIdCondition }) => {
+					const params = {
+						limit: defaultLimit,
+						...(lastId ? { lastId } : {}),
+						...(excludedExecutionsIds ? { excludedExecutionsIds } : {}),
+					};
+					const mockEntities = [{ id: '1' }, { id: '2' }];
+					entityManager.find.mockResolvedValueOnce(mockEntities);
+					const result = await executionRepository.getExecutionsForPublicApi(params);
+
+					expect(entityManager.find).toHaveBeenCalledWith(ExecutionEntity, {
+						...defaultQuery,
+						where: {
+							...(expectedIdCondition ? { id: expectedIdCondition } : {}),
+						},
+					});
+					expect(result.length).toBe(mockEntities.length);
+					expect(result[0].id).toEqual(mockEntities[0].id);
+				},
+			);
 		});
 
 		describe('with status filter', () => {
@@ -77,35 +118,21 @@ describe('ExecutionRepository', () => {
 				filterStatus  | entityStatus
 				${'canceled'} | ${'canceled'}
 				${'error'}    | ${In(['error', 'crashed'])}
+				${'running'}  | ${'running'}
 				${'success'}  | ${'success'}
 				${'waiting'}  | ${'waiting'}
 			`('should find all "$filterStatus" executions', async ({ filterStatus, entityStatus }) => {
-				const limit = 10;
 				const mockEntities = [{ id: '1' }, { id: '2' }];
 
 				entityManager.find.mockResolvedValueOnce(mockEntities);
 				const result = await executionRepository.getExecutionsForPublicApi({
-					limit,
+					limit: defaultLimit,
 					status: filterStatus,
 				});
 
 				expect(entityManager.find).toHaveBeenCalledWith(ExecutionEntity, {
-					select: [
-						'id',
-						'mode',
-						'retryOf',
-						'retrySuccessId',
-						'startedAt',
-						'stoppedAt',
-						'workflowId',
-						'waitTill',
-						'finished',
-						'status',
-					],
+					...defaultQuery,
 					where: { status: entityStatus },
-					order: { id: 'DESC' },
-					take: limit,
-					relations: ['executionData'],
 				});
 				expect(result.length).toBe(mockEntities.length);
 				expect(result[0].id).toEqual(mockEntities[0].id);
@@ -115,37 +142,21 @@ describe('ExecutionRepository', () => {
 				filterStatus
 				${'crashed'}
 				${'new'}
-				${'running'}
 				${'unknown'}
 			`(
 				'should find all executions and ignore status filter "$filterStatus"',
 				async ({ filterStatus }) => {
-					const limit = 10;
 					const mockEntities = [{ id: '1' }, { id: '2' }];
 
 					entityManager.find.mockResolvedValueOnce(mockEntities);
 					const result = await executionRepository.getExecutionsForPublicApi({
-						limit,
+						limit: defaultLimit,
 						status: filterStatus,
 					});
 
 					expect(entityManager.find).toHaveBeenCalledWith(ExecutionEntity, {
-						select: [
-							'id',
-							'mode',
-							'retryOf',
-							'retrySuccessId',
-							'startedAt',
-							'stoppedAt',
-							'workflowId',
-							'waitTill',
-							'finished',
-							'status',
-						],
+						...defaultQuery,
 						where: {},
-						order: { id: 'DESC' },
-						take: limit,
-						relations: ['executionData'],
 					});
 					expect(result.length).toBe(mockEntities.length);
 					expect(result[0].id).toEqual(mockEntities[0].id);
@@ -155,8 +166,7 @@ describe('ExecutionRepository', () => {
 	});
 
 	describe('getExecutionsCountForPublicApi', () => {
-		test('should get executions matching the filter parameters', async () => {
-			const limit = 10;
+		test('should get executions matching all filter parameters', async () => {
 			const mockCount = 20;
 			const params = {
 				limit: 10,
@@ -172,9 +182,60 @@ describe('ExecutionRepository', () => {
 					id: LessThan(params.lastId),
 					workflowId: In(params.workflowIds),
 				},
-				take: limit,
+				take: params.limit,
 			});
 			expect(result).toBe(mockCount);
+		});
+
+		test('should get executions matching the workflowIds filter', async () => {
+			const mockCount = 12;
+			const params = {
+				limit: 10,
+				workflowIds: ['7', '8'],
+			};
+
+			entityManager.count.mockResolvedValueOnce(mockCount);
+			const result = await executionRepository.getExecutionsCountForPublicApi(params);
+
+			expect(entityManager.count).toHaveBeenCalledWith(ExecutionEntity, {
+				where: {
+					workflowId: In(params.workflowIds),
+				},
+				take: params.limit,
+			});
+			expect(result).toBe(mockCount);
+		});
+
+		describe('with id filters', () => {
+			test.each`
+				lastId       | excludedExecutionsIds | expectedIdCondition
+				${'5'}       | ${['2', '3']}         | ${And(LessThan('5'), Not(In(['2', '3'])))}
+				${'5'}       | ${[]}                 | ${LessThan('5')}
+				${'5'}       | ${undefined}          | ${LessThan('5')}
+				${undefined} | ${['2', '3']}         | ${Not(In(['2', '3']))}
+				${undefined} | ${[]}                 | ${undefined}
+				${undefined} | ${undefined}          | ${undefined}
+			`(
+				'should find with id less than "$lastId" and not in "$excludedExecutionsIds"',
+				async ({ lastId, excludedExecutionsIds, expectedIdCondition }) => {
+					const mockCount = 15;
+					const params = {
+						limit: 10,
+						...(lastId ? { lastId } : {}),
+						...(excludedExecutionsIds ? { excludedExecutionsIds } : {}),
+					};
+					entityManager.count.mockResolvedValueOnce(mockCount);
+					const result = await executionRepository.getExecutionsCountForPublicApi(params);
+
+					expect(entityManager.count).toHaveBeenCalledWith(ExecutionEntity, {
+						where: {
+							...(expectedIdCondition ? { id: expectedIdCondition } : {}),
+						},
+						take: params.limit,
+					});
+					expect(result).toBe(mockCount);
+				},
+			);
 		});
 
 		describe('with status filter', () => {
@@ -182,6 +243,7 @@ describe('ExecutionRepository', () => {
 				filterStatus  | entityStatus
 				${'canceled'} | ${'canceled'}
 				${'error'}    | ${In(['error', 'crashed'])}
+				${'running'}  | ${'running'}
 				${'success'}  | ${'success'}
 				${'waiting'}  | ${'waiting'}
 			`('should retrieve all $filterStatus executions', async ({ filterStatus, entityStatus }) => {
@@ -206,7 +268,6 @@ describe('ExecutionRepository', () => {
 				filterStatus
 				${'crashed'}
 				${'new'}
-				${'running'}
 				${'unknown'}
 			`(
 				'should find all executions and ignore status filter "$filterStatus"',

--- a/packages/@n8n/db/src/utils/test-utils/mock-entity-manager.ts
+++ b/packages/@n8n/db/src/utils/test-utils/mock-entity-manager.ts
@@ -1,0 +1,15 @@
+import { DataSource, EntityManager, type EntityMetadata } from '@n8n/typeorm';
+import { mock } from 'jest-mock-extended';
+import type { Class } from 'n8n-core';
+
+import { mockInstance } from './mock-instance';
+
+export const mockEntityManager = (entityClass: Class) => {
+	const entityManager = mockInstance(EntityManager);
+	const dataSource = mockInstance(DataSource, {
+		manager: entityManager,
+		getMetadata: () => mock<EntityMetadata>({ target: entityClass }),
+	});
+	Object.assign(entityManager, { connection: dataSource });
+	return entityManager;
+};

--- a/packages/@n8n/db/src/utils/test-utils/mock-instance.ts
+++ b/packages/@n8n/db/src/utils/test-utils/mock-instance.ts
@@ -1,0 +1,12 @@
+import { Container, type Constructable } from '@n8n/di';
+import { mock } from 'jest-mock-extended';
+import type { DeepPartial } from 'ts-essentials';
+
+export const mockInstance = <T>(
+	serviceClass: Constructable<T>,
+	data: DeepPartial<T> | undefined = undefined,
+) => {
+	const instance = mock<T>(data);
+	Container.set(serviceClass, instance);
+	return instance;
+};

--- a/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
@@ -114,19 +114,23 @@ export = {
 				return res.status(200).json({ data: [], nextCursor: null });
 			}
 
-			// get running workflows so we exclude them from the result
+			// get running executions so we exclude them from the result
 			const runningExecutionsIds = Container.get(ActiveExecutions)
 				.getActiveExecutions()
 				.map(({ id }) => id);
 
-			const filters = {
-				status,
-				limit,
-				lastId,
-				includeData,
-				workflowIds: workflowId ? [workflowId] : sharedWorkflowsIds,
-				excludedExecutionsIds: runningExecutionsIds,
-			};
+			const filters: Parameters<typeof ExecutionRepository.prototype.getExecutionsForPublicApi>[0] =
+				{
+					status,
+					limit,
+					lastId,
+					includeData,
+					workflowIds: workflowId ? [workflowId] : sharedWorkflowsIds,
+
+					// for backward compatibility `running` executions are always excluded
+					// unless the user explicitly filters by `running` status
+					excludedExecutionsIds: status !== 'running' ? runningExecutionsIds : undefined,
+				};
 
 			const executions =
 				await Container.get(ExecutionRepository).getExecutionsForPublicApi(filters);

--- a/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.yml
+++ b/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.yml
@@ -13,7 +13,7 @@ get:
       required: false
       schema:
         type: string
-        enum: ['canceled', 'error', 'success', 'waiting']
+        enum: ['canceled', 'error', 'running', 'success', 'waiting']
     - name: workflowId
       in: query
       description: Workflow to filter the executions by.

--- a/packages/cli/src/public-api/v1/handlers/executions/spec/schemas/execution.yml
+++ b/packages/cli/src/public-api/v1/handlers/executions/spec/schemas/execution.yml
@@ -24,6 +24,8 @@ properties:
   stoppedAt:
     type: string
     format: date-time
+    nullable: true
+    description: The time at which the execution stopped. Will only be null for executions that still have the status 'running'.
   workflowId:
     type: number
     example: '1000'

--- a/packages/cli/test/integration/public-api/executions.test.ts
+++ b/packages/cli/test/integration/public-api/executions.test.ts
@@ -402,12 +402,13 @@ describe('GET /executions', () => {
 	});
 
 	describe('with query status', () => {
-		type AllowedQueryStatus = 'success' | 'error' | 'canceled' | 'waiting';
+		type AllowedQueryStatus = 'canceled' | 'error' | 'running' | 'success' | 'waiting';
 		test.each`
 			queryStatus   | entityStatus
 			${'canceled'} | ${'canceled'}
 			${'error'}    | ${'error'}
 			${'error'}    | ${'crashed'}
+			${'running'}  | ${'running'}
 			${'success'}  | ${'success'}
 			${'waiting'}  | ${'waiting'}
 		`(
@@ -419,6 +420,10 @@ describe('GET /executions', () => {
 				const workflow = await createWorkflow({}, owner);
 
 				await createdExecutionWithStatus(workflow, queryStatus === 'success' ? 'error' : 'success');
+				if (queryStatus !== 'running') {
+					// ensure there is a running execution that gets excluded unless filtering by `running`
+					await createdExecutionWithStatus(workflow, 'running');
+				}
 
 				const expectedExecution = await createdExecutionWithStatus(workflow, entityStatus);
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds support for status=running in the Public API GET /executions and keeps backward compatibility by excluding running executions unless you explicitly filter for them. Also simplifies repository filters and expands tests.

- New Features
  - GET /executions accepts status=running; OpenAPI enum updated.
  - Running executions are excluded by default unless status=running is set.
  - stoppedAt is now nullable with a note explaining it’s null while status is running.

- Refactors
  - Replaced Raw conditions with And/Not for id and exclusion filters; unified condition builders for consistency.
  - Updated count/query paths to share the same filtering logic.
  - Added unit/integration tests and lightweight test utils (mock-entity-manager, mock-instance).

<!-- End of auto-generated description by cubic. -->

