### PR TITLE
n8n-auto-pr (N8N - 738761)

### DIFF
--- a/packages/nodes-base/credentials/OpenAiApi.credentials.ts
+++ b/packages/nodes-base/credentials/OpenAiApi.credentials.ts
@@ -82,10 +82,11 @@ export class OpenAiApi implements ICredentialType {
 		credentials: ICredentialDataDecryptedObject,
 		requestOptions: IHttpRequestOptions,
 	): Promise<IHttpRequestOptions> {
-		requestOptions.headers = {
-			Authorization: 'Bearer ' + credentials.apiKey,
-			'OpenAI-Organization': credentials.organizationId,
-		};
+		requestOptions.headers ??= {};
+
+		requestOptions.headers['Authorization'] = `Bearer ${credentials.apiKey}`;
+		requestOptions.headers['OpenAI-Organization'] = credentials.organizationId;
+
 		if (
 			credentials.header &&
 			typeof credentials.headerName === 'string' &&
@@ -94,6 +95,7 @@ export class OpenAiApi implements ICredentialType {
 		) {
 			requestOptions.headers[credentials.headerName] = credentials.headerValue;
 		}
+
 		return requestOptions;
 	}
 }

--- a/packages/nodes-base/credentials/test/OpenAiApi.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/OpenAiApi.credentials.test.ts
@@ -151,5 +151,53 @@ describe('OpenAiApi Credential', () => {
 				'OpenAI-Organization': '',
 			});
 		});
+
+		it('should preserve existing headers when adding auth headers', async () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				apiKey: 'sk-test123456789',
+			};
+
+			const requestOptions: IHttpRequestOptions = {
+				headers: {
+					'OpenAI-Beta': 'assistants=v2',
+				},
+				url: '/assistants',
+				baseURL: 'https://api.openai.com/v1',
+			};
+
+			const result = await openAiApi.authenticate(credentials, requestOptions);
+
+			expect(result.headers).toEqual({
+				'OpenAI-Beta': 'assistants=v2',
+				Authorization: 'Bearer sk-test123456789',
+			});
+		});
+
+		it('should preserve existing headers even with custom header option enabled', async () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				apiKey: 'sk-test123456789',
+				header: true,
+				headerName: 'X-Additional-Header',
+				headerValue: 'additional-value',
+			};
+
+			const requestOptions: IHttpRequestOptions = {
+				headers: {
+					'OpenAI-Beta': 'assistants=v2',
+					'X-Existing-Header': 'existing-value',
+				},
+				url: '/assistants/asst_123',
+				baseURL: 'https://api.openai.com/v1',
+			};
+
+			const result = await openAiApi.authenticate(credentials, requestOptions);
+
+			expect(result.headers).toEqual({
+				'OpenAI-Beta': 'assistants=v2',
+				'X-Existing-Header': 'existing-value',
+				Authorization: 'Bearer sk-test123456789',
+				'X-Additional-Header': 'additional-value',
+			});
+		});
 	});
 });


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes OpenAI credential auth to merge into existing request headers instead of overwriting them. This preserves beta/custom headers (e.g., OpenAI-Beta) so Assistants API calls work as expected and aligns with N8N-738761.

- **Bug Fixes**
  - Preserve existing headers; add Authorization and OpenAI-Organization without clobbering.
  - Added tests to verify header preservation with and without custom header options.

<!-- End of auto-generated description by cubic. -->

