### PR TITLE
n8n-auto-pr (N8N - 693890)

### DIFF
--- a/packages/frontend/editor-ui/src/components/CodeNodeEditor/CodeNodeEditor.vue
+++ b/packages/frontend/editor-ui/src/components/CodeNodeEditor/CodeNodeEditor.vue
@@ -20,6 +20,7 @@ import { useLinter } from './linter';
 import { useSettingsStore } from '@/stores/settings.store';
 import { dropInCodeEditor } from '@/plugins/codemirror/dragAndDrop';
 import type { TargetNodeParameterContext } from '@/Interface';
+import { valueToInsert } from './utils';
 
 export type CodeNodeLanguageOption = CodeNodeEditorLanguage | 'pythonNative';
 
@@ -203,12 +204,11 @@ function onAiLoadEnd() {
 async function onDrop(value: string, event: MouseEvent) {
 	if (!editor.value) return;
 
-	const valueToInsert =
-		props.mode === 'runOnceForAllItems'
-			? value.replace('$json', '$input.first().json').replace(/\$\((.*)\)\.item/, '$($1).first()')
-			: value;
-
-	await dropInCodeEditor(toRaw(editor.value), event, valueToInsert);
+	await dropInCodeEditor(
+		toRaw(editor.value),
+		event,
+		valueToInsert(value, props.language, props.mode),
+	);
 }
 
 defineExpose({

--- a/packages/frontend/editor-ui/src/components/CodeNodeEditor/utils.test.ts
+++ b/packages/frontend/editor-ui/src/components/CodeNodeEditor/utils.test.ts
@@ -1,5 +1,5 @@
 import * as esprima from 'esprima-next';
-import { walk } from './utils';
+import { valueToInsert, walk } from './utils';
 
 describe('CodeNodeEditor utils', () => {
 	describe('walk', () => {
@@ -39,6 +39,90 @@ const y = f({ a: 'c' })
 					new esprima.Literal(2, '2'),
 				]),
 			]);
+		});
+	});
+
+	describe('valueToInsert', () => {
+		describe('JavaScript', () => {
+			it('should convert input item correctly, runOnceForAllItems', () => {
+				expect(
+					valueToInsert('{{ $json.foo.bar[0].baz }}', 'javaScript', 'runOnceForAllItems'),
+				).toBe('{{ $input.first().json.foo.bar[0].baz }}');
+			});
+
+			it('should convert input item correctly, runOnceForEachItem', () => {
+				expect(
+					valueToInsert('{{ $json.foo.bar[0].baz }}', 'javaScript', 'runOnceForEachItem'),
+				).toBe('{{ $json.foo.bar[0].baz }}');
+			});
+
+			it('should convert previous node correctly, runOnceForAllItems', () => {
+				expect(
+					valueToInsert(
+						"{{ $('Some Previous Node').item.json.foo.bar[0].baz }}",
+						'javaScript',
+						'runOnceForAllItems',
+					),
+				).toBe("{{ $('Some Previous Node').first().json.foo.bar[0].baz }}");
+			});
+
+			it('should convert previous node correctly, runOnceForEachItem', () => {
+				expect(
+					valueToInsert(
+						"{{ $('Some Previous Node').item.json.foo.bar[0].baz }}",
+						'javaScript',
+						'runOnceForEachItem',
+					),
+				).toBe("{{ $('Some Previous Node').item.json.foo.bar[0].baz }}");
+			});
+		});
+
+		describe('Python (Pyodide)', () => {
+			it('should convert input item correctly, runOnceForAllItems', () => {
+				expect(valueToInsert('{{ $json.foo.bar[0].baz }}', 'python', 'runOnceForAllItems')).toBe(
+					'{{ _input.first().json.foo.bar[0].baz }}',
+				);
+			});
+
+			it('should convert input item correctly, runOnceForEachItem', () => {
+				expect(valueToInsert('{{ $json.foo.bar[0].baz }}', 'python', 'runOnceForEachItem')).toBe(
+					'{{ _input.item.json.foo.bar[0].baz }}',
+				);
+			});
+
+			it('should convert previous node correctly, runOnceForAllItems', () => {
+				expect(
+					valueToInsert(
+						"{{ $('Some Previous Node').item.json.foo.bar[0].baz }}",
+						'python',
+						'runOnceForAllItems',
+					),
+				).toBe("{{ _('Some Previous Node').first().json.foo.bar[0].baz }}");
+			});
+
+			it('should convert previous node correctly, runOnceForEachItem', () => {
+				expect(
+					valueToInsert(
+						"{{ $('Some Previous Node').item.json.foo.bar[0].baz }}",
+						'python',
+						'runOnceForEachItem',
+					),
+				).toBe("{{ _('Some Previous Node').item.json.foo.bar[0].baz }}");
+			});
+		});
+
+		describe('Python (Native)', () => {
+			it('should convert input item correctly, runOnceForAllItems', () => {
+				expect(
+					valueToInsert('{{ $json.foo.bar[0].baz }}', 'pythonNative', 'runOnceForAllItems'),
+				).toBe('{{ _items[0]["json"]["foo"]["bar"][0]["baz"] }}');
+			});
+
+			it('should convert input item correctly, runOnceForEachItem', () => {
+				expect(
+					valueToInsert('{{ $json.foo.bar[0].baz }}', 'pythonNative', 'runOnceForEachItem'),
+				).toBe('{{ _item["json"]["foo"]["bar"][0]["baz"] }}');
+			});
 		});
 	});
 });


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes drag-and-drop in Code Node so inserted expressions are correct for JavaScript, Python (Pyodide), and Python (Native), respecting execution mode. Prevents broken code on drop and addresses N8N-693890.

- Bug Fixes
  - Centralized valueToInsert() to generate per-language, per-mode expressions.
  - JavaScript: $json -> $input.first().json; $('...').item -> $('...').first() in runOnceForAllItems.
  - Python (Pyodide): $json -> _input.first().json or _input.item.json; $('...').item -> _('...').first()/item.
  - Python (Native): $json -> _items[0]["json"] or _item["json"]; converts .a.b to ["a"]["b"].
  - Added unit tests for valueToInsert across languages and modes.

<!-- End of auto-generated description by cubic. -->

