### PR TITLE
n8n-auto-pr (N8N - 693510)

### DIFF
--- a/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
@@ -44,6 +44,7 @@ import {
 	NodeOperationError,
 	Workflow,
 } from 'n8n-workflow';
+import assert from 'node:assert';
 
 import * as Helpers from '@test/helpers';
 import { legacyWorkflowExecuteTests, v1WorkflowExecuteTests } from '@test/helpers/constants';
@@ -2483,6 +2484,89 @@ describe('WorkflowExecute', () => {
 					},
 				},
 			]);
+		});
+	});
+
+	describe('Cancellation', () => {
+		test('should update only running task statuses to cancelled when workflow is cancelled', () => {
+			// Arrange - create a workflow with some nodes
+			const startNode = createNodeData({ name: 'Start' });
+			const processingNode = createNodeData({ name: 'Processing' });
+			const completedNode = createNodeData({ name: 'Completed' });
+
+			const workflow = new Workflow({
+				id: 'test-workflow',
+				nodes: [startNode, processingNode, completedNode],
+				connections: {},
+				active: false,
+				nodeTypes,
+			});
+
+			const waitPromise = createDeferredPromise<IRun>();
+			const additionalData = Helpers.WorkflowExecuteAdditionalData(waitPromise);
+			const workflowExecute = new WorkflowExecute(additionalData, 'manual');
+
+			// Create run execution data with tasks in various statuses
+			const runExecutionData: IRunExecutionData = {
+				startData: { startNodes: [{ name: 'Start', sourceData: null }] },
+				resultData: {
+					runData: {
+						Start: [toITaskData([{ data: { test: 'data' } }], { executionStatus: 'success' })],
+						Processing: [toITaskData([{ data: { test: 'data' } }], { executionStatus: 'running' })],
+						Completed: [
+							toITaskData([{ data: { test: 'data1' } }], { executionStatus: 'error' }),
+							toITaskData([{ data: { test: 'data2' } }], { executionStatus: 'running' }),
+							toITaskData([{ data: { test: 'data3' } }], { executionStatus: 'waiting' }),
+						],
+					},
+					lastNodeExecuted: 'Processing',
+				},
+				executionData: mock<IRunExecutionData['executionData']>({
+					nodeExecutionStack: [],
+					metadata: {},
+				}),
+			};
+
+			// Set the run execution data on the workflow execute instance
+			// @ts-expect-error private data
+			workflowExecute.runExecutionData = runExecutionData;
+
+			assert(additionalData.hooks);
+			const runHook = jest.fn();
+			additionalData.hooks.runHook = runHook;
+
+			const promise = workflowExecute.processRunExecutionData(workflow);
+			promise.cancel('reason');
+
+			const updatedExecutionData = {
+				data: {
+					startData: { startNodes: [{ name: 'Start', sourceData: null }] },
+					resultData: {
+						runData: {
+							Start: [toITaskData([{ data: { test: 'data' } }], { executionStatus: 'success' })],
+							Processing: [
+								toITaskData([{ data: { test: 'data' } }], { executionStatus: 'canceled' }),
+							],
+							Completed: [
+								toITaskData([{ data: { test: 'data1' } }], { executionStatus: 'error' }),
+								toITaskData([{ data: { test: 'data2' } }], { executionStatus: 'canceled' }),
+								toITaskData([{ data: { test: 'data3' } }], { executionStatus: 'waiting' }),
+							],
+						},
+						lastNodeExecuted: 'Processing',
+					},
+					executionData: mock<IRunExecutionData['executionData']>({
+						nodeExecutionStack: [],
+						metadata: {},
+					}),
+				},
+			};
+
+			expect(runHook.mock.lastCall[0]).toEqual('workflowExecuteAfter');
+			expect(JSON.stringify(runHook.mock.lastCall[1][0].data)).toBe(
+				JSON.stringify(updatedExecutionData.data),
+			);
+			expect(runHook.mock.lastCall[1][0].status).toEqual('canceled');
 		});
 	});
 });

