### PR TITLE
n8n-auto-pr (N8N - 701980)

### DIFF
--- a/packages/@n8n/nodes-langchain/utils/N8nBinaryLoader.ts
+++ b/packages/@n8n/nodes-langchain/utils/N8nBinaryLoader.ts
@@ -25,7 +25,7 @@ const SUPPORTED_MIME_TYPES = {
 	csvLoader: ['text/csv'],
 	epubLoader: ['application/epub+zip'],
 	docxLoader: ['application/vnd.openxmlformats-officedocument.wordprocessingml.document'],
-	textLoader: ['text/plain', 'text/mdx', 'text/md'],
+	textLoader: ['text/plain', 'text/mdx', 'text/md', 'text/markdown'],
 	jsonLoader: ['application/json'],
 };
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add support for the text/markdown MIME type in N8nBinaryLoader so Markdown files use the text loader. Addresses N8N-701980 and prevents misclassification of Markdown content.

<!-- End of auto-generated description by cubic. -->

