### PR TITLE
n8n-auto-pr (N8N - 706758)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
@@ -104,7 +104,9 @@ async function processEventStream(
 					let chunkText = '';
 					if (Array.isArray(chunkContent)) {
 						for (const message of chunkContent) {
-							chunkText += (message as MessageContentText)?.text;
+							if (message?.type === 'text') {
+								chunkText += (message as MessageContentText)?.text;
+							}
 						}
 					} else if (typeof chunkContent === 'string') {
 						chunkText = chunkContent;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Filters non-text items from streamed chat chunks in ToolsAgent V2 so only text is emitted, preventing noisy or invalid output during streaming. Adds tests to ensure mixed and empty content are handled safely. Addresses Linear N8N-706758.

- **Bug Fixes**
  - Append chunk text only when message.type === 'text'.
  - Support string content and arrays; ignore non-text types.
  - Handle null/empty chunk content without errors.
  - Added tests for mixed content, string content, non-text-only content, and empty chunks.

<!-- End of auto-generated description by cubic. -->

