### PR TITLE
n8n-auto-pr (N8N - 717290)

### DIFF
--- a/.github/workflows/release-standalone-package.yml
+++ b/.github/workflows/release-standalone-package.yml
@@ -12,9 +12,6 @@ on:
           - '@n8n/create-node'
           - '@n8n/scan-community-package'
 
-env:
-  BUILD_DIST_NAME: ${{ github.sha }}-${{ github.event.inputs.package }}-build
-
 concurrency:
   group: release-package-${{ github.event.inputs.package }}
   cancel-in-progress: false
@@ -36,8 +33,19 @@ jobs:
     needs: validate
     runs-on: blacksmith-4vcpu-ubuntu-2204
     timeout-minutes: 15
+    outputs:
+      artifact-name: ${{ steps.sanitize.outputs.result }}
 
     steps:
+      - name: Create sanitized artifact name
+        id: sanitize
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const packageName = '${{ github.event.inputs.package }}';
+            const sanitizedName = packageName.replace(/[/:]/g, '-');
+            return `${{ github.sha }}-${sanitizedName}-build`;
+
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -51,7 +59,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: ${{ env.BUILD_DIST_NAME }}
+          name: ${{ steps.sanitize.outputs.result }}
           path: ./packages/**/dist
           if-no-files-found: error
           retention-days: 7
@@ -88,7 +96,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@65d862660abb3549b588b37db4038d3fd1a05f8a # v4.1.8
         with:
-          name: ${{ env.BUILD_DIST_NAME }}
+          name: ${{ needs.build.outputs.artifact-name }}
           path: .
 
       - name: Pre publishing changes


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Sanitizes build artifact names in the release-standalone-package workflow to handle scoped packages and avoid invalid characters. Also replaces the env var with a job output so upload/download steps use the same sanitized name (addresses N8N-717290).

- **Bug Fixes**
  - Generate artifact name via github-script, replacing “/” and “:” with “-”.
  - Remove BUILD_DIST_NAME env var and pass artifact-name via job outputs to the publish job.

<!-- End of auto-generated description by cubic. -->

