### PR TITLE
n8n-auto-pr (N8N - 695881)

### DIFF
--- a/packages/cli/src/services/__tests__/public-api-key.service.test.ts
+++ b/packages/cli/src/services/__tests__/public-api-key.service.test.ts
@@ -233,6 +233,30 @@ describe('PublicApiKeyService', () => {
 				);
 			});
 		});
+
+		it('should return false if user is disabled', async () => {
+			//Arrange
+
+			const path = '/test';
+			const method = 'GET';
+			const apiVersion = 'v1';
+
+			const owner = await createOwnerWithApiKey();
+
+			await userRepository.update({ id: owner.id }, { disabled: true });
+
+			const [{ apiKey }] = owner.apiKeys;
+
+			const middleware = publicApiKeyService.getAuthMiddleware(apiVersion);
+
+			//Act
+
+			const response = await middleware(mockReqWith(apiKey, path, method), {}, securitySchema);
+
+			//Assert
+
+			expect(response).toBe(false);
+		});
 	});
 
 	describe('redactApiKey', () => {

--- a/packages/cli/src/services/public-api-key.service.ts
+++ b/packages/cli/src/services/public-api-key.service.ts
@@ -119,6 +119,8 @@ export class PublicApiKeyService {
 
 			if (!user) return false;
 
+			if (user.disabled) return false;
+
 			// Legacy API keys are not JWTs and do not need to be verified.
 			if (!providedApiKey.startsWith(PREFIX_LEGACY_API_KEY)) {
 				try {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Prevent API requests from disabled users by rejecting public API key authentication, aligning with N8N-695881. Added a unit test to confirm the auth middleware returns false for disabled accounts.

<!-- End of auto-generated description by cubic. -->