--- a/packages/core/src/execution-engine/node-execution-context/supply-data-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/supply-data-context.ts
@@ -280,8 +280,14 @@ export class SupplyDataContext extends BaseExecuteContext implements ISupplyData
 		taskData = taskData!;
 
 		if (data instanceof Error) {
-			taskData.executionStatus = 'error';
-			taskData.error = data;
+			// if running node was already marked as "canceled" because execution was aborted
+			// leave as "canceled" instead of showing "This operation was aborted" error
+			if (
+				!(type === 'output' && this.abortSignal?.aborted && taskData.executionStatus === 'canceled')
+			) {
+				taskData.executionStatus = 'error';
+				taskData.error = data;
+			}
 		} else {
 			if (type === 'output') {
 				taskData.executionStatus = 'success';

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -1584,6 +1584,7 @@ export class WorkflowExecute {
 			onCancel.shouldReject = false;
 			onCancel(() => {
 				this.status = 'canceled';
+				this.updateTaskStatusesToCancelled();
 				this.abortController.abort();
 				const fullRunData = this.getFullRunData(startedAt);
 				void hooks.runHook('workflowExecuteAfter', [fullRunData]);
@@ -2652,6 +2653,17 @@ export class WorkflowExecute {
 		}
 
 		return nodeSuccessData;
+	}
+
+	private updateTaskStatusesToCancelled(): void {
+		Object.keys(this.runExecutionData.resultData.runData).forEach((nodeName) => {
+			const taskDataArray = this.runExecutionData.resultData.runData[nodeName];
+			taskDataArray.forEach((taskData) => {
+				if (taskData.executionStatus === 'running') {
+					taskData.executionStatus = 'canceled';
+				}
+			});
+		});
 	}
 
 	private get isCancelled() {

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -1883,6 +1883,7 @@
 	"runData.editValue": "Edit Value",
 	"runData.executionStatus.success": "Executed successfully",
 	"runData.executionStatus.failed": "Execution failed",
+	"runData.executionStatus.canceled": "Execution canceled",
 	"runData.downloadBinaryData": "Download",
 	"runData.executeNode": "Test Node",
 	"runData.executionTime": "Execution Time",

--- a/packages/frontend/editor-ui/src/components/RunInfo.test.ts
+++ b/packages/frontend/editor-ui/src/components/RunInfo.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { ITaskData } from 'n8n-workflow';
+import RunInfo from './RunInfo.vue';
+import { createComponentRenderer } from '@/__tests__/render';
+import { mock } from 'vitest-mock-extended';
+
+vi.mock('@/utils/formatters/dateFormatter', () => ({
+	convertToDisplayDateComponents: vi.fn(() => ({
+		date: 'Jan 15',
+		time: '10:30:00',
+	})),
+}));
+
+vi.mock('@n8n/i18n', async (importOriginal) => {
+	return {
+		...(await importOriginal()),
+		useI18n: () => ({
+			baseText: vi.fn((key: string) => {
+				const translations: Record<string, string> = {
+					'runData.executionStatus.success': 'Success',
+					'runData.executionStatus.canceled': 'Canceled',
+					'runData.executionStatus.failed': 'Failed',
+					'runData.startTime': 'Start time',
+					'runData.executionTime': 'Execution time',
+					'runData.ms': 'ms',
+				};
+				return translations[key] || key;
+			}),
+		}),
+	};
+});
+
+const renderComponent = createComponentRenderer(RunInfo);
+
+describe('RunInfo', () => {
+	it('should display success status when execution status is success', () => {
+		const successTaskData: ITaskData = mock<ITaskData>({
+			startTime: Date.now(),
+			executionTime: 1500,
+			executionStatus: 'success',
+			data: {},
+			error: undefined,
+		});
+
+		const { getByTestId, container } = renderComponent({
+			props: {
+				taskData: successTaskData,
+				hasStaleData: false,
+				hasPinData: false,
+			},
+		});
+
+		expect(getByTestId('node-run-status-success')).toBeInTheDocument();
+		expect(getByTestId('node-run-info')).toBeInTheDocument();
+
+		const tooltipDiv = container.querySelector('.tooltipRow');
+		expect(tooltipDiv).toBeInTheDocument();
+
+		const statusIcon = getByTestId('node-run-status-success');
+		expect(statusIcon).toHaveClass('success');
+
+		const infoIcon = getByTestId('node-run-info');
+		expect(infoIcon).toBeInTheDocument();
+
+		// Verify the component renders with success status
+		expect(statusIcon).toHaveAttribute('data-test-id', 'node-run-status-success');
+
+		// Check tooltip content exists in the DOM (even if hidden)
+		expect(document.body).toHaveTextContent('Success');
+		expect(document.body).toHaveTextContent('Start time:');
+		expect(document.body).toHaveTextContent('Jan 15 at 10:30:00');
+		expect(document.body).toHaveTextContent('Execution time:');
+		expect(document.body).toHaveTextContent('1500 ms');
+	});
+
+	it('should display cancelled status when execution status is canceled', () => {
+		const cancelledTaskData: ITaskData = mock<ITaskData>({
+			startTime: 1757506978099,
+			executionTime: 800,
+			executionStatus: 'canceled',
+			data: {},
+			error: undefined,
+		});
+
+		const { getByTestId, container, queryByTestId } = renderComponent({
+			props: {
+				taskData: cancelledTaskData,
+				hasStaleData: false,
+				hasPinData: false,
+			},
+		});
+
+		expect(queryByTestId('node-run-status-success')).not.toBeInTheDocument();
+		expect(getByTestId('node-run-info')).toBeInTheDocument();
+
+		const tooltipDiv = container.querySelector('.tooltipRow');
+		expect(tooltipDiv).toBeInTheDocument();
+
+		const infoIcon = getByTestId('node-run-info');
+		expect(infoIcon).toBeInTheDocument();
+
+		// For cancelled status, only info tooltip is shown (no status icon)
+		expect(infoIcon).toHaveAttribute('data-test-id', 'node-run-info');
+
+		// Check tooltip content exists in the DOM (even if hidden)
+		expect(document.body).toHaveTextContent('Canceled');
+		expect(document.body).toHaveTextContent('Start time:');
+		expect(document.body).toHaveTextContent('Jan 15 at 10:30:00');
+		expect(document.body).toHaveTextContent('Execution time:');
+		expect(document.body).toHaveTextContent('800 ms');
+	});
+
+	it('should display error status when there is an error', () => {
+		const errorTaskData: ITaskData = mock<ITaskData>({
+			startTime: 1757506978099,
+			executionTime: 1200,
+			executionStatus: 'success',
+			data: {},
+			error: {
+				message: 'Something went wrong',
+				name: 'Error',
+			},
+		});
+
+		const { getByTestId, container } = renderComponent({
+			props: {
+				taskData: errorTaskData,
+				hasStaleData: false,
+				hasPinData: false,
+			},
+		});
+
+		expect(getByTestId('node-run-status-danger')).toBeInTheDocument();
+		expect(getByTestId('node-run-info')).toBeInTheDocument();
+
+		const tooltipDiv = container.querySelector('.tooltipRow');
+		expect(tooltipDiv).toBeInTheDocument();
+
+		const statusIcon = getByTestId('node-run-status-danger');
+		expect(statusIcon).toHaveClass('danger');
+
+		const infoIcon = getByTestId('node-run-info');
+		expect(infoIcon).toBeInTheDocument();
+
+		// Verify the component renders with error status
+		expect(statusIcon).toHaveAttribute('data-test-id', 'node-run-status-danger');
+
+		// Check tooltip content exists in the DOM (even if hidden)
+		expect(document.body).toHaveTextContent('Failed');
+		expect(document.body).toHaveTextContent('Start time:');
+		expect(document.body).toHaveTextContent('Jan 15 at 10:30:00');
+		expect(document.body).toHaveTextContent('Execution time:');
+		expect(document.body).toHaveTextContent('1200 ms');
+	});
+});

--- a/packages/frontend/editor-ui/src/components/RunInfo.vue
+++ b/packages/frontend/editor-ui/src/components/RunInfo.vue
@@ -53,6 +53,7 @@ const runMetadata = computed(() => {
 	</N8nInfoTip>
 	<div v-else-if="runMetadata" :class="$style.tooltipRow">
 		<N8nInfoTip
+			v-if="taskData?.executionStatus !== 'canceled'"
 			type="note"
 			:theme="theme"
 			:data-test-id="`node-run-status-${theme}`"
@@ -69,7 +70,9 @@ const runMetadata = computed(() => {
 					>{{
 						runTaskData?.error
 							? i18n.baseText('runData.executionStatus.failed')
-							: i18n.baseText('runData.executionStatus.success')
+							: runTaskData?.executionStatus === 'canceled'
+								? i18n.baseText('runData.executionStatus.canceled')
+								: i18n.baseText('runData.executionStatus.success')
 					}} </n8n-text
 				><br />
 				<n8n-text :bold="true" size="small">{{

--- a/packages/frontend/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeDefault.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeDefault.vue
@@ -53,7 +53,7 @@ const classes = computed(() => {
 		[$style.node]: true,
 		[$style.selected]: isSelected.value,
 		[$style.disabled]: isDisabled.value,
-		[$style.success]: hasRunData.value,
+		[$style.success]: hasRunData.value && executionStatus.value === 'success',
 		[$style.error]: hasExecutionErrors.value,
 		[$style.pinned]: hasPinnedData.value,
 		[$style.waiting]: executionWaiting.value ?? executionStatus.value === 'waiting',

--- a/packages/frontend/editor-ui/src/components/canvas/elements/nodes/render-types/parts/CanvasNodeStatusIcons.test.ts
+++ b/packages/frontend/editor-ui/src/components/canvas/elements/nodes/render-types/parts/CanvasNodeStatusIcons.test.ts
@@ -75,13 +75,34 @@ describe('CanvasNodeStatusIcons', () => {
 				provide: {
 					...createCanvasProvide(),
 					...createCanvasNodeProvide({
-						data: { runData: { outputMap: {}, iterations: 15, visible: true } },
+						data: {
+							execution: { status: 'success', running: false },
+							runData: { outputMap: {}, iterations: 15, visible: true },
+						},
 					}),
 				},
 			},
 		});
 
 		expect(getByTestId('canvas-node-status-success')).toHaveTextContent('15');
+	});
+
+	it('should not render success icon for a node that was canceled', () => {
+		const { queryByTestId } = renderComponent({
+			global: {
+				provide: {
+					...createCanvasProvide(),
+					...createCanvasNodeProvide({
+						data: {
+							execution: { status: 'canceled', running: false },
+							runData: { outputMap: {}, iterations: 15, visible: true },
+						},
+					}),
+				},
+			},
+		});
+
+		expect(queryByTestId('canvas-node-status-success')).not.toBeInTheDocument();
 	});
 
 	it('should render correctly for a dirty node that has run successfully', () => {

--- a/packages/frontend/editor-ui/src/components/canvas/elements/nodes/render-types/parts/CanvasNodeStatusIcons.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/elements/nodes/render-types/parts/CanvasNodeStatusIcons.vue
@@ -131,7 +131,7 @@ const commonClasses = computed(() => [
 		</N8nTooltip>
 	</div>
 	<div
-		v-else-if="hasRunData"
+		v-else-if="hasRunData && executionStatus === 'success'"
 		data-test-id="canvas-node-status-success"
 		:class="[...commonClasses, $style.runData]"
 	>

--- a/packages/frontend/editor-ui/src/composables/useCanvasMapping.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasMapping.ts
@@ -345,7 +345,11 @@ export function useCanvasMapping({
 		nodes.value.reduce<Record<string, ExecutionStatus>>((acc, node) => {
 			const tasks = workflowsStore.getWorkflowRunData?.[node.name] ?? [];
 
-			acc[node.id] = tasks.at(-1)?.executionStatus ?? 'new';
+			let lastExecutionStatus = tasks.at(-1)?.executionStatus;
+			if (tasks.length > 1 && lastExecutionStatus === 'canceled') {
+				lastExecutionStatus = tasks.at(-2)?.executionStatus;
+			}
+			acc[node.id] = lastExecutionStatus ?? 'new';
 			return acc;
 		}, {}),
 	);
@@ -382,7 +386,9 @@ export function useCanvasMapping({
 							acc[nodeId][connectionType][outputIndex] = acc[nodeId][connectionType][
 								outputIndex
 							] ?? { ...outputData };
-							acc[nodeId][connectionType][outputIndex].iterations += 1;
+							if (runIteration.executionStatus !== 'canceled') {
+								acc[nodeId][connectionType][outputIndex].iterations += 1;
+							}
 							acc[nodeId][connectionType][outputIndex].total +=
 								connectionTypeOutputIndexData.length;
 						}
@@ -593,6 +599,14 @@ export function useCanvasMapping({
 		}, {});
 	});
 
+	function filterOutCanceled(tasks: ITaskData[] | null): ITaskData[] | null {
+		if (!tasks) {
+			return null;
+		}
+
+		return tasks.filter((task) => task.executionStatus !== 'canceled');
+	}
+
 	const mappedNodes = computed<CanvasNode[]>(() => {
 		const connectionsBySourceNode = connections.value;
 		const connectionsByDestinationNode =
@@ -635,7 +649,7 @@ export function useCanvasMapping({
 					},
 					runData: {
 						outputMap: nodeExecutionRunDataOutputMapById.value[node.id],
-						iterations: nodeExecutionRunDataById.value[node.id]?.length ?? 0,
+						iterations: filterOutCanceled(nodeExecutionRunDataById.value[node.id])?.length ?? 0,
 						visible: !!nodeExecutionRunDataById.value[node.id],
 					},
 					render: renderTypeByNodeId.value[node.id] ?? { type: 'default', options: {} },
@@ -677,6 +691,12 @@ export function useCanvasMapping({
 		const runDataTotal =
 			nodeExecutionRunDataOutputMapById.value[connection.source]?.[type]?.[index]?.total ?? 0;
 
+		const sourceTasks = nodeExecutionRunDataById.value[connection.source] ?? [];
+		let lastSourceTask: ITaskData | undefined = sourceTasks[sourceTasks.length - 1];
+		if (lastSourceTask?.executionStatus === 'canceled' && sourceTasks.length > 1) {
+			lastSourceTask = sourceTasks[sourceTasks.length - 2];
+		}
+
 		let status: CanvasConnectionData['status'];
 		if (nodeExecutionRunningById.value[connection.source]) {
 			status = 'running';
@@ -687,7 +707,7 @@ export function useCanvasMapping({
 			status = 'pinned';
 		} else if (nodeHasIssuesById.value[connection.source]) {
 			status = 'error';
-		} else if (runDataTotal > 0) {
+		} else if (runDataTotal > 0 && lastSourceTask?.executionStatus !== 'canceled') {
 			status = 'success';
 		}
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Show the correct “canceled” status across the execution engine and editor UI. Addresses N8N-693510 by preventing canceled runs from appearing as success and by fixing counts and link styling.

- **Bug Fixes**
  - Engine: On workflow cancel, update only running tasks to “canceled” and keep that status if an aborted node emits an error.
  - Editor UI: Show “Canceled” in RunInfo, hide the success icon for canceled runs, and only style nodes as success when status is “success”.
  - Canvas: Do not show a green success link when the last task was canceled; use the previous non-canceled task for status where applicable.
  - Counts: Exclude canceled iterations from iteration counts but keep their data in totals.
  - i18n: Added “Execution canceled” translation key.
  - Tests: Added coverage for engine cancellation flow, RunInfo, canvas status icons, and useCanvasMapping logic.

<!-- End of auto-generated description by cubic. -->

