### PR TITLE
n8n-auto-pr (N8N - 728158)

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -1834,6 +1834,7 @@
 	"resourceLocator.mode.list.placeholder": "Choose...",
 	"resourceLocator.mode.list.searchRequired": "Enter a search term to show results",
 	"resourceLocator.mode.list.addNewResource.vectorStoreInMemory": "Create key '{resourceName}'",
+	"resourceLocator.dataTable.createNew": "Create new data table",
 	"resourceLocator.modeSelector.placeholder": "Mode...",
 	"resourceLocator.openSpecificResource": "Open {entity} in {appName}",
 	"resourceLocator.openResource": "Open in {appName}",

--- a/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocator.test.constants.ts
+++ b/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocator.test.constants.ts
@@ -134,3 +134,35 @@ export const TEST_NODE_NO_CREDENTIALS: INode = {
 	},
 	credentials: undefined,
 };
+
+export const TEST_PARAMETER_URL_REDIRECT: INodeProperties = {
+	...TEST_PARAMETER_MULTI_MODE,
+	name: 'testParameterUrlRedirect',
+	modes: [
+		{
+			displayName: 'From List',
+			name: 'list',
+			type: 'list',
+			typeOptions: {
+				searchListMethod: 'testSearch',
+				searchable: true,
+				allowNewResource: {
+					label: 'resourceLocator.dataTable.createNew',
+					url: '/projects/{{$projectId}}/datatables/new',
+				},
+			},
+		},
+	],
+};
+
+export const TEST_NODE_URL_REDIRECT: INode = {
+	...TEST_NODE_MULTI_MODE,
+	name: 'Test Node - URL Redirect',
+	parameters: {
+		resource: 'test',
+		operation: 'get',
+		testParameterUrlRedirect: TEST_MODEL_VALUE,
+		id: '',
+		options: {},
+	},
+};

--- a/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocatorDropdown.vue
+++ b/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocatorDropdown.vue
@@ -439,11 +439,16 @@ defineExpose({ isWithinDropdown });
 }
 
 .resourceNameContainer {
+	display: flex;
+	align-items: center;
 	font-size: var(--font-size-2xs);
+	min-width: 0;
+	align-self: center;
+}
+
+.resourceNameContainer > :first-child {
 	overflow: hidden;
 	text-overflow: ellipsis;
-	display: inline-block;
-	align-self: center;
 }
 
 .searchIcon {

--- a/packages/nodes-base/nodes/DataTable/actions/row/Row.resource.ts
+++ b/packages/nodes-base/nodes/DataTable/actions/row/Row.resource.ts
@@ -69,6 +69,10 @@ export const description: INodeProperties[] = [
 				typeOptions: {
 					searchListMethod: 'tableSearch',
 					searchable: true,
+					allowNewResource: {
+						label: 'resourceLocator.dataTable.createNew',
+						url: '/projects/{{$projectId}}/datatables/new',
+					},
 				},
 			},
 			{

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1561,9 +1561,10 @@ export interface INodePropertyModeTypeOptions {
 	skipCredentialsCheckInRLC?: boolean;
 	allowNewResource?: {
 		label: string;
-		defaultName: string;
-		method: string;
-	};
+	} & (
+		| { method: string; url?: never; defaultName: string }
+		| { method?: never; url: string; defaultName?: never }
+	);
 }
 
 export interface INodePropertyMode {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a “Create new data table” action to the Resource Locator that opens the data table creation page in a new tab, resolving the current project ID. Addresses Linear N8N-728158.

- **New Features**
  - Resource Locator supports allowNewResource via URL; resolves {{$projectId}} and opens in a new tab.
  - Data Table row selector shows “Create new data table” and links to /projects/{projectId}/datatables/new.
  - Added i18n key: resourceLocator.dataTable.createNew.

- **Refactors**
  - Updated types: allowNewResource now accepts either method or url (mutually exclusive).
  - Minor dropdown UI tweak to prevent text overflow.
  - Added tests for URL redirect behavior in Resource Locator.

<!-- End of auto-generated description by cubic. -->

