### PR TITLE
n8n-auto-pr (N8N - 730191)

### DIFF
--- a/packages/@n8n/config/src/configs/data-table.config.ts
+++ b/packages/@n8n/config/src/configs/data-table.config.ts
@@ -18,5 +18,5 @@ export class DataTableConfig {
 	 * This prevents excessive database queries for size validation.
 	 */
 	@Env('N8N_DATA_TABLES_SIZE_CHECK_CACHE_DURATION_MS')
-	sizeCheckCacheDuration: number = 5 * 1000;
+	sizeCheckCacheDuration: number = 60 * 1000;
 }

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -55,7 +55,7 @@ describe('GlobalConfig', () => {
 		dataTable: {
 			maxSize: 50 * 1024 * 1024,
 			warningThreshold: 45 * 1024 * 1024,
-			sizeCheckCacheDuration: 5000,
+			sizeCheckCacheDuration: 60000,
 		},
 		database: {
 			logging: {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Increase the default cache duration for data table size checks from 5s to 60s to reduce database load and avoid repeated validations in the editor (N8N-730191). Updated the config test to match; value remains configurable via N8N_DATA_TABLES_SIZE_CHECK_CACHE_DURATION_MS.

<!-- End of auto-generated description by cubic. -->

