### PR TITLE
n8n-auto-pr (N8N - 727753)

### DIFF
--- a/packages/nodes-base/credentials/SalesforceOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/SalesforceOAuth2Api.credentials.ts
@@ -38,7 +38,7 @@ export class SalesforceOAuth2Api implements ICredentialType {
 			type: 'hidden',
 			required: true,
 			default:
-				'={{ $self["environment"] === "sandbox" ? "https://test.salesforce.com/services/oauth2/authorize" : "https://login.salesforce.com/services/oauth2/authorize" }}',
+				'={{ $self["environment"] === "sandbox" ? "https://test.salesforce.com/services/oauth2/authorize?prompt=login" : "https://login.salesforce.com/services/oauth2/authorize?prompt=login" }}',
 		},
 		{
 			displayName: 'Access Token URL',


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Force the Salesforce OAuth2 authorize URL to always show the login screen. This prevents silent session reuse and makes switching accounts reliable.

- **Bug Fixes**
  - Added ?prompt=login to the authorize URL for both sandbox and production in SalesforceOAuth2Api credentials.

<!-- End of auto-generated description by cubic. -->

