### PR TITLE
n8n-auto-pr (N8N - 695481)

### DIFF
--- a/packages/cli/src/modules/data-table/data-store-rows.repository.ts
+++ b/packages/cli/src/modules/data-table/data-store-rows.repository.ts
@@ -1,4 +1,4 @@
-import type { ListDataStoreContentQueryDto, DataTableFilter } from '@n8n/api-types';
+import { ListDataStoreContentQueryDto, DataTableFilter } from '@n8n/api-types';
 import { CreateTable, DslColumn } from '@n8n/db';
 import { Service } from '@n8n/di';
 import {
@@ -549,7 +549,7 @@ export class DataStoreRowsRepository {
 	}
 
 	private applyPagination(query: QueryBuilder, dto: ListDataStoreContentQueryDto): void {
-		query.skip(dto.skip);
-		query.take(dto.take);
+		query.skip(dto.skip ?? 0);
+		if (dto.take) query.take(dto.take);
 	}
 }

--- a/packages/cli/src/modules/data-table/data-store.repository.ts
+++ b/packages/cli/src/modules/data-table/data-store.repository.ts
@@ -211,9 +211,7 @@ export class DataStoreRepository extends Repository<DataTable> {
 		options: Partial<ListDataStoreQueryDto>,
 	): void {
 		query.skip(options.skip ?? 0);
-		if (options?.take) {
-			query.skip(options.skip ?? 0).take(options.take);
-		}
+		if (query.take) query.take(options.take);
 	}
 
 	private applyDefaultSelect(query: SelectQueryBuilder<DataTable>): void {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Standardizes Data Table pagination: always default skip to 0 and apply take only when provided. Aligns with Linear N8N-695481 to unify pagination across Data Table endpoints.

- **Bug Fixes**
  - DataStoreRowsRepository: apply skip with default 0; only call take when dto.take is set.
  - DataStoreRepository: apply skip with default 0; only call take when a take value is provided.

<!-- End of auto-generated description by cubic. -->

