### PR TITLE
n8n-auto-pr (N8N - 717385)

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -75,7 +75,7 @@ jobs:
         run: echo "RELEASE=$(node -e 'console.log(require("./package.json").version)')" >> "$GITHUB_ENV"
 
       - name: Download build artifacts
-        uses: actions/download-artifact@65d862660abb3549b588b37db4038d3fd1a05f8a # v4.1.8
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: ${{ env.BUILD_DIST_NAME }}
           path: .
@@ -152,8 +152,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
       - name: Download build artifacts
-        uses: actions/download-artifact@65d862660abb3549b588b37db4038d3fd1a05f8a # v4.1.8
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: ${{ env.BUILD_DIST_NAME }}
           path: .

--- a/.github/workflows/release-standalone-package.yml
+++ b/.github/workflows/release-standalone-package.yml
@@ -95,7 +95,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Download build artifacts
-        uses: actions/download-artifact@65d862660abb3549b588b37db4038d3fd1a05f8a # v4.1.8
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: ${{ needs.build.outputs.artifact-name }}
           path: .


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Upgraded actions/download-artifact to v5.0.0 (pinned SHA) in release-publish and release-standalone-package workflows. This keeps our release pipelines current and more reliable when downloading build artifacts.

<!-- End of auto-generated description by cubic. -->

