### PR TITLE
n8n-auto-pr (N8N - 695428)

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/__tests__/supply-data-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/supply-data-context.test.ts
@@ -220,6 +220,40 @@ describe('SupplyDataContext', () => {
 		});
 	});
 
+	describe('logNodeOutput', () => {
+		it('it should parse JSON', () => {
+			const json = '{"key": "value", "nested": {"foo": "bar"}}';
+			const expectedParsedObject = { key: 'value', nested: { foo: 'bar' } };
+			const numberArg = 42;
+			const stringArg = 'hello world!';
+
+			const supplyDataContext = new SupplyDataContext(
+				workflow,
+				node,
+				additionalData,
+				mode,
+				runExecutionData,
+				runIndex,
+				connectionInputData,
+				inputData,
+				connectionType,
+				executeData,
+				[closeFn],
+				abortSignal,
+			);
+
+			const sendMessageSpy = jest.spyOn(supplyDataContext, 'sendMessageToUI');
+
+			supplyDataContext.logNodeOutput(json, numberArg, stringArg);
+
+			expect(sendMessageSpy.mock.calls[0][0]).toEqual(expectedParsedObject);
+			expect(sendMessageSpy.mock.calls[0][1]).toBe(numberArg);
+			expect(sendMessageSpy.mock.calls[0][2]).toBe(stringArg);
+
+			sendMessageSpy.mockRestore();
+		});
+	});
+
 	describe('addExecutionDataFunctions', () => {
 		it('should preserve canceled status when execution is aborted and output has error', async () => {
 			const errorData = new ExecutionCancelledError('Execution was aborted');

--- a/packages/core/src/execution-engine/node-execution-context/supply-data-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/supply-data-context.ts
@@ -18,7 +18,7 @@ import type {
 	NodeConnectionType,
 	ISourceData,
 } from 'n8n-workflow';
-import { createDeferredPromise, NodeConnectionTypes } from 'n8n-workflow';
+import { createDeferredPromise, jsonParse, NodeConnectionTypes } from 'n8n-workflow';
 
 import { BaseExecuteContext } from './base-execute-context';
 import {
@@ -342,6 +342,20 @@ export class SupplyDataContext extends BaseExecuteContext implements ISupplyData
 				node: nodeName,
 				runIndex: currentNodeRunIndex,
 			});
+		}
+	}
+
+	logNodeOutput(...args: unknown[]): void {
+		if (this.mode === 'manual') {
+			const parsedLogArgs = args.map((arg) =>
+				typeof arg === 'string' ? jsonParse(arg, { fallbackValue: arg }) : arg,
+			);
+			this.sendMessageToUI(...parsedLogArgs);
+			return;
+		}
+
+		if (process.env.CODE_ENABLE_STDOUT === 'true') {
+			console.log(`[Workflow "${this.getWorkflow().id}"][Node "${this.node.name}"]`, ...args);
 		}
 	}
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes Code node logs not appearing in the browser during manual runs. Adds structured logging that parses JSON strings and forwards them to the UI, addressing N8N-695428.

- **Bug Fixes**
  - Added SupplyDataContext.logNodeOutput: in manual mode, parses JSON strings (with fallback) and sends to UI; otherwise logs to stdout when CODE_ENABLE_STDOUT=true.
  - Added unit test to confirm JSON parsing and argument forwarding.

<!-- End of auto-generated description by cubic. -->

