### PR TITLE
n8n-auto-pr (N8N - 728333)

### DIFF
--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -107,6 +107,9 @@ ENV NODE_ENV=production \
     N8N_RELEASE_TYPE=${N8N_RELEASE_TYPE} \
     SHELL=/bin/sh
 
+# Bring `uv` over from python-runner-builder
+COPY --from=python-runner-builder /usr/local/bin/uv /usr/local/bin/uv
+
 # Bring node over from node-alpine
 COPY --from=node-alpine /usr/local/bin/node /usr/local/bin/node
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Include the uv binary in the n8nio/runners Docker image to enable Python steps and faster package installs at runtime. Copied from the python-runner-builder stage into /usr/local/bin.

<!-- End of auto-generated description by cubic. -->

