### PR TITLE
n8n-auto-pr (N8N - 739309)

### DIFF
--- a/packages/@n8n/eslint-config/src/configs/frontend.ts
+++ b/packages/@n8n/eslint-config/src/configs/frontend.ts
@@ -65,7 +65,7 @@ export const frontendConfig = tseslint.config(
 				'error',
 				'PascalCase',
 				{
-					registeredComponentsOnly: true,
+					registeredComponentsOnly: false,
 				},
 			],
 			'vue/no-reserved-component-names': [

--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.test.ts
@@ -40,11 +40,11 @@ vi.mock('../../types/assistant', async (importOriginal) => {
 });
 
 const stubs = [
-	'n8n-avatar',
-	'n8n-button',
-	'n8n-icon',
-	'n8n-icon-button',
-	'n8n-prompt-input',
+	'N8nAvatar',
+	'N8nButton',
+	'N8nIcon',
+	'N8nIconButton',
+	'N8nPromptInput',
 	'AssistantIcon',
 	'AssistantText',
 	'InlineAskAssistantButton',
@@ -845,7 +845,7 @@ describe('AskAssistantChat', () => {
 					stubs: {
 						...Object.fromEntries(stubs.map((stub) => [stub, true])),
 						MessageWrapper: MessageWrapperStub,
-						'n8n-button': { template: '<button><slot></button' },
+						N8nButton: { template: '<button><slot></button' },
 					},
 				},
 				props: {
@@ -1028,10 +1028,10 @@ describe('AskAssistantChat', () => {
 					directives: { n8nHtml },
 					stubs: {
 						...Object.fromEntries(
-							stubs.filter((stub) => stub !== 'n8n-prompt-input').map((stub) => [stub, true]),
+							stubs.filter((stub) => stub !== 'N8nPromptInput').map((stub) => [stub, true]),
 						),
-						'message-wrapper': MessageWrapperStub,
-						'n8n-prompt-input': {
+						MessageWrapper: MessageWrapperStub,
+						N8nPromptInput: {
 							name: 'n8n-prompt-input',
 							props: [
 								'modelValue',

--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/messages/MessageRating.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/messages/MessageRating.test.ts
@@ -4,7 +4,7 @@ import { nextTick } from 'vue';
 
 import MessageRating from './MessageRating.vue';
 
-const stubs = ['n8n-button', 'n8n-icon-button', 'n8n-input'];
+const stubs = ['N8nButton', 'N8nIconButton', 'N8nInput'];
 
 // Mock i18n to return keys instead of translated text
 vi.mock('@n8n/design-system/composables/useI18n', () => ({
@@ -126,7 +126,7 @@ describe('MessageRating', () => {
 		it('should submit feedback and show success', async () => {
 			const wrapper = render(MessageRating, {
 				props: { showFeedback: true },
-				global: { stubs: ['n8n-button', 'n8n-icon-button'] }, // Don't stub n8n-input
+				global: { stubs: ['N8nButton', 'N8nIconButton'] }, // Don't stub n8n-input
 			});
 
 			const downButton = wrapper.container.querySelector(

--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantLoadingMessage/AssistantLoadingMessage.vue
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantLoadingMessage/AssistantLoadingMessage.vue
@@ -15,11 +15,11 @@ withDefaults(
 <template>
 	<div :class="$style.container">
 		<div :class="$style['message-container']">
-			<transition :name="animationType" mode="out-in">
+			<Transition :name="animationType" mode="out-in">
 				<N8nText v-if="message" :key="message" :class="$style.message" :shimmer="true">{{
 					message
 				}}</N8nText>
-			</transition>
+			</Transition>
 		</div>
 	</div>
 </template>

--- a/packages/frontend/@n8n/design-system/src/components/CodeDiff/CodeDiff.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/CodeDiff/CodeDiff.test.ts
@@ -2,7 +2,7 @@ import { render } from '@testing-library/vue';
 
 import CodeDiff from './CodeDiff.vue';
 
-const stubs = ['n8n-button', 'n8n-icon'];
+const stubs = ['N8nButton', 'N8nIcon'];
 
 describe('CodeDiff', () => {
 	it('renders code diff correctly', () => {

--- a/packages/frontend/@n8n/design-system/src/components/N8nActionBox/ActionBox.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nActionBox/ActionBox.test.ts
@@ -14,7 +14,7 @@ describe('N8NActionBox', () => {
 				buttonType: 'primary',
 			},
 			global: {
-				stubs: ['n8n-heading', 'n8n-text', 'n8n-button', 'n8n-callout'],
+				stubs: ['N8nHeading', 'N8nText', 'N8nButton', 'N8nCallout'],
 			},
 		});
 		expect(wrapper.html()).toMatchSnapshot();

--- a/packages/frontend/@n8n/design-system/src/components/N8nActionDropdown/ActionDropdown.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nActionDropdown/ActionDropdown.test.ts
@@ -19,7 +19,7 @@ describe('components', () => {
 					],
 				},
 				global: {
-					stubs: ['n8n-icon', 'el-tooltip', 'el-dropdown', 'el-dropdown-menu', 'el-dropdown-item'],
+					stubs: ['N8nIcon', 'ElTooltip', 'ElDropdown', 'ElDropdownMenu', 'ElDropdownItem'],
 				},
 			});
 			expect(wrapper.html()).toMatchSnapshot();
@@ -49,7 +49,7 @@ describe('components', () => {
 					],
 				},
 				global: {
-					stubs: ['n8n-icon', 'el-dropdown', 'el-dropdown-menu', 'el-dropdown-item'],
+					stubs: ['N8nIcon', 'ElDropdown', 'ElDropdownMenu', 'ElDropdownItem'],
 				},
 			});
 			expect(wrapper.html()).toMatchSnapshot();

--- a/packages/frontend/@n8n/design-system/src/components/N8nAlert/Alert.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nAlert/Alert.test.ts
@@ -24,7 +24,7 @@ describe('components', () => {
 				},
 				global: {
 					components: {
-						'n8n-icon': {
+						N8nIcon: {
 							template: '<span class="n8n-icon" />',
 							props: ['icon'],
 						},

--- a/packages/frontend/@n8n/design-system/src/components/N8nBadge/Badge.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nBadge/Badge.test.ts
@@ -16,7 +16,7 @@ describe('components', () => {
 						default: '<n8n-text>Default badge</n8n-text>',
 					},
 					global: {
-						stubs: ['n8n-text'],
+						stubs: ['N8nText'],
 					},
 				});
 				expect(wrapper.html()).toMatchSnapshot();
@@ -32,7 +32,7 @@ describe('components', () => {
 						default: '<n8n-text>Secondary badge</n8n-text>',
 					},
 					global: {
-						stubs: ['n8n-text'],
+						stubs: ['N8nText'],
 					},
 				});
 				expect(wrapper.html()).toMatchSnapshot();
@@ -43,7 +43,7 @@ describe('components', () => {
 						default: '<n8n-text>A Badge</n8n-text>',
 					},
 					global: {
-						stubs: ['n8n-text'],
+						stubs: ['N8nText'],
 					},
 				});
 				expect(wrapper.html()).toMatchSnapshot();

--- a/packages/frontend/@n8n/design-system/src/components/N8nBlockUi/BlockUi.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nBlockUi/BlockUi.vue
@@ -9,14 +9,14 @@ withDefaults(defineProps<BlockUiProps>(), {
 </script>
 
 <template>
-	<transition name="fade" mode="out-in">
+	<Transition name="fade" mode="out-in">
 		<div
 			v-show="show"
 			:class="['n8n-block-ui', $style.uiBlocker]"
 			role="dialog"
 			:aria-hidden="true"
 		/>
-	</transition>
+	</Transition>
 </template>
 
 <style lang="scss" module>

--- a/packages/frontend/@n8n/design-system/src/components/N8nBreadcrumbs/BreadCrumbs.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nBreadcrumbs/BreadCrumbs.test.ts
@@ -198,7 +198,7 @@ describe('Breadcrumbs', async () => {
 			},
 			global: {
 				stubs: {
-					'n8n-action-toggle': N8nActionToggleMock,
+					N8nActionToggle: N8nActionToggleMock,
 				},
 				plugins: [router],
 			},
@@ -242,7 +242,7 @@ describe('Breadcrumbs', async () => {
 			},
 			global: {
 				stubs: {
-					'n8n-action-toggle': N8nActionToggleMock,
+					N8nActionToggle: N8nActionToggleMock,
 				},
 				plugins: [router],
 			},
@@ -285,7 +285,7 @@ describe('Breadcrumbs', async () => {
 			},
 			global: {
 				stubs: {
-					'n8n-action-toggle': N8nActionToggleMock,
+					N8nActionToggle: N8nActionToggleMock,
 				},
 				plugins: [router],
 			},
@@ -318,7 +318,7 @@ describe('Breadcrumbs', async () => {
 			},
 			global: {
 				stubs: {
-					'n8n-action-toggle': N8nActionToggleMock,
+					N8nActionToggle: N8nActionToggleMock,
 				},
 				plugins: [router],
 			},

--- a/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.test.ts
@@ -5,7 +5,7 @@ import N8nButton from './Button.vue';
 const slots = {
 	default: 'Button',
 };
-const stubs = ['n8n-spinner', 'n8n-icon'];
+const stubs = ['N8nSpinner', 'N8nIcon'];
 
 describe('components', () => {
 	describe('N8nButton', () => {

--- a/packages/frontend/@n8n/design-system/src/components/N8nCallout/Callout.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nCallout/Callout.test.ts
@@ -10,7 +10,7 @@ describe('components', () => {
 					theme: 'info',
 				},
 				global: {
-					stubs: ['n8n-icon', 'n8n-text'],
+					stubs: ['N8nIcon', 'N8nText'],
 				},
 				slots: {
 					default: '<n8n-text size="small">This is an info callout.</n8n-text>',
@@ -24,7 +24,7 @@ describe('components', () => {
 					theme: 'success',
 				},
 				global: {
-					stubs: ['n8n-icon', 'n8n-text'],
+					stubs: ['N8nIcon', 'N8nText'],
 				},
 				slots: {
 					default: '<n8n-text size="small">This is a success callout.</n8n-text>',
@@ -38,7 +38,7 @@ describe('components', () => {
 					theme: 'warning',
 				},
 				global: {
-					stubs: ['n8n-icon', 'n8n-text'],
+					stubs: ['N8nIcon', 'N8nText'],
 				},
 				slots: {
 					default: '<n8n-text size="small">This is a warning callout.</n8n-text>',
@@ -52,7 +52,7 @@ describe('components', () => {
 					theme: 'danger',
 				},
 				global: {
-					stubs: ['n8n-icon', 'n8n-text'],
+					stubs: ['N8nIcon', 'N8nText'],
 				},
 				slots: {
 					default: '<n8n-text size="small">This is a danger callout.</n8n-text>',
@@ -66,7 +66,7 @@ describe('components', () => {
 					theme: 'secondary',
 				},
 				global: {
-					stubs: ['n8n-icon', 'n8n-text'],
+					stubs: ['N8nIcon', 'N8nText'],
 				},
 				slots: {
 					default: '<n8n-text size="small">This is a secondary callout.</n8n-text>',
@@ -81,7 +81,7 @@ describe('components', () => {
 					icon: 'git-branch',
 				},
 				global: {
-					stubs: ['n8n-icon', 'n8n-text'],
+					stubs: ['N8nIcon', 'N8nText'],
 				},
 				slots: {
 					default: '<n8n-text size="small">This is a secondary callout.</n8n-text>',
@@ -96,7 +96,7 @@ describe('components', () => {
 					icon: 'git-branch',
 				},
 				global: {
-					stubs: ['n8n-icon', 'n8n-text', 'n8n-link'],
+					stubs: ['N8nIcon', 'N8nText', 'N8nLink'],
 				},
 				slots: {
 					default: '<n8n-text size="small">This is a secondary callout.</n8n-text>',

--- a/packages/frontend/@n8n/design-system/src/components/N8nDatatable/Datatable.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDatatable/Datatable.test.ts
@@ -6,8 +6,8 @@ import { rows, columns } from './__tests__/data';
 import N8nDatatable from './Datatable.vue';
 
 const stubs = [
-	'n8n-option',
-	'n8n-button',
+	'N8nOption',
+	'N8nButton',
 	// Ideally we'd like to stub N8nSelect & N8nPagination, but it doesn't work
 	// after migrating to setup script:
 	// https://github.com/vuejs/vue-test-utils/issues/2048

--- a/packages/frontend/@n8n/design-system/src/components/N8nExternalLink/ExternalLink.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nExternalLink/ExternalLink.test.ts
@@ -2,7 +2,7 @@ import { render } from '@testing-library/vue';
 
 import N8nExternalLink from './ExternalLink.vue';
 
-const stubs = ['n8n-icon'];
+const stubs = ['N8nIcon'];
 
 describe('components', () => {
 	describe('N8nExternalLink', () => {

--- a/packages/frontend/@n8n/design-system/src/components/N8nInfoTip/InfoTip.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInfoTip/InfoTip.test.ts
@@ -5,7 +5,7 @@ import N8nInfoTip from './InfoTip.vue';
 const slots = {
 	default: ['Need help doing something?', '<a href="/docs" target="_blank">Open docs</a>'],
 };
-const stubs = ['n8n-tooltip', 'n8n-icon'];
+const stubs = ['N8nTooltip', 'N8nIcon'];
 
 describe('N8nInfoTip', () => {
 	it('should render correctly as note', () => {

--- a/packages/frontend/@n8n/design-system/src/components/N8nNotice/Notice.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nNotice/Notice.test.ts
@@ -16,7 +16,7 @@ describe('components', () => {
 					default: 'This is a notice.',
 				},
 				global: {
-					stubs: ['n8n-text'],
+					stubs: ['N8nText'],
 				},
 			});
 			expect(wrapper.html()).toMatchSnapshot();
@@ -31,7 +31,7 @@ describe('components', () => {
 							content: 'This is a notice.',
 						},
 						global: {
-							stubs: ['n8n-text'],
+							stubs: ['N8nText'],
 						},
 					});
 					expect(wrapper.html()).toMatchSnapshot();
@@ -48,7 +48,7 @@ describe('components', () => {
 								n8nHtml,
 							},
 							components: {
-								'n8n-text': N8nText,
+								N8nText,
 							},
 						},
 					});
@@ -64,7 +64,7 @@ describe('components', () => {
 							content: '<script>alert(1);</script> This is a notice.',
 						},
 						global: {
-							stubs: ['n8n-text'],
+							stubs: ['N8nText'],
 						},
 					});
 

--- a/packages/frontend/@n8n/design-system/src/components/N8nSelectableList/SelectableList.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nSelectableList/SelectableList.test.ts
@@ -20,7 +20,7 @@ describe('N8nSelectableList', () => {
 				inputs: [{ name: 'propA', initialValue: '' }],
 			},
 			global: {
-				stubs: ['n8n-icon'],
+				stubs: ['N8nIcon'],
 			},
 		});
 
@@ -53,7 +53,7 @@ describe('N8nSelectableList', () => {
 				],
 			},
 			global: {
-				stubs: ['n8n-icon'],
+				stubs: ['N8nIcon'],
 			},
 		});
 
@@ -94,7 +94,7 @@ describe('N8nSelectableList', () => {
 				],
 			},
 			global: {
-				stubs: ['n8n-icon'],
+				stubs: ['N8nIcon'],
 			},
 		});
 

--- a/packages/frontend/@n8n/design-system/src/components/N8nSuggestedActions/SuggestedActions.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nSuggestedActions/SuggestedActions.test.ts
@@ -35,18 +35,18 @@ const MockN8nPopoverReka = {
 };
 
 const stubs = {
-	'n8n-text': { template: '<span><slot /></span>' },
-	'n8n-link': {
+	N8nText: { template: '<span><slot /></span>' },
+	N8nLink: {
 		props: ['to', 'href'],
 		template: '<a :href="to || href"><slot /></a>',
 	},
-	'n8n-icon': true,
-	'n8n-heading': { template: '<h4><slot /></h4>' },
-	'n8n-tag': {
+	N8nIcon: true,
+	N8nHeading: { template: '<h4><slot /></h4>' },
+	N8nTag: {
 		props: ['text'],
 		template: '<span>{{ text }}</span>',
 	},
-	'n8n-callout': {
+	N8nCallout: {
 		props: ['theme'],
 		template: '<div data-test-id="n8n-callout" :class="theme"><slot /></div>',
 	},

--- a/packages/frontend/editor-ui/src/__tests__/render.ts
+++ b/packages/frontend/editor-ui/src/__tests__/render.ts
@@ -37,8 +37,8 @@ const TestingGlobalComponentsPlugin: Plugin<{}> = {
 const defaultOptions = {
 	global: {
 		stubs: {
-			'router-link': true,
-			'vue-json-pretty': vueJsonPretty,
+			RouterLink: true,
+			VueJsonPretty: vueJsonPretty,
 		},
 		plugins: [
 			i18nInstance,

--- a/packages/frontend/editor-ui/src/components/AboutModal.vue
+++ b/packages/frontend/editor-ui/src/components/AboutModal.vue
@@ -58,66 +58,66 @@ const copyDebugInfoToClipboard = async () => {
 	>
 		<template #content>
 			<div :class="$style.container">
-				<el-row>
-					<el-col :span="8" class="info-name">
-						<n8n-text>{{ i18n.baseText('about.n8nVersion') }}</n8n-text>
-					</el-col>
-					<el-col :span="16">
-						<n8n-text>{{ rootStore.versionCli }}</n8n-text>
-					</el-col>
-				</el-row>
-				<el-row>
-					<el-col :span="8" class="info-name">
-						<n8n-text>{{ i18n.baseText('about.sourceCode') }}</n8n-text>
-					</el-col>
-					<el-col :span="16">
-						<n8n-link to="https://github.com/n8n-io/n8n">https://github.com/n8n-io/n8n</n8n-link>
-					</el-col>
-				</el-row>
-				<el-row>
-					<el-col :span="8" class="info-name">
-						<n8n-text>{{ i18n.baseText('about.license') }}</n8n-text>
-					</el-col>
-					<el-col :span="16">
-						<n8n-link to="https://github.com/n8n-io/n8n/blob/master/LICENSE.md">
+				<ElRow>
+					<ElCol :span="8" class="info-name">
+						<N8nText>{{ i18n.baseText('about.n8nVersion') }}</N8nText>
+					</ElCol>
+					<ElCol :span="16">
+						<N8nText>{{ rootStore.versionCli }}</N8nText>
+					</ElCol>
+				</ElRow>
+				<ElRow>
+					<ElCol :span="8" class="info-name">
+						<N8nText>{{ i18n.baseText('about.sourceCode') }}</N8nText>
+					</ElCol>
+					<ElCol :span="16">
+						<N8nLink to="https://github.com/n8n-io/n8n">https://github.com/n8n-io/n8n</N8nLink>
+					</ElCol>
+				</ElRow>
+				<ElRow>
+					<ElCol :span="8" class="info-name">
+						<N8nText>{{ i18n.baseText('about.license') }}</N8nText>
+					</ElCol>
+					<ElCol :span="16">
+						<N8nLink to="https://github.com/n8n-io/n8n/blob/master/LICENSE.md">
 							{{ i18n.baseText('about.n8nLicense') }}
-						</n8n-link>
-					</el-col>
-				</el-row>
-				<el-row>
-					<el-col :span="8" class="info-name">
-						<n8n-text>{{ i18n.baseText('about.thirdPartyLicenses') }}</n8n-text>
-					</el-col>
-					<el-col :span="16">
-						<n8n-link @click="downloadThirdPartyLicenses">
+						</N8nLink>
+					</ElCol>
+				</ElRow>
+				<ElRow>
+					<ElCol :span="8" class="info-name">
+						<N8nText>{{ i18n.baseText('about.thirdPartyLicenses') }}</N8nText>
+					</ElCol>
+					<ElCol :span="16">
+						<N8nLink @click="downloadThirdPartyLicenses">
 							{{ i18n.baseText('about.thirdPartyLicensesLink') }}
-						</n8n-link>
-					</el-col>
-				</el-row>
-				<el-row>
-					<el-col :span="8" class="info-name">
-						<n8n-text>{{ i18n.baseText('about.instanceID') }}</n8n-text>
-					</el-col>
-					<el-col :span="16">
-						<n8n-text>{{ rootStore.instanceId }}</n8n-text>
-					</el-col>
-				</el-row>
-				<el-row>
-					<el-col :span="8" class="info-name">
-						<n8n-text>{{ i18n.baseText('about.debug.title') }}</n8n-text>
-					</el-col>
-					<el-col :span="16">
+						</N8nLink>
+					</ElCol>
+				</ElRow>
+				<ElRow>
+					<ElCol :span="8" class="info-name">
+						<N8nText>{{ i18n.baseText('about.instanceID') }}</N8nText>
+					</ElCol>
+					<ElCol :span="16">
+						<N8nText>{{ rootStore.instanceId }}</N8nText>
+					</ElCol>
+				</ElRow>
+				<ElRow>
+					<ElCol :span="8" class="info-name">
+						<N8nText>{{ i18n.baseText('about.debug.title') }}</N8nText>
+					</ElCol>
+					<ElCol :span="16">
 						<div :class="$style.debugInfo" @click="copyDebugInfoToClipboard">
-							<n8n-link>{{ i18n.baseText('about.debug.message') }}</n8n-link>
+							<N8nLink>{{ i18n.baseText('about.debug.message') }}</N8nLink>
 						</div>
-					</el-col>
-				</el-row>
+					</ElCol>
+				</ElRow>
 			</div>
 		</template>
 
 		<template #footer>
 			<div class="action-buttons">
-				<n8n-button
+				<N8nButton
 					float="right"
 					:label="i18n.baseText('about.close')"
 					data-test-id="close-about-modal-button"

--- a/packages/frontend/editor-ui/src/components/ActivationModal.vue
+++ b/packages/frontend/editor-ui/src/components/ActivationModal.vue
@@ -98,29 +98,29 @@ const handleCheckboxChange = (checkboxValue: boolean) => {
 	>
 		<template #content>
 			<div>
-				<n8n-text>{{ triggerContent }}</n8n-text>
+				<N8nText>{{ triggerContent }}</N8nText>
 			</div>
 			<div :class="$style.spaced">
-				<n8n-text>
-					<n8n-text :bold="true">
+				<N8nText>
+					<N8nText :bold="true">
 						{{ i18n.baseText('activationModal.theseExecutionsWillNotShowUp') }}
-					</n8n-text>
+					</N8nText>
 					{{ i18n.baseText('activationModal.butYouCanSeeThem') }}
 					<a @click="showExecutionsList">
 						{{ i18n.baseText('activationModal.executionList') }}
 					</a>
 					{{ i18n.baseText('activationModal.ifYouChooseTo') }}
 					<a @click="showSettings">{{ i18n.baseText('activationModal.saveExecutions') }}</a>
-				</n8n-text>
+				</N8nText>
 			</div>
 		</template>
 
 		<template #footer="{ close }">
 			<div :class="$style.footer">
-				<el-checkbox :model-value="checked" @update:model-value="handleCheckboxChange">{{
+				<ElCheckbox :model-value="checked" @update:model-value="handleCheckboxChange">{{
 					i18n.baseText('generic.dontShowAgain')
-				}}</el-checkbox>
-				<n8n-button :label="i18n.baseText('activationModal.gotIt')" @click="close" />
+				}}</ElCheckbox>
+				<N8nButton :label="i18n.baseText('activationModal.gotIt')" @click="close" />
 			</div>
 		</template>
 	</Modal>

--- a/packages/frontend/editor-ui/src/components/ApiKeyCard.vue
+++ b/packages/frontend/editor-ui/src/components/ApiKeyCard.vue
@@ -57,20 +57,20 @@ const getExpirationTime = (apiKey: ApiKey): string => {
 </script>
 
 <template>
-	<n8n-card :class="$style.cardLink" data-test-id="api-key-card" @click="onAction('edit')">
+	<N8nCard :class="$style.cardLink" data-test-id="api-key-card" @click="onAction('edit')">
 		<template #header>
 			<div>
-				<n8n-text tag="h2" bold :class="$style.cardHeading">
+				<N8nText tag="h2" bold :class="$style.cardHeading">
 					{{ apiKey.label }}
-				</n8n-text>
+				</N8nText>
 				<div :class="[$style.cardDescription]">
-					<n8n-text :color="!hasApiKeyExpired(apiKey) ? 'text-light' : 'warning'" size="small">
+					<N8nText :color="!hasApiKeyExpired(apiKey) ? 'text-light' : 'warning'" size="small">
 						<span>{{ getExpirationTime(apiKey) }}</span>
-					</n8n-text>
+					</N8nText>
 				</div>
 			</div>
 			<div v-if="apiKey.apiKey.includes('*')" :class="$style.cardApiKey">
-				<n8n-text color="text-light" size="small"> {{ apiKey.apiKey }}</n8n-text>
+				<N8nText color="text-light" size="small"> {{ apiKey.apiKey }}</N8nText>
 			</div>
 		</template>
 
@@ -79,7 +79,7 @@ const getExpirationTime = (apiKey: ApiKey): string => {
 				<N8nActionToggle :actions="ACTION_LIST" theme="dark" @action="onAction" />
 			</div>
 		</template>
-	</n8n-card>
+	</N8nCard>
 </template>
 
 <style lang="scss" module>

--- a/packages/frontend/editor-ui/src/components/ApiKeyCreateOrEditModal.vue
+++ b/packages/frontend/editor-ui/src/components/ApiKeyCreateOrEditModal.vue
@@ -250,7 +250,7 @@ async function handleEnterKey(event: KeyboardEvent) {
 	>
 		<template #content>
 			<div @keyup.enter="handleEnterKey">
-				<n8n-card v-if="newApiKey" class="mb-4xs">
+				<N8nCard v-if="newApiKey" class="mb-4xs">
 					<CopyInput
 						:label="newApiKey.label"
 						:value="newApiKey.rawApiKey"
@@ -259,7 +259,7 @@ async function handleEnterKey(event: KeyboardEvent) {
 						:toast-title="i18n.baseText('settings.api.view.copy.toast')"
 						:hint="i18n.baseText('settings.api.view.copy')"
 					/>
-				</n8n-card>
+				</N8nCard>
 
 				<div v-else :class="$style.form">
 					<N8nInputLabel
@@ -309,7 +309,7 @@ async function handleEnterKey(event: KeyboardEvent) {
 								interpolate: { expirationDate },
 							})
 						}}</N8nText>
-						<el-date-picker
+						<ElDatePicker
 							v-if="showExpirationDateSelector"
 							v-model="customExpirationDate"
 							type="date"

--- a/packages/frontend/editor-ui/src/components/ApiKeyScopes.vue
+++ b/packages/frontend/editor-ui/src/components/ApiKeyScopes.vue
@@ -95,14 +95,14 @@ function goToUpgradeApiKeyScopes() {
 				:append-to="popperContainer"
 			>
 				<template #header>
-					<el-checkbox
+					<ElCheckbox
 						v-model="checkAll"
 						:disabled="!enabled"
 						:class="$style['scopes-checkbox']"
 						:indeterminate="indeterminate"
 					>
 						{{ i18n.baseText('settings.api.scopes.selectAll') }}
-					</el-checkbox>
+					</ElCheckbox>
 				</template>
 
 				<template v-for="(actions, resource) in groupedScopes" :key="resource">
@@ -120,9 +120,9 @@ function goToUpgradeApiKeyScopes() {
 		<N8nNotice v-if="!enabled">
 			<I18nT keypath="settings.api.scopes.upgrade" scope="global">
 				<template #link>
-					<n8n-link size="small" @click="goToUpgradeApiKeyScopes">
+					<N8nLink size="small" @click="goToUpgradeApiKeyScopes">
 						{{ i18n.baseText('generic.upgrade') }}
-					</n8n-link>
+					</N8nLink>
 				</template>
 			</I18nT>
 		</N8nNotice>

--- a/packages/frontend/editor-ui/src/components/AskAssistant/Agent/AskAssistantBuild.vue
+++ b/packages/frontend/editor-ui/src/components/AskAssistant/Agent/AskAssistantBuild.vue
@@ -209,9 +209,9 @@ watch(currentRoute, () => {
 				<slot name="header" />
 			</template>
 			<template #placeholder>
-				<n8n-text :class="$style.topText">{{
+				<N8nText :class="$style.topText">{{
 					i18n.baseText('aiAssistant.builder.assistantPlaceholder')
-				}}</n8n-text>
+				}}</N8nText>
 			</template>
 		</AskAssistantChat>
 	</div>

--- a/packages/frontend/editor-ui/src/components/AskAssistant/Chat/AskAssistantFloatingButton.vue
+++ b/packages/frontend/editor-ui/src/components/AskAssistant/Chat/AskAssistantFloatingButton.vue
@@ -36,7 +36,7 @@ const onClick = () => {
 
 <template>
 	<div :class="$style.container" data-test-id="ask-assistant-floating-button">
-		<n8n-tooltip
+		<N8nTooltip
 			:z-index="APP_Z_INDEXES.ASK_ASSISTANT_FLOATING_BUTTON_TOOLTIP"
 			placement="top"
 			:visible="!!lastUnread"
@@ -50,7 +50,7 @@ const onClick = () => {
 				</div>
 			</template>
 			<AskAssistantButton :unread-count="assistantStore.unreadCount" @click="onClick" />
-		</n8n-tooltip>
+		</N8nTooltip>
 	</div>
 </template>
 

--- a/packages/frontend/editor-ui/src/components/AskAssistant/Chat/NewAssistantSessionModal.vue
+++ b/packages/frontend/editor-ui/src/components/AskAssistant/Chat/NewAssistantSessionModal.vue
@@ -57,17 +57,17 @@ const startNewSession = async () => {
 		<template #content>
 			<div :class="$style.container">
 				<p>
-					<n8n-text>{{ i18n.baseText('aiAssistant.newSessionModal.message') }}</n8n-text>
+					<N8nText>{{ i18n.baseText('aiAssistant.newSessionModal.message') }}</N8nText>
 				</p>
 				<p>
-					<n8n-text>{{ i18n.baseText('aiAssistant.newSessionModal.question') }}</n8n-text>
+					<N8nText>{{ i18n.baseText('aiAssistant.newSessionModal.question') }}</N8nText>
 				</p>
 			</div>
 		</template>
 		<template #footer>
 			<div :class="$style.footer">
-				<n8n-button :label="i18n.baseText('generic.cancel')" type="secondary" @click="close" />
-				<n8n-button
+				<N8nButton :label="i18n.baseText('generic.cancel')" type="secondary" @click="close" />
+				<N8nButton
 					:label="i18n.baseText('aiAssistant.newSessionModal.confirm')"
 					@click="startNewSession"
 				/>

--- a/packages/frontend/editor-ui/src/components/AskAssistant/HubSwitcher.vue
+++ b/packages/frontend/editor-ui/src/components/AskAssistant/HubSwitcher.vue
@@ -23,7 +23,7 @@ function toggle(value: boolean) {
 </script>
 
 <template>
-	<n8n-radio-buttons
+	<N8nRadioButtons
 		size="small"
 		:model-value="isBuildMode"
 		:options="options"

--- a/packages/frontend/editor-ui/src/components/AssignmentCollection/AssignmentCollection.vue
+++ b/packages/frontend/editor-ui/src/components/AssignmentCollection/AssignmentCollection.vue
@@ -135,7 +135,7 @@ function optionSelected(action: string) {
 		:class="{ [$style.assignmentCollection]: true, [$style.empty]: empty }"
 		:data-test-id="`assignment-collection-${parameter.name}`"
 	>
-		<n8n-input-label
+		<N8nInputLabel
 			:label="parameter.displayName"
 			:show-expression-selector="false"
 			size="small"
@@ -152,7 +152,7 @@ function optionSelected(action: string) {
 					@update:model-value="optionSelected"
 				/>
 			</template>
-		</n8n-input-label>
+		</N8nInputLabel>
 
 		<ExperimentalEmbeddedNdvMapper
 			v-if="

--- a/packages/frontend/editor-ui/src/components/AssignmentCollection/TypeSelect.vue
+++ b/packages/frontend/editor-ui/src/components/AssignmentCollection/TypeSelect.vue
@@ -30,7 +30,7 @@ const onTypeChange = (type: string): void => {
 </script>
 
 <template>
-	<n8n-select
+	<N8nSelect
 		data-test-id="assignment-type-select"
 		size="small"
 		:model-value="modelValue"
@@ -38,23 +38,23 @@ const onTypeChange = (type: string): void => {
 		@update:model-value="onTypeChange"
 	>
 		<template #prefix>
-			<n8n-icon :class="$style.icon" :icon="icon" color="text-light" size="small" />
+			<N8nIcon :class="$style.icon" :icon="icon" color="text-light" size="small" />
 		</template>
-		<n8n-option
+		<N8nOption
 			v-for="option in types"
 			:key="option.type"
 			:value="option.type"
 			:label="i18n.baseText(`type.${option.type}` as BaseTextKey)"
 			:class="$style.option"
 		>
-			<n8n-icon
+			<N8nIcon
 				:icon="option.icon"
 				:color="modelValue === option.type ? 'primary' : 'text-light'"
 				size="small"
 			/>
 			<span>{{ i18n.baseText(`type.${option.type}` as BaseTextKey) }}</span>
-		</n8n-option>
-	</n8n-select>
+		</N8nOption>
+	</N8nSelect>
 </template>
 
 <style lang="scss" module>

--- a/packages/frontend/editor-ui/src/components/Badge.vue
+++ b/packages/frontend/editor-ui/src/components/Badge.vue
@@ -5,7 +5,7 @@ export default {
 </script>
 
 <template>
-	<el-tag
+	<ElTag
 		v-if="type === 'danger'"
 		type="danger"
 		size="small"
@@ -13,15 +13,15 @@ export default {
 		:disable-transitions="true"
 	>
 		{{ text }}
-	</el-tag>
-	<el-tag
+	</ElTag>
+	<ElTag
 		v-else-if="type === 'warning'"
 		size="small"
 		:class="$style['warning']"
 		:disable-transitions="true"
 	>
 		{{ text }}
-	</el-tag>
+	</ElTag>
 </template>
 
 <style lang="scss" module>

--- a/packages/frontend/editor-ui/src/components/Banner.vue
+++ b/packages/frontend/editor-ui/src/components/Banner.vue
@@ -36,8 +36,8 @@ const onClick = () => {
 </script>
 
 <template>
-	<el-tag :type="theme" :disable-transitions="true" :class="$style.container">
-		<n8n-icon
+	<ElTag :type="theme" :disable-transitions="true" :class="$style.container">
+		<N8nIcon
 			:icon="theme === 'success' ? 'circle-check' : 'triangle-alert'"
 			:class="theme === 'success' ? $style.icon : $style.dangerIcon"
 		/>
@@ -47,14 +47,14 @@ const onClick = () => {
 					<span :class="theme === 'success' ? $style.message : $style.dangerMessage">
 						{{ message }}&nbsp;
 					</span>
-					<n8n-link v-if="details && !expanded" :bold="true" size="small" @click="expand">
+					<N8nLink v-if="details && !expanded" :bold="true" size="small" @click="expand">
 						<span :class="$style.moreDetails">More details</span>
-					</n8n-link>
+					</N8nLink>
 				</div>
 			</div>
 
 			<slot v-if="$slots.button" name="button" />
-			<n8n-button
+			<N8nButton
 				v-else-if="buttonLabel"
 				:label="buttonLoading && buttonLoadingLabel ? buttonLoadingLabel : buttonLabel"
 				:title="buttonTitle"
@@ -69,7 +69,7 @@ const onClick = () => {
 		<div v-if="expanded" :class="$style.details">
 			{{ details }}
 		</div>
-	</el-tag>
+	</ElTag>
 </template>
 
 <style module lang="scss">

--- a/packages/frontend/editor-ui/src/components/BecomeTemplateCreatorCta/BecomeTemplateCreatorCta.vue
+++ b/packages/frontend/editor-ui/src/components/BecomeTemplateCreatorCta/BecomeTemplateCreatorCta.vue
@@ -28,11 +28,11 @@ const onClick = () => {
 				data-test-id="close-become-template-creator-cta"
 				@click="store.dismissCta()"
 			>
-				<n8n-icon icon="x" size="xsmall" :title="i18n.baseText('generic.close')" />
+				<N8nIcon icon="x" size="xsmall" :title="i18n.baseText('generic.close')" />
 			</button>
 		</div>
 
-		<n8n-button
+		<N8nButton
 			:class="$style.becomeCreatorButton"
 			:label="i18n.baseText('becomeCreator.buttonText')"
 			size="xmini"

--- a/packages/frontend/editor-ui/src/components/BinaryDataDisplay.vue
+++ b/packages/frontend/editor-ui/src/components/BinaryDataDisplay.vue
@@ -74,7 +74,7 @@ function closeWindow() {
 
 <template>
 	<div v-if="windowVisible" :class="['binary-data-window', binaryData?.fileType]">
-		<n8n-button
+		<N8nButton
 			size="small"
 			class="binary-data-window-back"
 			:title="i18n.baseText('binaryDataDisplay.backToOverviewPage')"

--- a/packages/frontend/editor-ui/src/components/ButtonParameter/ButtonParameter.vue
+++ b/packages/frontend/editor-ui/src/components/ButtonParameter/ButtonParameter.vue
@@ -195,7 +195,7 @@ async function updateCursorPositionOnMouseMove(event: MouseEvent, activeDrop: bo
 
 <template>
 	<div>
-		<n8n-input-label
+		<N8nInputLabel
 			v-if="hasInputField"
 			:label="i18n.nodeText(activeNode?.type).inputLabelDisplayName(parameter, path)"
 			:tooltip-text="i18n.nodeText(activeNode?.type).inputLabelDescription(parameter, path)"
@@ -203,7 +203,7 @@ async function updateCursorPositionOnMouseMove(event: MouseEvent, activeDrop: bo
 			size="small"
 			color="text-dark"
 		>
-		</n8n-input-label>
+		</N8nInputLabel>
 		<div
 			:class="[$style.inputContainer, { [$style.disabled]: isReadOnly }]"
 			:hidden="!hasInputField"

--- a/packages/frontend/editor-ui/src/components/ChangePasswordModal.vue
+++ b/packages/frontend/editor-ui/src/components/ChangePasswordModal.vue
@@ -139,7 +139,7 @@ onMounted(() => {
 		@enter="onSubmitClick"
 	>
 		<template #content>
-			<n8n-form-inputs
+			<N8nFormInputs
 				v-if="config"
 				:inputs="config"
 				:event-bus="formBus"
@@ -149,7 +149,7 @@ onMounted(() => {
 			/>
 		</template>
 		<template #footer>
-			<n8n-button
+			<N8nButton
 				:loading="loading"
 				:label="i18n.baseText('auth.changePassword')"
 				float="right"

--- a/packages/frontend/editor-ui/src/components/ChatEmbedModal.vue
+++ b/packages/frontend/editor-ui/src/components/ChatEmbedModal.vue
@@ -149,25 +149,25 @@ function closeDialog() {
 	>
 		<template #content>
 			<div :class="$style.container">
-				<n8n-tabs v-model="currentTab" :options="tabs" />
+				<N8nTabs v-model="currentTab" :options="tabs" />
 
 				<div v-if="currentTab !== 'cdn'">
 					<div class="mb-s">
-						<n8n-text>
+						<N8nText>
 							{{ i18n.baseText('chatEmbed.install') }}
-						</n8n-text>
+						</N8nText>
 					</div>
 					<HtmlEditor :model-value="commonCode.install" is-read-only />
 				</div>
 
 				<div class="mb-s">
-					<n8n-text>
+					<N8nText>
 						<I18nT :keypath="`chatEmbed.paste.${currentTab}`" scope="global">
 							<template #code>
 								<code>{{ i18n.baseText(`chatEmbed.paste.${currentTab}.file`) }}</code>
 							</template>
 						</I18nT>
-					</n8n-text>
+					</N8nText>
 				</div>
 
 				<HtmlEditor v-if="currentTab === 'cdn'" :model-value="cdnCode" is-read-only />
@@ -175,22 +175,22 @@ function closeDialog() {
 				<JsEditor v-if="currentTab === 'react'" :model-value="reactCode" is-read-only />
 				<JsEditor v-if="currentTab === 'other'" :model-value="otherCode" is-read-only />
 
-				<n8n-text>
+				<N8nText>
 					{{ i18n.baseText('chatEmbed.packageInfo.description') }}
-					<n8n-link :href="i18n.baseText('chatEmbed.url')" new-window bold>
+					<N8nLink :href="i18n.baseText('chatEmbed.url')" new-window bold>
 						{{ i18n.baseText('chatEmbed.packageInfo.link') }}
-					</n8n-link>
-				</n8n-text>
+					</N8nLink>
+				</N8nText>
 
-				<n8n-info-tip class="mt-s">
+				<N8nInfoTip class="mt-s">
 					{{ i18n.baseText('chatEmbed.chatTriggerNode') }}
-				</n8n-info-tip>
+				</N8nInfoTip>
 			</div>
 		</template>
 
 		<template #footer>
 			<div class="action-buttons">
-				<n8n-button float="right" :label="i18n.baseText('chatEmbed.close')" @click="closeDialog" />
+				<N8nButton float="right" :label="i18n.baseText('chatEmbed.close')" @click="closeDialog" />
 			</div>
 		</template>
 	</Modal>

--- a/packages/frontend/editor-ui/src/components/CodeNodeEditor/AskAI/AskAI.vue
+++ b/packages/frontend/editor-ui/src/components/CodeNodeEditor/AskAI/AskAI.vue
@@ -281,7 +281,7 @@ onMounted(() => {
 					v-text="`${prompt.length} / ${ASK_AI_MAX_PROMPT_LENGTH}`"
 				/>
 				<a href="https://docs.n8n.io/code-examples/ai-code" target="_blank" :class="$style.help">
-					<n8n-icon icon="circle-help" color="text-light" size="large" />{{
+					<N8nIcon icon="circle-help" color="text-light" size="large" />{{
 						i18n.baseText('codeNodeEditor.askAi.help')
 					}}
 				</a>
@@ -289,10 +289,10 @@ onMounted(() => {
 		</div>
 		<div :class="$style.controls">
 			<div v-if="isLoading" :class="$style.loader">
-				<transition name="text-fade-in-out" mode="out-in">
+				<Transition name="text-fade-in-out" mode="out-in">
 					<div :key="loadingPhraseIndex" v-text="loadingString" />
-				</transition>
-				<n8n-circle-loader :radius="8" :progress="loaderProgress" :stroke-width="3" />
+				</Transition>
+				<N8nCircleLoader :radius="8" :progress="loaderProgress" :stroke-width="3" />
 			</div>
 			<N8nTooltip v-else :disabled="isSubmitEnabled">
 				<div>

--- a/packages/frontend/editor-ui/src/components/CodeNodeEditor/CodeNodeEditor.vue
+++ b/packages/frontend/editor-ui/src/components/CodeNodeEditor/CodeNodeEditor.vue
@@ -107,9 +107,7 @@ onBeforeUnmount(() => {
 });
 
 const askAiEnabled = computed(() => {
-	return (
-		props.disableAskAi !== true && settingsStore.isAskAiEnabled && props.language === 'javaScript'
-	);
+	return !props.disableAskAi && settingsStore.isAskAiEnabled && props.language === 'javaScript';
 });
 
 watch([() => props.language, () => props.mode], (_, [prevLanguage, prevMode]) => {
@@ -221,7 +219,7 @@ defineExpose({
 		ref="codeNodeEditorContainerRef"
 		:class="['code-node-editor', $style['code-node-editor-container']]"
 	>
-		<el-tabs
+		<ElTabs
 			v-if="askAiEnabled"
 			ref="tabs"
 			v-model="activeTab"
@@ -229,7 +227,7 @@ defineExpose({
 			:before-leave="onBeforeTabLeave"
 			:class="$style.tabs"
 		>
-			<el-tab-pane
+			<ElTabPane
 				:label="i18n.baseText('codeNodeEditor.tabs.code')"
 				name="code"
 				data-test-id="code-node-tab-code"
@@ -255,8 +253,8 @@ defineExpose({
 					</template>
 				</DraggableTarget>
 				<slot name="suffix" />
-			</el-tab-pane>
-			<el-tab-pane
+			</ElTabPane>
+			<ElTabPane
 				:label="i18n.baseText('codeNodeEditor.tabs.askAi')"
 				name="ask-ai"
 				data-test-id="code-node-tab-ai"
@@ -270,8 +268,8 @@ defineExpose({
 					@started-loading="onAiLoadStart"
 					@finished-loading="onAiLoadEnd"
 				/>
-			</el-tab-pane>
-		</el-tabs>
+			</ElTabPane>
+		</ElTabs>
 		<!-- If AskAi not enabled, there's no point in rendering tabs -->
 		<div v-else :class="$style.fillHeight">
 			<DraggableTarget

--- a/packages/frontend/editor-ui/src/components/CollectionParameter.vue
+++ b/packages/frontend/editor-ui/src/components/CollectionParameter.vue
@@ -169,7 +169,7 @@ function valueChanged(parameterData: IUpdateInformation) {
 	<div class="collection-parameter" @keydown.stop>
 		<div class="collection-parameter-wrapper">
 			<div v-if="getProperties.length === 0" class="no-items-exist">
-				<n8n-text size="small">{{ i18n.baseText('collectionParameter.noProperties') }}</n8n-text>
+				<N8nText size="small">{{ i18n.baseText('collectionParameter.noProperties') }}</N8nText>
 			</div>
 
 			<Suspense>
@@ -185,7 +185,7 @@ function valueChanged(parameterData: IUpdateInformation) {
 			</Suspense>
 
 			<div v-if="parameterOptions.length > 0 && !isReadOnly" class="param-options">
-				<n8n-button
+				<N8nButton
 					v-if="(parameter.options ?? []).length === 1"
 					type="tertiary"
 					block
@@ -193,22 +193,22 @@ function valueChanged(parameterData: IUpdateInformation) {
 					@click="optionSelected((parameter.options ?? [])[0].name)"
 				/>
 				<div v-else class="add-option">
-					<n8n-select
+					<N8nSelect
 						v-model="selectedOption"
 						:placeholder="getPlaceholderText"
 						size="small"
 						filterable
 						@update:model-value="optionSelected"
 					>
-						<n8n-option
+						<N8nOption
 							v-for="item in parameterOptions"
 							:key="item.name"
 							:label="getParameterOptionLabel(item)"
 							:value="item.name"
 							data-test-id="collection-parameter-option"
 						>
-						</n8n-option>
-					</n8n-select>
+						</N8nOption>
+					</N8nSelect>
 				</div>
 			</div>
 		</div>

--- a/packages/frontend/editor-ui/src/components/CollectionWorkflowCard.vue
+++ b/packages/frontend/editor-ui/src/components/CollectionWorkflowCard.vue
@@ -6,15 +6,15 @@ defineProps<{
 </script>
 
 <template>
-	<n8n-card :class="$style.card" v-bind="$attrs">
+	<N8nCard :class="$style.card" v-bind="$attrs">
 		<template v-if="!loading && title" #header>
 			<span :class="$style.title" v-text="title" />
 		</template>
-		<n8n-loading :loading="loading" :rows="3" variant="p" />
+		<N8nLoading :loading="loading" :rows="3" variant="p" />
 		<template v-if="!loading" #footer>
 			<slot name="footer" />
 		</template>
-	</n8n-card>
+	</N8nCard>
 </template>
 
 <style lang="scss" module>

--- a/packages/frontend/editor-ui/src/components/CommunityPackageCard.vue
+++ b/packages/frontend/editor-ui/src/components/CommunityPackageCard.vue
@@ -99,43 +99,43 @@ watch(
 <template>
 	<div :class="$style.cardContainer" data-test-id="community-package-card">
 		<div v-if="loading" :class="$style.cardSkeleton">
-			<n8n-loading :class="$style.loader" variant="p" :rows="1" />
-			<n8n-loading :class="$style.loader" variant="p" :rows="1" />
+			<N8nLoading :class="$style.loader" variant="p" :rows="1" />
+			<N8nLoading :class="$style.loader" variant="p" :rows="1" />
 		</div>
 		<div v-else-if="communityPackage" :class="$style.packageCard">
 			<div :class="$style.cardInfoContainer">
 				<div :class="$style.cardTitle">
-					<n8n-text :bold="true" size="large">{{ communityPackage.packageName }}</n8n-text>
+					<N8nText :bold="true" size="large">{{ communityPackage.packageName }}</N8nText>
 				</div>
 				<div :class="$style.cardSubtitle">
-					<n8n-text :bold="true" size="small" color="text-light">
+					<N8nText :bold="true" size="small" color="text-light">
 						{{
 							i18n.baseText('settings.communityNodes.packageNodes.label', {
 								adjustToNumber: communityPackage.installedNodes.length,
 							})
 						}}:&nbsp;
-					</n8n-text>
-					<n8n-text size="small" color="text-light">
+					</N8nText>
+					<N8nText size="small" color="text-light">
 						<span v-for="(node, index) in communityPackage.installedNodes" :key="node.name">
 							{{ node.name
 							}}<span v-if="index != communityPackage.installedNodes.length - 1">,</span>
 						</span>
-					</n8n-text>
+					</N8nText>
 				</div>
 			</div>
 			<div :class="$style.cardControlsContainer">
-				<n8n-text :bold="true" size="large" color="text-light">
+				<N8nText :bold="true" size="large" color="text-light">
 					v{{ communityPackage.installedVersion }}
-				</n8n-text>
-				<n8n-tooltip v-if="communityPackage.failedLoading === true" placement="top">
+				</N8nText>
+				<N8nTooltip v-if="communityPackage.failedLoading === true" placement="top">
 					<template #content>
 						<div>
 							{{ i18n.baseText('settings.communityNodes.failedToLoad.tooltip') }}
 						</div>
 					</template>
-					<n8n-icon icon="triangle-alert" color="danger" size="large" />
-				</n8n-tooltip>
-				<n8n-tooltip
+					<N8nIcon icon="triangle-alert" color="danger" size="large" />
+				</N8nTooltip>
+				<N8nTooltip
 					v-else-if="hasUnverifiedPackagesUpdate || hasVerifiedPackageUpdate"
 					placement="top"
 				>
@@ -144,18 +144,18 @@ watch(
 							{{ i18n.baseText('settings.communityNodes.updateAvailable.tooltip') }}
 						</div>
 					</template>
-					<n8n-button outline label="Update" @click="onUpdateClick" />
-				</n8n-tooltip>
-				<n8n-tooltip v-else placement="top">
+					<N8nButton outline label="Update" @click="onUpdateClick" />
+				</N8nTooltip>
+				<N8nTooltip v-else placement="top">
 					<template #content>
 						<div>
 							{{ i18n.baseText('settings.communityNodes.upToDate.tooltip') }}
 						</div>
 					</template>
-					<n8n-icon icon="circle-check" color="text-light" size="large" />
-				</n8n-tooltip>
+					<N8nIcon icon="circle-check" color="text-light" size="large" />
+				</N8nTooltip>
 				<div :class="$style.cardActions">
-					<n8n-action-toggle :actions="packageActions" @action="onAction"></n8n-action-toggle>
+					<N8nActionToggle :actions="packageActions" @action="onAction"></N8nActionToggle>
 				</div>
 			</div>
 		</div>

--- a/packages/frontend/editor-ui/src/components/CommunityPackageInstallModal.vue
+++ b/packages/frontend/editor-ui/src/components/CommunityPackageInstallModal.vue
@@ -100,15 +100,15 @@ const onLearnMoreLinkClick = () => {
 		<template #content>
 			<div :class="[$style.descriptionContainer, 'p-s']">
 				<div>
-					<n8n-text>
+					<N8nText>
 						{{ i18n.baseText('settings.communityNodes.installModal.description') }}
-					</n8n-text>
+					</N8nText>
 					{{ ' ' }}
-					<n8n-link :to="COMMUNITY_NODES_INSTALLATION_DOCS_URL" @click="onMoreInfoTopClick">
+					<N8nLink :to="COMMUNITY_NODES_INSTALLATION_DOCS_URL" @click="onMoreInfoTopClick">
 						{{ i18n.baseText('generic.moreInfo') }}
-					</n8n-link>
+					</N8nLink>
 				</div>
-				<n8n-button
+				<N8nButton
 					:label="i18n.baseText('settings.communityNodes.browseButton.label')"
 					icon="external-link"
 					:class="$style.browseButton"
@@ -116,7 +116,7 @@ const onLearnMoreLinkClick = () => {
 				/>
 			</div>
 			<div :class="[$style.formContainer, 'mt-m']">
-				<n8n-input-label
+				<N8nInputLabel
 					:class="$style.labelTooltip"
 					:label="i18n.baseText('settings.communityNodes.installModal.packageName.label')"
 					:tooltip-text="
@@ -125,7 +125,7 @@ const onLearnMoreLinkClick = () => {
 						})
 					"
 				>
-					<n8n-input
+					<N8nInput
 						v-model="packageName"
 						name="packageNameInput"
 						type="text"
@@ -138,7 +138,7 @@ const onLearnMoreLinkClick = () => {
 						:disabled="loading"
 						@blur="onInputBlur"
 					/>
-				</n8n-input-label>
+				</N8nInputLabel>
 				<div :class="[$style.infoText, 'mt-4xs']">
 					<span
 						size="small"
@@ -146,24 +146,24 @@ const onLearnMoreLinkClick = () => {
 						v-text="infoTextErrorMessage"
 					></span>
 				</div>
-				<el-checkbox
+				<ElCheckbox
 					v-model="userAgreed"
 					:class="[$style.checkbox, checkboxWarning ? $style.error : '', 'mt-l']"
 					:disabled="loading"
 					data-test-id="user-agreement-checkbox"
 					@update:model-value="onCheckboxChecked"
 				>
-					<n8n-text>
-						{{ i18n.baseText('settings.communityNodes.installModal.checkbox.label') }} </n8n-text
+					<N8nText>
+						{{ i18n.baseText('settings.communityNodes.installModal.checkbox.label') }} </N8nText
 					><br />
-					<n8n-link :to="COMMUNITY_NODES_RISKS_DOCS_URL" @click="onLearnMoreLinkClick">{{
+					<N8nLink :to="COMMUNITY_NODES_RISKS_DOCS_URL" @click="onLearnMoreLinkClick">{{
 						i18n.baseText('generic.moreInfo')
-					}}</n8n-link>
-				</el-checkbox>
+					}}</N8nLink>
+				</ElCheckbox>
 			</div>
 		</template>
 		<template #footer>
-			<n8n-button
+			<N8nButton
 				:loading="loading"
 				:disabled="!userAgreed || packageName === '' || loading"
 				:label="

--- a/packages/frontend/editor-ui/src/components/CommunityPackageManageConfirmModal.test.ts
+++ b/packages/frontend/editor-ui/src/components/CommunityPackageManageConfirmModal.test.ts
@@ -145,7 +145,7 @@ describe('CommunityPackageManageConfirmModal', () => {
 			},
 			global: {
 				stubs: {
-					'router-link': {
+					RouterLink: {
 						template: '<a><slot /></a>',
 					},
 				},

--- a/packages/frontend/editor-ui/src/components/CommunityPackageManageConfirmModal.vue
+++ b/packages/frontend/editor-ui/src/components/CommunityPackageManageConfirmModal.vue
@@ -243,7 +243,7 @@ onMounted(async () => {
 	>
 		<template #content>
 			<N8nText color="text-dark" :bold="true">{{ getModalContent.message }}</N8nText>
-			<n8n-notice
+			<N8nNotice
 				v-if="!isLatestPackageVerified"
 				data-test-id="communityPackageManageConfirmModal-warning"
 				:content="getModalContent.warning"
@@ -260,7 +260,7 @@ onMounted(async () => {
 			/>
 		</template>
 		<template #footer>
-			<n8n-button
+			<N8nButton
 				:label="i18n.baseText('settings.communityNodes.confirmModal.cancel')"
 				size="large"
 				float="left"
@@ -268,7 +268,7 @@ onMounted(async () => {
 				data-test-id="close-button"
 				@click="onClick"
 			/>
-			<n8n-button
+			<N8nButton
 				:loading="loading"
 				:disabled="loading"
 				:label="loading ? getModalContent.buttonLoadingLabel : getModalContent.buttonLabel"

--- a/packages/frontend/editor-ui/src/components/ConfirmPasswordModal/ConfirmPasswordModal.vue
+++ b/packages/frontend/editor-ui/src/components/ConfirmPasswordModal/ConfirmPasswordModal.vue
@@ -62,10 +62,10 @@ onMounted(() => {
 		@enter="onSubmitClick"
 	>
 		<template #content>
-			<n8n-text :class="$style.description" tag="p">{{
+			<N8nText :class="$style.description" tag="p">{{
 				i18n.baseText('auth.confirmPassword.confirmPasswordToChangeEmail')
-			}}</n8n-text>
-			<n8n-form-inputs
+			}}</N8nText>
+			<N8nFormInputs
 				v-if="config"
 				:inputs="config"
 				:event-bus="formBus"
@@ -74,7 +74,7 @@ onMounted(() => {
 			/>
 		</template>
 		<template #footer>
-			<n8n-button
+			<N8nButton
 				:loading="loading"
 				:label="i18n.baseText('generic.confirm')"
 				float="right"

--- a/packages/frontend/editor-ui/src/components/ContactPromptModal.vue
+++ b/packages/frontend/editor-ui/src/components/ContactPromptModal.vue
@@ -85,24 +85,24 @@ const send = async () => {
 		width="460px"
 	>
 		<template #header>
-			<n8n-heading tag="h2" size="xlarge" color="text-dark">{{ title }}</n8n-heading>
+			<N8nHeading tag="h2" size="xlarge" color="text-dark">{{ title }}</N8nHeading>
 		</template>
 		<template #content>
 			<div :class="$style.description">
-				<n8n-text size="medium" color="text-base">{{ description }}</n8n-text>
+				<N8nText size="medium" color="text-base">{{ description }}</N8nText>
 			</div>
 			<div @keyup.enter="send">
-				<n8n-input v-model="email" placeholder="Your email address" />
+				<N8nInput v-model="email" placeholder="Your email address" />
 			</div>
 			<div :class="$style.disclaimer">
-				<n8n-text size="small" color="text-base"
-					>David from our product team will get in touch personally</n8n-text
+				<N8nText size="small" color="text-base"
+					>David from our product team will get in touch personally</N8nText
 				>
 			</div>
 		</template>
 		<template #footer>
 			<div :class="$style.footer">
-				<n8n-button label="Send" float="right" :disabled="!isEmailValid" @click="send" />
+				<N8nButton label="Send" float="right" :disabled="!isEmailValid" @click="send" />
 			</div>
 		</template>
 	</Modal>

--- a/packages/frontend/editor-ui/src/components/CopyInput.vue
+++ b/packages/frontend/editor-ui/src/components/CopyInput.vue
@@ -49,7 +49,7 @@ function copy() {
 
 <template>
 	<div>
-		<n8n-input-label :label="label">
+		<N8nInputLabel :label="label">
 			<div
 				:class="{
 					[$style.copyText]: true,
@@ -66,7 +66,7 @@ function copy() {
 					<span>{{ copyButtonText }}</span>
 				</div>
 			</div>
-		</n8n-input-label>
+		</N8nInputLabel>
 		<div v-if="hint" :class="$style.hint">{{ hint }}</div>
 	</div>
 </template>

--- a/packages/frontend/editor-ui/src/components/CredentialCard.vue
+++ b/packages/frontend/editor-ui/src/components/CredentialCard.vue
@@ -129,12 +129,12 @@ function moveResource() {
 </script>
 
 <template>
-	<n8n-card :class="$style.cardLink" @click.stop="onClick">
+	<N8nCard :class="$style.cardLink" @click.stop="onClick">
 		<template #prepend>
 			<CredentialIcon :credential-type-name="credentialType?.name ?? ''" />
 		</template>
 		<template #header>
-			<n8n-text tag="h2" bold :class="$style.cardHeading">
+			<N8nText tag="h2" bold :class="$style.cardHeading">
 				{{ data.name }}
 				<N8nBadge v-if="readOnly" class="ml-3xs" theme="tertiary" bold>
 					{{ locale.baseText('credentials.item.readonly') }}
@@ -142,10 +142,10 @@ function moveResource() {
 				<N8nBadge v-if="needsSetup" class="ml-3xs" theme="warning">
 					{{ locale.baseText('credentials.item.needsSetup') }}
 				</N8nBadge>
-			</n8n-text>
+			</N8nText>
 		</template>
 		<div :class="$style.cardDescription">
-			<n8n-text color="text-light" size="small">
+			<N8nText color="text-light" size="small">
 				<span v-if="credentialType">{{ credentialType.displayName }} | </span>
 				<span v-show="data"
 					>{{ locale.baseText('credentials.item.updated') }} <TimeAgo :date="data.updatedAt" /> |
@@ -153,7 +153,7 @@ function moveResource() {
 				<span v-show="data"
 					>{{ locale.baseText('credentials.item.created') }} {{ formattedCreatedAtDate }}
 				</span>
-			</n8n-text>
+			</N8nText>
 		</div>
 		<template #append>
 			<div :class="$style.cardActions" @click.stop>
@@ -165,7 +165,7 @@ function moveResource() {
 					:personal-project="projectsStore.personalProject"
 					:show-badge-border="false"
 				/>
-				<n8n-action-toggle
+				<N8nActionToggle
 					data-test-id="credential-card-actions"
 					:actions="actions"
 					theme="dark"
@@ -173,7 +173,7 @@ function moveResource() {
 				/>
 			</div>
 		</template>
-	</n8n-card>
+	</N8nCard>
 </template>
 
 <style lang="scss" module>

--- a/packages/frontend/editor-ui/src/components/CredentialEdit/AuthTypeSelector.vue
+++ b/packages/frontend/editor-ui/src/components/CredentialEdit/AuthTypeSelector.vue
@@ -135,13 +135,13 @@ defineExpose({
 			/>
 		</div>
 		<div>
-			<n8n-input-label
+			<N8nInputLabel
 				:label="i18n.baseText('credentialEdit.credentialConfig.authTypeSelectorLabel')"
 				:tooltip-text="i18n.baseText('credentialEdit.credentialConfig.authTypeSelectorTooltip')"
 				:required="true"
 			/>
 		</div>
-		<el-radio
+		<ElRadio
 			v-for="prop in filteredNodeAuthOptions"
 			:key="prop.value"
 			v-model="selected"
@@ -149,7 +149,7 @@ defineExpose({
 			:class="$style.authRadioButton"
 			border
 			@update:model-value="onAuthTypeChange"
-			>{{ prop.name }}</el-radio
+			>{{ prop.name }}</ElRadio
 		>
 	</div>
 </template>

--- a/packages/frontend/editor-ui/src/components/CredentialEdit/CredentialConfig.vue
+++ b/packages/frontend/editor-ui/src/components/CredentialEdit/CredentialConfig.vue
@@ -227,9 +227,9 @@ watch(showOAuthSuccessBanner, (newValue, oldValue) => {
 </script>
 
 <template>
-	<n8n-callout v-if="isManaged" theme="warning" icon="triangle-alert">
+	<N8nCallout v-if="isManaged" theme="warning" icon="triangle-alert">
 		{{ i18n.baseText('freeAi.credits.credentials.edit') }}
-	</n8n-callout>
+	</N8nCallout>
 	<div v-else>
 		<div :class="$style.config" data-test-id="node-credentials-config-container">
 			<FreeAiCreditsCallout :credential-type-name="credentialType?.name" />
@@ -296,14 +296,14 @@ watch(showOAuthSuccessBanner, (newValue, oldValue) => {
 			/>
 
 			<template v-if="credentialPermissions.update">
-				<n8n-notice v-if="documentationUrl && credentialProperties.length" theme="warning">
+				<N8nNotice v-if="documentationUrl && credentialProperties.length" theme="warning">
 					{{ i18n.baseText('credentialEdit.credentialConfig.needHelpFillingOutTheseFields') }}
 					<span class="ml-4xs">
-						<n8n-link :to="documentationUrl" size="small" bold @click="onDocumentationUrlClick">
+						<N8nLink :to="documentationUrl" size="small" bold @click="onDocumentationUrlClick">
 							{{ i18n.baseText('credentialEdit.credentialConfig.openDocs') }}
-						</n8n-link>
+						</N8nLink>
 					</span>
-				</n8n-notice>
+				</N8nNotice>
 
 				<AuthTypeSelector
 					v-if="showAuthTypeSelector && isNewCredential"
@@ -338,13 +338,13 @@ watch(showOAuthSuccessBanner, (newValue, oldValue) => {
 			</template>
 			<EnterpriseEdition v-else :features="[EnterpriseEditionFeature.Sharing]">
 				<div>
-					<n8n-info-tip :bold="false">
+					<N8nInfoTip :bold="false">
 						{{
 							i18n.baseText('credentialEdit.credentialEdit.info.sharee', {
 								interpolate: { credentialOwnerName },
 							})
 						}}
-					</n8n-info-tip>
+					</N8nInfoTip>
 				</div>
 			</EnterpriseEdition>
 
@@ -369,18 +369,18 @@ watch(showOAuthSuccessBanner, (newValue, oldValue) => {
 				@click="$emit('oauth')"
 			/>
 
-			<n8n-text v-if="isMissingCredentials" color="text-base" size="medium">
+			<N8nText v-if="isMissingCredentials" color="text-base" size="medium">
 				{{ i18n.baseText('credentialEdit.credentialConfig.missingCredentialType') }}
-			</n8n-text>
+			</N8nText>
 
 			<EnterpriseEdition :features="[EnterpriseEditionFeature.ExternalSecrets]">
 				<template #fallback>
-					<n8n-info-tip class="mt-s">
+					<N8nInfoTip class="mt-s">
 						{{ i18n.baseText('credentialEdit.credentialConfig.externalSecrets') }}
-						<n8n-link bold :to="i18n.baseText('settings.externalSecrets.docs')" size="small">
+						<N8nLink bold :to="i18n.baseText('settings.externalSecrets.docs')" size="small">
 							{{ i18n.baseText('credentialEdit.credentialConfig.externalSecrets.moreInfo') }}
-						</n8n-link>
-					</n8n-info-tip>
+						</N8nLink>
+					</N8nInfoTip>
 				</template>
 			</EnterpriseEdition>
 		</div>

--- a/packages/frontend/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
@@ -1105,7 +1105,7 @@ const { width } = useElementSize(credNameRef);
 					</div>
 				</div>
 				<div :class="$style.credActions">
-					<n8n-icon-button
+					<N8nIconButton
 						v-if="currentCredential && credentialPermissions.delete"
 						:title="i18n.baseText('credentialEdit.credentialEdit.delete')"
 						icon="trash-2"
@@ -1133,12 +1133,12 @@ const { width } = useElementSize(credNameRef);
 		<template #content>
 			<div :class="$style.container" data-test-id="credential-edit-dialog">
 				<div v-if="!isEditingManagedCredential" :class="$style.sidebar">
-					<n8n-menu
+					<N8nMenu
 						mode="tabs"
 						:items="sidebarItems"
 						:transparent-background="true"
 						@select="onTabSelect"
-					></n8n-menu>
+					></N8nMenu>
 				</div>
 				<div
 					v-if="activeTab === 'connection' && credentialType"

--- a/packages/frontend/editor-ui/src/components/CredentialEdit/CredentialInfo.vue
+++ b/packages/frontend/editor-ui/src/components/CredentialEdit/CredentialInfo.vue
@@ -15,40 +15,40 @@ const i18n = useI18n();
 
 <template>
 	<div :class="$style.container">
-		<el-row v-if="currentCredential">
-			<el-col :span="8" :class="$style.label">
+		<ElRow v-if="currentCredential">
+			<ElCol :span="8" :class="$style.label">
 				<N8nText :compact="true" :bold="true">
 					{{ i18n.baseText('credentialEdit.credentialInfo.created') }}
 				</N8nText>
-			</el-col>
-			<el-col :span="16" :class="$style.valueLabel">
+			</ElCol>
+			<ElCol :span="16" :class="$style.valueLabel">
 				<N8nText :compact="true"
 					><TimeAgo :date="currentCredential.createdAt" :capitalize="true"
 				/></N8nText>
-			</el-col>
-		</el-row>
-		<el-row v-if="currentCredential">
-			<el-col :span="8" :class="$style.label">
+			</ElCol>
+		</ElRow>
+		<ElRow v-if="currentCredential">
+			<ElCol :span="8" :class="$style.label">
 				<N8nText :compact="true" :bold="true">
 					{{ i18n.baseText('credentialEdit.credentialInfo.lastModified') }}
 				</N8nText>
-			</el-col>
-			<el-col :span="16" :class="$style.valueLabel">
+			</ElCol>
+			<ElCol :span="16" :class="$style.valueLabel">
 				<N8nText :compact="true"
 					><TimeAgo :date="currentCredential.updatedAt" :capitalize="true"
 				/></N8nText>
-			</el-col>
-		</el-row>
-		<el-row v-if="currentCredential">
-			<el-col :span="8" :class="$style.label">
+			</ElCol>
+		</ElRow>
+		<ElRow v-if="currentCredential">
+			<ElCol :span="8" :class="$style.label">
 				<N8nText :compact="true" :bold="true">
 					{{ i18n.baseText('credentialEdit.credentialInfo.id') }}
 				</N8nText>
-			</el-col>
-			<el-col :span="16" :class="$style.valueLabel">
+			</ElCol>
+			<ElCol :span="16" :class="$style.valueLabel">
 				<N8nText :compact="true">{{ currentCredential.id }}</N8nText>
-			</el-col>
-		</el-row>
+			</ElCol>
+		</ElRow>
 	</div>
 </template>
 

--- a/packages/frontend/editor-ui/src/components/CredentialEdit/CredentialInputs.vue
+++ b/packages/frontend/editor-ui/src/components/CredentialEdit/CredentialInputs.vue
@@ -45,7 +45,7 @@ function valueChanged(parameterData: IUpdateInformation) {
 			@submit.prevent
 		>
 			<!-- Why form? to break up inputs, to prevent Chrome autofill -->
-			<n8n-notice v-if="parameter.type === 'notice'" :content="parameter.displayName" />
+			<N8nNotice v-if="parameter.type === 'notice'" :content="parameter.displayName" />
 			<ParameterInputExpanded
 				v-else
 				:parameter="parameter"

--- a/packages/frontend/editor-ui/src/components/CredentialEdit/OauthButton.test.ts
+++ b/packages/frontend/editor-ui/src/components/CredentialEdit/OauthButton.test.ts
@@ -10,7 +10,7 @@ const renderComponent = createComponentRenderer(OauthButton, {
 describe('OauthButton', () => {
 	test.each([
 		['GoogleAuthButton', true],
-		['n8n-button', false],
+		['N8nButton', false],
 	])('should emit click event only once when %s is clicked', async (_, isGoogleOAuthType) => {
 		const { emitted, getByRole } = renderComponent({
 			props: { isGoogleOAuthType },

--- a/packages/frontend/editor-ui/src/components/CredentialEdit/OauthButton.vue
+++ b/packages/frontend/editor-ui/src/components/CredentialEdit/OauthButton.vue
@@ -11,7 +11,7 @@ const i18n = useI18n();
 <template>
 	<div :class="$style.container">
 		<GoogleAuthButton v-if="isGoogleOAuthType" />
-		<n8n-button
+		<N8nButton
 			v-else
 			:label="i18n.baseText('credentialEdit.oAuthButton.connectMyAccount')"
 			size="large"

--- a/packages/frontend/editor-ui/src/components/CredentialIcon.test.ts
+++ b/packages/frontend/editor-ui/src/components/CredentialIcon.test.ts
@@ -13,7 +13,7 @@ describe('CredentialIcon', () => {
 	const renderComponent = createComponentRenderer(CredentialIcon, {
 		pinia: createTestingPinia(),
 		global: {
-			stubs: ['n8n-tooltip'],
+			stubs: ['N8nTooltip'],
 		},
 	});
 	let pinia: TestingPinia;

--- a/packages/frontend/editor-ui/src/components/CredentialPicker/CredentialPicker.vue
+++ b/packages/frontend/editor-ui/src/components/CredentialPicker/CredentialPicker.vue
@@ -106,7 +106,7 @@ listenForModalChanges({
 				@new-credential="createNewCredential"
 			/>
 
-			<n8n-icon-button
+			<N8nIconButton
 				icon="pen"
 				type="secondary"
 				:class="{
@@ -119,7 +119,7 @@ listenForModalChanges({
 			/>
 		</div>
 
-		<n8n-button
+		<N8nButton
 			v-else
 			:label="`Create new ${props.appName} credential`"
 			data-test-id="create-credential"

--- a/packages/frontend/editor-ui/src/components/CredentialPicker/CredentialsDropdown.vue
+++ b/packages/frontend/editor-ui/src/components/CredentialPicker/CredentialsDropdown.vue
@@ -31,12 +31,12 @@ const onCredentialSelected = (credentialId: string) => {
 </script>
 
 <template>
-	<n8n-select
+	<N8nSelect
 		size="small"
 		:model-value="props.selectedCredentialId"
 		@update:model-value="onCredentialSelected"
 	>
-		<n8n-option
+		<N8nOption
 			v-for="item in props.credentialOptions"
 			:key="item.id"
 			:data-test-id="`node-credentials-select-item-${item.id}`"
@@ -44,18 +44,18 @@ const onCredentialSelected = (credentialId: string) => {
 			:value="item.id"
 		>
 			<div :class="[$style.credentialOption, 'mt-2xs mb-2xs']">
-				<n8n-text bold>{{ item.name }}</n8n-text>
-				<n8n-text size="small">{{ item.typeDisplayName }}</n8n-text>
+				<N8nText bold>{{ item.name }}</N8nText>
+				<N8nText size="small">{{ item.typeDisplayName }}</N8nText>
 			</div>
-		</n8n-option>
-		<n8n-option
+		</N8nOption>
+		<N8nOption
 			:key="NEW_CREDENTIALS_TEXT"
 			data-test-id="node-credentials-select-item-new"
 			:value="NEW_CREDENTIALS_TEXT"
 			:label="NEW_CREDENTIALS_TEXT"
 		>
-		</n8n-option>
-	</n8n-select>
+		</N8nOption>
+	</N8nSelect>
 </template>
 
 <style lang="scss" module>

--- a/packages/frontend/editor-ui/src/components/CredentialsSelectModal.vue
+++ b/packages/frontend/editor-ui/src/components/CredentialsSelectModal.vue
@@ -89,7 +89,7 @@ function openCredentialType() {
 					@update:model-value="onSelect"
 				>
 					<template #prefix>
-						<n8n-icon icon="search" />
+						<N8nIcon icon="search" />
 					</template>
 					<N8nOption
 						v-for="credential in credentialsStore.allCredentialTypes"

--- a/packages/frontend/editor-ui/src/components/DebugPaywallModal.vue
+++ b/packages/frontend/editor-ui/src/components/DebugPaywallModal.vue
@@ -13,21 +13,21 @@ const i18n = useI18n();
 <template>
 	<Modal width="500px" :title="props.data.title" :name="props.modalName">
 		<template #content>
-			<n8n-text>
+			<N8nText>
 				{{ i18n.baseText('executionsList.debug.paywall.content') }}
 				<br />
 				<br />
 				{{ i18n.baseText('executionsList.debug.paywall.subContent') }}
-				<n8n-link :to="i18n.baseText('executionsList.debug.paywall.link.url')" new-window>
+				<N8nLink :to="i18n.baseText('executionsList.debug.paywall.link.url')" new-window>
 					{{ i18n.baseText('executionsList.debug.paywall.link.text') }}
-				</n8n-link>
-			</n8n-text>
+				</N8nLink>
+			</N8nText>
 		</template>
 		<template #footer>
 			<div :class="$style.footer">
-				<n8n-button @click="props.data.footerButtonAction">
+				<N8nButton @click="props.data.footerButtonAction">
 					{{ i18n.baseText('generic.seePlans') }}
-				</n8n-button>
+				</N8nButton>
 			</div>
 		</template>
 	</Modal>

--- a/packages/frontend/editor-ui/src/components/DeleteUserModal.vue
+++ b/packages/frontend/editor-ui/src/components/DeleteUserModal.vue
@@ -126,29 +126,29 @@ async function onSubmit() {
 		<template #content>
 			<div>
 				<div v-if="isPending">
-					<n8n-text color="text-base">{{
+					<N8nText color="text-base">{{
 						i18n.baseText('settings.users.confirmUserDeletion')
-					}}</n8n-text>
+					}}</N8nText>
 				</div>
 				<div v-else :class="$style.content">
 					<div>
-						<n8n-text color="text-base">{{
+						<N8nText color="text-base">{{
 							i18n.baseText('settings.users.confirmDataHandlingAfterDeletion')
-						}}</n8n-text>
+						}}</N8nText>
 					</div>
-					<el-radio
+					<ElRadio
 						v-model="operation"
 						label="transfer"
 						@update:model-value="operation = 'transfer'"
 					>
-						<n8n-text color="text-dark">{{
+						<N8nText color="text-dark">{{
 							i18n.baseText('settings.users.transferWorkflowsAndCredentials')
-						}}</n8n-text>
-					</el-radio>
+						}}</N8nText>
+					</ElRadio>
 					<div v-if="operation === 'transfer'" :class="$style.optionInput">
-						<n8n-text color="text-dark">{{
+						<N8nText color="text-dark">{{
 							i18n.baseText('settings.users.transferWorkflowsAndCredentials.user')
-						}}</n8n-text>
+						}}</N8nText>
 						<ProjectSharing
 							v-model="selectedProject"
 							class="pt-2xs"
@@ -158,28 +158,28 @@ async function onSubmit() {
 							"
 						/>
 					</div>
-					<el-radio v-model="operation" label="delete" @update:model-value="operation = 'delete'">
-						<n8n-text color="text-dark">{{
+					<ElRadio v-model="operation" label="delete" @update:model-value="operation = 'delete'">
+						<N8nText color="text-dark">{{
 							i18n.baseText('settings.users.deleteWorkflowsAndCredentials')
-						}}</n8n-text>
-					</el-radio>
+						}}</N8nText>
+					</ElRadio>
 					<div
 						v-if="operation === 'delete'"
 						:class="$style.optionInput"
 						data-test-id="delete-data-input"
 					>
-						<n8n-input-label :label="i18n.baseText('settings.users.deleteConfirmationMessage')">
-							<n8n-input
+						<N8nInputLabel :label="i18n.baseText('settings.users.deleteConfirmationMessage')">
+							<N8nInput
 								v-model="deleteConfirmText"
 								:placeholder="i18n.baseText('settings.users.deleteConfirmationText')"
 							/>
-						</n8n-input-label>
+						</N8nInputLabel>
 					</div>
 				</div>
 			</div>
 		</template>
 		<template #footer>
-			<n8n-button
+			<N8nButton
 				:loading="loading"
 				:disabled="!enabled"
 				:label="i18n.baseText('settings.users.delete')"

--- a/packages/frontend/editor-ui/src/components/DuplicateWorkflowDialog.vue
+++ b/packages/frontend/editor-ui/src/components/DuplicateWorkflowDialog.vue
@@ -163,7 +163,7 @@ onMounted(async () => {
 	>
 		<template #content>
 			<div :class="$style.content">
-				<n8n-input
+				<N8nInput
 					ref="nameInputRef"
 					v-model="name"
 					:placeholder="i18n.baseText('duplicateWorkflowDialog.enterWorkflowName')"
@@ -183,13 +183,13 @@ onMounted(async () => {
 		</template>
 		<template #footer="{ close }">
 			<div :class="$style.footer">
-				<n8n-button
+				<N8nButton
 					:loading="isSaving"
 					:label="i18n.baseText('duplicateWorkflowDialog.save')"
 					float="right"
 					@click="save"
 				/>
-				<n8n-button
+				<N8nButton
 					type="secondary"
 					:disabled="isSaving"
 					:label="i18n.baseText('duplicateWorkflowDialog.cancel')"

--- a/packages/frontend/editor-ui/src/components/Error/NodeErrorView.vue
+++ b/packages/frontend/editor-ui/src/components/Error/NodeErrorView.vue
@@ -465,7 +465,7 @@ async function onAskAssistantClick() {
 			></div>
 
 			<div v-if="isSubNodeError">
-				<n8n-button
+				<N8nButton
 					icon="arrow-right"
 					type="secondary"
 					:label="i18n.baseText('pushConnection.executionError.openNode')"
@@ -488,7 +488,7 @@ async function onAskAssistantClick() {
 				<p class="node-error-view__info-title">
 					{{ i18n.baseText('nodeErrorView.details.title') }}
 				</p>
-				<n8n-tooltip
+				<N8nTooltip
 					class="item"
 					:content="i18n.baseText('nodeErrorView.copyToClipboard.tooltip')"
 					placement="left"
@@ -503,7 +503,7 @@ async function onAskAssistantClick() {
 							@click="copyErrorDetails"
 						/>
 					</div>
-				</n8n-tooltip>
+				</N8nTooltip>
 			</div>
 
 			<div class="node-error-view__info-content">
@@ -517,7 +517,7 @@ async function onAskAssistantClick() {
 					class="node-error-view__details"
 				>
 					<summary class="node-error-view__details-summary">
-						<n8n-icon class="node-error-view__details-icon" icon="chevron-right" />
+						<N8nIcon class="node-error-view__details-icon" icon="chevron-right" />
 						{{
 							i18n.baseText('nodeErrorView.details.from', {
 								interpolate: { node: `${nodeDefaultName}` },
@@ -572,7 +572,7 @@ async function onAskAssistantClick() {
 
 				<details class="node-error-view__details">
 					<summary class="node-error-view__details-summary">
-						<n8n-icon class="node-error-view__details-icon" icon="chevron-right" />
+						<N8nIcon class="node-error-view__details-icon" icon="chevron-right" />
 						{{ i18n.baseText('nodeErrorView.details.info') }}
 					</summary>
 					<div class="node-error-view__details-content">

--- a/packages/frontend/editor-ui/src/components/Evaluations.ee/Paywall/EvaluationsPaywall.vue
+++ b/packages/frontend/editor-ui/src/components/Evaluations.ee/Paywall/EvaluationsPaywall.vue
@@ -17,11 +17,11 @@ const goToUpgrade = async () => {
 </script>
 
 <template>
-	<n8n-action-box
+	<N8nActionBox
 		data-test-id="evaluations-unlicensed"
 		:heading="i18n.baseText('evaluations.paywall.title')"
 		:description="i18n.baseText('evaluations.paywall.description')"
 		:button-text="i18n.baseText('evaluations.paywall.cta')"
 		@click="goToUpgrade"
-	></n8n-action-box>
+	></N8nActionBox>
 </template>

--- a/packages/frontend/editor-ui/src/components/Evaluations.ee/shared/TableCell.vue
+++ b/packages/frontend/editor-ui/src/components/Evaluations.ee/shared/TableCell.vue
@@ -30,9 +30,9 @@ const getCellContent = (column: TestTableColumn<T>, row: T) => {
 		<a v-if="column.openInNewTab" :href="router.resolve(column.route(row)!).href" target="_blank">
 			{{ getCellContent(column, row) }}
 		</a>
-		<router-link v-else :to="column.route(row)!">
+		<RouterLink v-else :to="column.route(row)!">
 			{{ getCellContent(column, row) }}
-		</router-link>
+		</RouterLink>
 	</div>
 
 	<div v-else>

--- a/packages/frontend/editor-ui/src/components/ExpressionEditModal.vue
+++ b/packages/frontend/editor-ui/src/components/ExpressionEditModal.vue
@@ -135,7 +135,7 @@ const onResizeThrottle = useThrottleFn(onResize, 10);
 </script>
 
 <template>
-	<el-dialog
+	<ElDialog
 		width="calc(100% - var(--spacing-3xl))"
 		:append-to="`#${APP_MODALS_ELEMENT_ID}`"
 		:class="$style.modal"
@@ -231,7 +231,7 @@ const onResizeThrottle = useThrottleFn(onResize, 10);
 				</div>
 			</div>
 		</div>
-	</el-dialog>
+	</ElDialog>
 </template>
 
 <style module lang="scss">

--- a/packages/frontend/editor-ui/src/components/ExpressionParameterInput.vue
+++ b/packages/frontend/editor-ui/src/components/ExpressionParameterInput.vue
@@ -215,7 +215,7 @@ defineExpose({ focus, select });
 					/>
 				</template>
 			</DraggableTarget>
-			<n8n-button
+			<N8nButton
 				v-if="!isDragging"
 				square
 				outline

--- a/packages/frontend/editor-ui/src/components/ExternalSecretsProviderCard.ee.vue
+++ b/packages/frontend/editor-ui/src/components/ExternalSecretsProviderCard.ee.vue
@@ -106,12 +106,12 @@ async function onActionDropdownClick(id: string) {
 </script>
 
 <template>
-	<n8n-card :class="$style.card">
+	<N8nCard :class="$style.card">
 		<div :class="$style.cardBody">
 			<ExternalSecretsProviderImage :class="$style.cardImage" :provider="provider" />
 			<div :class="$style.cardContent">
-				<n8n-text bold>{{ provider.displayName }}</n8n-text>
-				<n8n-text v-if="provider.connected" color="text-light" size="small">
+				<N8nText bold>{{ provider.displayName }}</N8nText>
+				<N8nText v-if="provider.connected" color="text-light" size="small">
 					<span>
 						{{
 							i18n.baseText('settings.externalSecrets.card.secretsCount', {
@@ -131,10 +131,10 @@ async function onActionDropdownClick(id: string) {
 							})
 						}}
 					</span>
-				</n8n-text>
+				</N8nText>
 			</div>
 			<div v-if="provider.name === 'infisical'" :class="$style.deprecationWarning">
-				<n8n-icon :class="$style['warningTriangle']" icon="triangle-alert" />
+				<N8nIcon :class="$style['warningTriangle']" icon="triangle-alert" />
 				<N8nBadge class="mr-xs" theme="tertiary" bold data-test-id="card-badge">
 					{{ i18n.baseText('settings.externalSecrets.card.deprecated') }}
 				</N8nBadge>
@@ -145,18 +145,18 @@ async function onActionDropdownClick(id: string) {
 					:before-update="onBeforeConnectionUpdate"
 					:disabled="connectionState === 'error' && !provider.connected"
 				/>
-				<n8n-action-toggle
+				<N8nActionToggle
 					class="ml-s"
 					theme="dark"
 					:actions="actionDropdownOptions"
 					@action="onActionDropdownClick"
 				/>
 			</div>
-			<n8n-button v-else type="tertiary" @click="openExternalSecretProvider()">
+			<N8nButton v-else type="tertiary" @click="openExternalSecretProvider()">
 				{{ i18n.baseText('settings.externalSecrets.card.setUp') }}
-			</n8n-button>
+			</N8nButton>
 		</div>
-	</n8n-card>
+	</N8nCard>
 </template>
 
 <style lang="scss" module>

--- a/packages/frontend/editor-ui/src/components/ExternalSecretsProviderConnectionSwitch.ee.vue
+++ b/packages/frontend/editor-ui/src/components/ExternalSecretsProviderConnectionSwitch.ee.vue
@@ -65,20 +65,20 @@ async function onUpdateConnected(value: boolean) {
 
 <template>
 	<div v-loading="saving" class="connection-switch">
-		<n8n-icon
+		<N8nIcon
 			v-if="provider.state === 'error'"
 			color="danger"
 			icon="triangle-alert"
 			class="mr-2xs"
 		/>
-		<n8n-text :color="connectedTextColor" bold class="mr-2xs">
+		<N8nText :color="connectedTextColor" bold class="mr-2xs">
 			{{
 				i18n.baseText(
 					`settings.externalSecrets.card.${provider.connected ? 'connected' : 'disconnected'}`,
 				)
 			}}
-		</n8n-text>
-		<el-switch
+		</N8nText>
+		<ElSwitch
 			:model-value="provider.connected"
 			:title="
 				i18n.baseText('settings.externalSecrets.card.connectedSwitch.title', {
@@ -89,7 +89,7 @@ async function onUpdateConnected(value: boolean) {
 			data-test-id="settings-external-secrets-connected-switch"
 			@update:model-value="onUpdateConnected"
 		>
-		</el-switch>
+		</ElSwitch>
 	</div>
 </template>
 

--- a/packages/frontend/editor-ui/src/components/ExternalSecretsProviderModal.ee.vue
+++ b/packages/frontend/editor-ui/src/components/ExternalSecretsProviderModal.ee.vue
@@ -188,18 +188,13 @@ async function onConnectionStateChange() {
 						:provider="provider"
 						@change="onConnectionStateChange"
 					/>
-					<n8n-button
-						type="primary"
-						:loading="saving"
-						:disabled="!canSave && !saving"
-						@click="save"
-					>
+					<N8nButton type="primary" :loading="saving" :disabled="!canSave && !saving" @click="save">
 						{{
 							i18n.baseText(
 								`settings.externalSecrets.provider.buttons.${saving ? 'saving' : 'save'}`,
 							)
 						}}
-					</n8n-button>
+					</N8nButton>
 				</div>
 			</div>
 		</template>
@@ -208,7 +203,7 @@ async function onConnectionStateChange() {
 			<div v-if="provider" :class="$style.container">
 				<hr class="mb-l" />
 				<div v-if="connectionState !== 'initializing'" class="mb-l">
-					<n8n-callout
+					<N8nCallout
 						v-if="connectionState === 'connected' || connectionState === 'tested'"
 						theme="success"
 					>
@@ -235,16 +230,16 @@ async function onConnectionStateChange() {
 									<code>{{ `\{\{ \$secrets\.${provider.name}\.secret_name \}\}` }}</code>
 								</template>
 							</I18nT>
-							<n8n-link :href="i18n.baseText('settings.externalSecrets.docs.use')" size="small">
+							<N8nLink :href="i18n.baseText('settings.externalSecrets.docs.use')" size="small">
 								{{
 									i18n.baseText(
 										'settings.externalSecrets.provider.testConnection.success.connected.docs',
 									)
 								}}
-							</n8n-link>
+							</N8nLink>
 						</span>
-					</n8n-callout>
-					<n8n-callout v-else-if="connectionState === 'error'" theme="danger">
+					</N8nCallout>
+					<N8nCallout v-else-if="connectionState === 'error'" theme="danger">
 						{{
 							i18n.baseText(
 								`settings.externalSecrets.provider.testConnection.error${
@@ -255,7 +250,7 @@ async function onConnectionStateChange() {
 								},
 							)
 						}}
-					</n8n-callout>
+					</N8nCallout>
 				</div>
 
 				<form
@@ -266,7 +261,7 @@ async function onConnectionStateChange() {
 					data-test-id="external-secrets-provider-properties-form"
 					@submit.prevent
 				>
-					<n8n-notice v-if="property.type === 'notice'" :content="property.displayName" />
+					<N8nNotice v-if="property.type === 'notice'" :content="property.displayName" />
 					<ParameterInputExpanded
 						v-else
 						class="mb-l"

--- a/packages/frontend/editor-ui/src/components/FilterConditions/CombinatorSelect.vue
+++ b/packages/frontend/editor-ui/src/components/FilterConditions/CombinatorSelect.vue
@@ -26,20 +26,15 @@ const onCombinatorChange = (combinator: FilterTypeCombinator): void => {
 		<div v-if="readOnly || options.length === 1">
 			{{ i18n.baseText(`filter.combinator.${selected}`) }}
 		</div>
-		<n8n-select
-			v-else
-			size="small"
-			:model-value="selected"
-			@update:model-value="onCombinatorChange"
-		>
-			<n8n-option
+		<N8nSelect v-else size="small" :model-value="selected" @update:model-value="onCombinatorChange">
+			<N8nOption
 				v-for="option in options"
 				:key="option"
 				:value="option"
 				:label="i18n.baseText(`filter.combinator.${option}`)"
 			>
-			</n8n-option>
-		</n8n-select>
+			</N8nOption>
+		</N8nSelect>
 	</div>
 </template>
 

--- a/packages/frontend/editor-ui/src/components/FilterConditions/Condition.vue
+++ b/packages/frontend/editor-ui/src/components/FilterConditions/Condition.vue
@@ -224,25 +224,25 @@ const onBlur = (): void => {
 		<div :class="$style.status">
 			<ParameterIssues v-if="allIssues.length > 0" :issues="allIssues" />
 
-			<n8n-tooltip
+			<N8nTooltip
 				v-else-if="conditionResult.status === 'success' && conditionResult.result === true"
 				:show-after="500"
 			>
 				<template #content>
 					{{ i18n.baseText('filter.condition.resolvedTrue') }}
 				</template>
-				<n8n-icon icon="circle-check" size="medium" color="text-light" />
-			</n8n-tooltip>
+				<N8nIcon icon="circle-check" size="medium" color="text-light" />
+			</N8nTooltip>
 
-			<n8n-tooltip
+			<N8nTooltip
 				v-else-if="conditionResult.status === 'success' && conditionResult.result === false"
 				:show-after="500"
 			>
 				<template #content>
 					{{ i18n.baseText('filter.condition.resolvedFalse') }}
 				</template>
-				<n8n-icon icon="circle-x" size="medium" color="text-light" />
-			</n8n-tooltip>
+				<N8nIcon icon="circle-x" size="medium" color="text-light" />
+			</N8nTooltip>
 		</div>
 	</div>
 </template>

--- a/packages/frontend/editor-ui/src/components/FilterConditions/FilterConditions.vue
+++ b/packages/frontend/editor-ui/src/components/FilterConditions/FilterConditions.vue
@@ -168,7 +168,7 @@ function getIssues(index: number): string[] {
 		:class="{ [$style.filter]: true, [$style.single]: singleCondition }"
 		:data-test-id="`filter-${parameter.name}`"
 	>
-		<n8n-input-label
+		<N8nInputLabel
 			v-if="!singleCondition"
 			:label="parameter.displayName"
 			:underline="true"
@@ -177,7 +177,7 @@ function getIssues(index: number): string[] {
 			size="small"
 			color="text-dark"
 		>
-		</n8n-input-label>
+		</N8nInputLabel>
 		<div :class="$style.content">
 			<div :class="$style.conditions">
 				<Draggable
@@ -217,7 +217,7 @@ function getIssues(index: number): string[] {
 				</Draggable>
 			</div>
 			<div v-if="!singleCondition && !readOnly" :class="$style.addConditionWrapper">
-				<n8n-button
+				<N8nButton
 					type="tertiary"
 					block
 					:class="$style.addCondition"

--- a/packages/frontend/editor-ui/src/components/FilterConditions/OperatorSelect.vue
+++ b/packages/frontend/editor-ui/src/components/FilterConditions/OperatorSelect.vue
@@ -58,7 +58,7 @@ function onGroupSelect(group: string) {
 </script>
 
 <template>
-	<n8n-select
+	<N8nSelect
 		:key="selectedGroupIcon"
 		data-test-id="filter-operator-select"
 		size="small"
@@ -69,11 +69,11 @@ function onGroupSelect(group: string) {
 		@mouseenter="shouldRenderItems = true"
 	>
 		<template v-if="selectedGroupIcon" #prefix>
-			<n8n-icon :class="$style.icon" :icon="selectedGroupIcon" color="text-light" size="small" />
+			<N8nIcon :class="$style.icon" :icon="selectedGroupIcon" color="text-light" size="small" />
 		</template>
 		<div v-if="shouldRenderItems" :class="$style.groups">
 			<div v-for="group of groups" :key="group.name">
-				<n8n-popover
+				<N8nPopover
 					:visible="submenu === group.id"
 					placement="right-start"
 					:show-arrow="false"
@@ -94,30 +94,30 @@ function onGroupSelect(group: string) {
 							@click="() => onGroupSelect(group.id)"
 						>
 							<div :class="$style.groupTitle">
-								<n8n-icon v-if="group.icon" :icon="group.icon" :class="$style.icon" size="small" />
+								<N8nIcon v-if="group.icon" :icon="group.icon" :class="$style.icon" size="small" />
 								<span>{{ i18n.baseText(group.name) }}</span>
 							</div>
-							<n8n-icon icon="chevron-right" color="text-light" size="xsmall" />
+							<N8nIcon icon="chevron-right" color="text-light" size="xsmall" />
 						</div>
 					</template>
 					<div>
-						<n8n-option
+						<N8nOption
 							v-for="operator in group.children"
 							:key="getOperatorId(operator)"
 							:value="getOperatorId(operator)"
 							:label="i18n.baseText(operator.name)"
 						/>
 					</div>
-				</n8n-popover>
+				</N8nPopover>
 			</div>
 		</div>
-		<n8n-option
+		<N8nOption
 			v-else
 			:key="selected"
 			:value="selected"
 			:label="i18n.baseText(selectedOperator.name)"
 		/>
-	</n8n-select>
+	</N8nSelect>
 </template>
 
 <style lang="scss" module>

--- a/packages/frontend/editor-ui/src/components/FixedCollectionParameter.vue
+++ b/packages/frontend/editor-ui/src/components/FixedCollectionParameter.vue
@@ -266,8 +266,8 @@ function getItemKey(item: INodeParameters, property: INodePropertyCollection) {
 			/>
 			<div v-if="multipleValues">
 				<Draggable
-					:item-key="(item: INodeParameters) => getItemKey(item, property)"
 					v-model="mutableValues[property.name]"
+					:item-key="(item: INodeParameters) => getItemKey(item, property)"
 					handle=".drag-handle"
 					drag-class="dragging"
 					ghost-class="ghost"

--- a/packages/frontend/editor-ui/src/components/Folders/DeleteFolderModal.vue
+++ b/packages/frontend/editor-ui/src/components/Folders/DeleteFolderModal.vue
@@ -152,33 +152,31 @@ const onFolderSelected = (payload: ChangeLocationSearchResult) => {
 		<template #content>
 			<div>
 				<div v-if="isPending">
-					<n8n-text color="text-base">{{
-						i18n.baseText('folders.delete.confirm.message')
-					}}</n8n-text>
+					<N8nText color="text-base">{{ i18n.baseText('folders.delete.confirm.message') }}</N8nText>
 				</div>
 				<div v-else :class="$style.content">
 					<div>
-						<n8n-text color="text-base">{{ folderContentWarningMessage }}</n8n-text>
+						<N8nText color="text-base">{{ folderContentWarningMessage }}</N8nText>
 					</div>
-					<el-radio
+					<ElRadio
 						v-model="operation"
 						data-test-id="transfer-content-radio"
 						label="transfer"
 						@update:model-value="operation = 'transfer'"
 					>
-						<n8n-text v-if="currentProjectName">{{
+						<N8nText v-if="currentProjectName">{{
 							i18n.baseText('folders.transfer.action', {
 								interpolate: { projectName: currentProjectName },
 							})
-						}}</n8n-text>
-						<n8n-text v-else color="text-dark">{{
+						}}</N8nText>
+						<N8nText v-else color="text-dark">{{
 							i18n.baseText('folders.transfer.action.noProject')
-						}}</n8n-text>
-					</el-radio>
+						}}</N8nText>
+					</ElRadio>
 					<div v-if="operation === 'transfer'" :class="$style.optionInput">
-						<n8n-text color="text-dark">{{
+						<N8nText color="text-dark">{{
 							i18n.baseText('folders.transfer.selectFolder')
-						}}</n8n-text>
+						}}</N8nText>
 						<MoveToFolderDropdown
 							v-if="projectsStore.currentProject"
 							:selected-location="selectedFolder"
@@ -189,27 +187,27 @@ const onFolderSelected = (payload: ChangeLocationSearchResult) => {
 							@location:selected="onFolderSelected"
 						/>
 					</div>
-					<el-radio
+					<ElRadio
 						v-model="operation"
 						data-test-id="delete-content-radio"
 						label="delete"
 						@update:model-value="operation = 'delete'"
 					>
-						<n8n-text color="text-dark">{{ i18n.baseText('folders.delete.action') }}</n8n-text>
-					</el-radio>
+						<N8nText color="text-dark">{{ i18n.baseText('folders.delete.action') }}</N8nText>
+					</ElRadio>
 					<div
 						v-if="operation === 'delete'"
 						:class="$style.optionInput"
 						data-test-id="delete-data-input"
 					>
-						<n8n-input-label
+						<N8nInputLabel
 							:label="
 								i18n.baseText('folders.delete.confirmation.message', {
 									interpolate: { folderName: folderToDelete?.name ?? '' },
 								})
 							"
 						>
-							<n8n-input
+							<N8nInput
 								v-model="deleteConfirmText"
 								data-test-id="delete-data-input"
 								:placeholder="
@@ -218,13 +216,13 @@ const onFolderSelected = (payload: ChangeLocationSearchResult) => {
 									})
 								"
 							/>
-						</n8n-input-label>
+						</N8nInputLabel>
 					</div>
 				</div>
 			</div>
 		</template>
 		<template #footer>
-			<n8n-button
+			<N8nButton
 				:loading="loading"
 				:disabled="!enabled"
 				:label="i18n.baseText('generic.delete')"

--- a/packages/frontend/editor-ui/src/components/Folders/EmptySharedSectionActionBox.vue
+++ b/packages/frontend/editor-ui/src/components/Folders/EmptySharedSectionActionBox.vue
@@ -37,7 +37,7 @@ const onPersonalLinkClick = (event: MouseEvent) => {
 </script>
 
 <template>
-	<n8n-action-box
+	<N8nActionBox
 		data-test-id="empty-shared-action-box"
 		:heading="heading"
 		:description="i18n.baseText('workflows.empty.shared-with-me.link')"

--- a/packages/frontend/editor-ui/src/components/Folders/FolderBreadcrumbs.vue
+++ b/packages/frontend/editor-ui/src/components/Folders/FolderBreadcrumbs.vue
@@ -192,7 +192,7 @@ onBeforeUnmount(() => {
 		:class="{ [$style.container]: true, [$style['dragging']]: isDragging }"
 		data-test-id="folder-breadcrumbs"
 	>
-		<n8n-breadcrumbs
+		<N8nBreadcrumbs
 			v-if="visibleBreadcrumbsItems.length"
 			v-model:drag-active="isDragging"
 			:items="visibleBreadcrumbsItems"
@@ -216,7 +216,7 @@ onBeforeUnmount(() => {
 			<template #append>
 				<slot name="append"></slot>
 			</template>
-		</n8n-breadcrumbs>
+		</N8nBreadcrumbs>
 		<!-- If there is no current folder, just show project badge -->
 		<div v-else-if="currentProject || isSharedContext" :class="$style['home-project']">
 			<ProjectBreadcrumb
@@ -231,7 +231,7 @@ onBeforeUnmount(() => {
 		<div v-else>
 			<slot name="append"></slot>
 		</div>
-		<n8n-action-toggle
+		<N8nActionToggle
 			v-if="visibleBreadcrumbsItems && actions?.length"
 			:actions="actions"
 			:class="$style['action-toggle']"

--- a/packages/frontend/editor-ui/src/components/Folders/FolderCard.test.ts
+++ b/packages/frontend/editor-ui/src/components/Folders/FolderCard.test.ts
@@ -59,7 +59,7 @@ const renderComponent = createComponentRenderer(FolderCard, {
 	},
 	global: {
 		stubs: {
-			'router-link': {
+			RouterLink: {
 				template: '<div data-test-id="folder-card-link"><slot /></div>',
 			},
 		},

--- a/packages/frontend/editor-ui/src/components/Folders/FolderCard.vue
+++ b/packages/frontend/editor-ui/src/components/Folders/FolderCard.vue
@@ -122,10 +122,10 @@ const onBreadcrumbItemClick = async (item: PathItem) => {
 
 <template>
 	<div data-test-id="folder-card">
-		<router-link :to="cardUrl" @click="() => emit('folderOpened', { folder: props.data })">
-			<n8n-card :class="$style.card">
+		<RouterLink :to="cardUrl" @click="() => emit('folderOpened', { folder: props.data })">
+			<N8nCard :class="$style.card">
 				<template #prepend>
-					<n8n-icon
+					<N8nIcon
 						data-test-id="folder-card-icon"
 						:class="$style['folder-icon']"
 						icon="folder"
@@ -135,9 +135,9 @@ const onBreadcrumbItemClick = async (item: PathItem) => {
 				</template>
 				<template #header>
 					<div :class="$style['card-header']">
-						<n8n-heading tag="h2" bold size="small" data-test-id="folder-card-name">
+						<N8nHeading tag="h2" bold size="small" data-test-id="folder-card-name">
 							{{ data.name }}
-						</n8n-heading>
+						</N8nHeading>
 						<N8nBadge v-if="readOnly" class="ml-3xs" theme="tertiary" bold>
 							{{ i18n.baseText('workflows.item.readonly') }}
 						</N8nBadge>
@@ -145,7 +145,7 @@ const onBreadcrumbItemClick = async (item: PathItem) => {
 				</template>
 				<template #footer>
 					<div :class="$style['card-footer']">
-						<n8n-text
+						<N8nText
 							v-if="data.workflowCount > 0"
 							size="small"
 							color="text-light"
@@ -155,8 +155,8 @@ const onBreadcrumbItemClick = async (item: PathItem) => {
 							{{
 								i18n.baseText('generic.workflow', { interpolate: { count: data.workflowCount } })
 							}}
-						</n8n-text>
-						<n8n-text
+						</N8nText>
+						<N8nText
 							v-if="data.subFolderCount > 0"
 							size="small"
 							color="text-light"
@@ -168,8 +168,8 @@ const onBreadcrumbItemClick = async (item: PathItem) => {
 									interpolate: { count: data.subFolderCount },
 								})
 							}}
-						</n8n-text>
-						<n8n-text
+						</N8nText>
+						<N8nText
 							size="small"
 							color="text-light"
 							:class="[$style['info-cell'], $style['info-cell--updated']]"
@@ -177,8 +177,8 @@ const onBreadcrumbItemClick = async (item: PathItem) => {
 						>
 							{{ i18n.baseText('workerList.item.lastUpdated') }}
 							<TimeAgo :date="String(data.updatedAt)" />
-						</n8n-text>
-						<n8n-text
+						</N8nText>
+						<N8nText
 							size="small"
 							color="text-light"
 							:class="[$style['info-cell'], $style['info-cell--created']]"
@@ -186,7 +186,7 @@ const onBreadcrumbItemClick = async (item: PathItem) => {
 						>
 							{{ i18n.baseText('workflows.item.created') }}
 							<TimeAgo :date="String(data.createdAt)" />
-						</n8n-text>
+						</N8nText>
 					</div>
 				</template>
 				<template #append>
@@ -204,7 +204,7 @@ const onBreadcrumbItemClick = async (item: PathItem) => {
 								:show-badge-border="false"
 							>
 								<div v-if="showCardBreadcrumbs" :class="$style.breadcrumbs">
-									<n8n-breadcrumbs
+									<N8nBreadcrumbs
 										:items="cardBreadcrumbs"
 										:hidden-items="
 											data.parentFolder?.parentFolderId !== null
@@ -220,11 +220,11 @@ const onBreadcrumbItemClick = async (item: PathItem) => {
 										@item-selected="onBreadcrumbItemClick"
 									>
 										<template #prepend></template>
-									</n8n-breadcrumbs>
+									</N8nBreadcrumbs>
 								</div>
 							</ProjectCardBadge>
 						</div>
-						<n8n-action-toggle
+						<N8nActionToggle
 							v-if="actions.length"
 							:actions="actions"
 							theme="dark"
@@ -233,8 +233,8 @@ const onBreadcrumbItemClick = async (item: PathItem) => {
 						/>
 					</div>
 				</template>
-			</n8n-card>
-		</router-link>
+			</N8nCard>
+		</RouterLink>
 	</div>
 </template>
 

--- a/packages/frontend/editor-ui/src/components/Folders/MoveToFolderDropdown.vue
+++ b/packages/frontend/editor-ui/src/components/Folders/MoveToFolderDropdown.vue
@@ -139,14 +139,14 @@ const isTopLevelFolder = (location: ChangeLocationSearchResult, index: number) =
 				<div :class="$style['folder-select-item']">
 					<ul :class="$style.list">
 						<li v-if="location.resource === 'project'" :class="$style.current">
-							<n8n-text>{{ location.name }}</n8n-text>
+							<N8nText>{{ location.name }}</N8nText>
 						</li>
 						<template v-else>
 							<li v-if="location.path.length > maxPathLength" :class="$style.item">
-								<n8n-text>...</n8n-text>
+								<N8nText>...</N8nText>
 							</li>
 							<li v-if="location.path.length > 0" :class="$style.separator">
-								<n8n-text>{{ separator }}</n8n-text>
+								<N8nText>{{ separator }}</N8nText>
 							</li>
 							<template
 								v-for="(fragment, index) in location.path.slice(-maxPathLength)"
@@ -162,12 +162,12 @@ const isTopLevelFolder = (location: ChangeLocationSearchResult, index: number) =
 									data-test-id="breadcrumbs-item"
 									data-target="folder-breadcrumb-item"
 								>
-									<n8n-text>
+									<N8nText>
 										{{ fragment }}
-									</n8n-text>
+									</N8nText>
 								</li>
 								<li v-if="!isTopLevelFolder(location, index)" :class="$style.separator">
-									<n8n-text>{{ separator }}</n8n-text>
+									<N8nText>{{ separator }}</N8nText>
 								</li>
 							</template>
 						</template>

--- a/packages/frontend/editor-ui/src/components/Folders/MoveToFolderModal.vue
+++ b/packages/frontend/editor-ui/src/components/Folders/MoveToFolderModal.vue
@@ -350,11 +350,11 @@ onMounted(async () => {
 			>
 				{{ descriptionMessage }}
 			</p>
-			<enterprise-edition :features="[EnterpriseEditionFeature.Sharing]" :class="$style.content">
+			<EnterpriseEdition :features="[EnterpriseEditionFeature.Sharing]" :class="$style.content">
 				<div :class="$style.block">
-					<n8n-text color="text-dark">
+					<N8nText color="text-dark">
 						{{ i18n.baseText('folders.move.modal.project.label') }}
-					</n8n-text>
+					</N8nText>
 					<ProjectSharing
 						v-model="selectedProject"
 						class="pt-2xs"
@@ -388,12 +388,12 @@ onMounted(async () => {
 						</span>
 					</N8nText>
 				</div>
-			</enterprise-edition>
+			</EnterpriseEdition>
 			<template v-if="selectedProject && isFolderSelectable">
 				<div :class="$style.block">
-					<n8n-text color="text-dark">
+					<N8nText color="text-dark">
 						{{ i18n.baseText('folders.move.modal.folder.label') }}
-					</n8n-text>
+					</N8nText>
 					<MoveToFolderDropdown
 						ref="moveToFolderDropdown"
 						:selected-location="selectedFolder"
@@ -471,14 +471,14 @@ onMounted(async () => {
 		</template>
 		<template #footer="{ close }">
 			<div :class="$style.footer">
-				<n8n-button
+				<N8nButton
 					type="secondary"
 					:label="i18n.baseText('generic.cancel')"
 					float="right"
 					data-test-id="cancel-move-folder-button"
 					@click="close"
 				/>
-				<n8n-button
+				<N8nButton
 					:disabled="!selectedFolder && isFolderSelectable"
 					:label="
 						i18n.baseText('folders.move.modal.confirm', {

--- a/packages/frontend/editor-ui/src/components/Folders/ProjectBreadcrumb.test.ts
+++ b/packages/frontend/editor-ui/src/components/Folders/ProjectBreadcrumb.test.ts
@@ -16,7 +16,7 @@ vi.mock('@n8n/i18n', async (importOriginal) => ({
 }));
 
 const mockComponents = {
-	'n8n-link': {
+	N8nLink: {
 		template: '<a :href="to"><slot /></a>',
 		props: ['to'],
 	},

--- a/packages/frontend/editor-ui/src/components/Folders/ProjectBreadcrumb.vue
+++ b/packages/frontend/editor-ui/src/components/Folders/ProjectBreadcrumb.vue
@@ -81,12 +81,12 @@ const onProjectMouseUp = () => {
 		@mouseenter="onHover"
 		@mouseup="isDragging ? onProjectMouseUp() : null"
 	>
-		<n8n-link :to="projectLink" :class="[$style['project-link']]">
+		<N8nLink :to="projectLink" :class="[$style['project-link']]">
 			<ProjectIcon :icon="projectIcon" :border-less="true" size="mini" :title="projectName" />
 			<N8nText size="medium" color="text-base" :class="$style['project-label']">
 				{{ projectName }}
 			</N8nText>
-		</n8n-link>
+		</N8nLink>
 	</div>
 </template>
 

--- a/packages/frontend/editor-ui/src/components/FreeAiCreditsCallout.vue
+++ b/packages/frontend/editor-ui/src/components/FreeAiCreditsCallout.vue
@@ -108,7 +108,7 @@ const onClaimCreditsClicked = async () => {
 			})
 		}}
 		<template #trailingContent>
-			<n8n-button
+			<N8nButton
 				type="tertiary"
 				size="small"
 				:label="i18n.baseText('freeAi.credits.callout.claim.button.label')"

--- a/packages/frontend/editor-ui/src/components/FromAiParametersModal.vue
+++ b/packages/frontend/editor-ui/src/components/FromAiParametersModal.vue
@@ -6,6 +6,7 @@ import { useAgentRequestStore, type IAgentRequest } from '@n8n/stores/useAgentRe
 import { useWorkflowsStore } from '@/stores/workflows.store';
 import { createEventBus } from '@n8n/utils/event-bus';
 import {
+	type INode,
 	type FromAIArgument,
 	type IDataObject,
 	NodeConnectionTypes,
@@ -19,7 +20,6 @@ import { useNDVStore } from '@/stores/ndv.store';
 import { useNodeTypesStore } from '@/stores/nodeTypes.store';
 import { type JSONSchema7 } from 'json-schema';
 import { useProjectsStore } from '@/stores/projects.store';
-import type { INode } from 'n8n-workflow';
 
 type Value = string | number | boolean | null | undefined;
 
@@ -294,19 +294,19 @@ const onUpdate = (change: FormFieldValueUpdate) => {
 			</N8nCallout>
 		</template>
 		<template v-else #content>
-			<el-col>
-				<el-row :class="$style.row">
-					<n8n-text data-testid="from-ai-parameters-modal-description">
+			<ElCol>
+				<ElRow :class="$style.row">
+					<N8nText data-testid="from-ai-parameters-modal-description">
 						{{
 							i18n.baseText('fromAiParametersModal.description', {
 								interpolate: { parentNodeName: parentNode || '' },
 							})
 						}}
-					</n8n-text>
-				</el-row>
-			</el-col>
-			<el-col>
-				<el-row :class="$style.row">
+					</N8nText>
+				</ElRow>
+			</ElCol>
+			<ElCol>
+				<ElRow :class="$style.row">
 					<N8nFormInputs
 						ref="inputs"
 						:inputs="parameters"
@@ -315,20 +315,20 @@ const onUpdate = (change: FormFieldValueUpdate) => {
 						@submit="onExecute"
 						@update="onUpdate"
 					></N8nFormInputs>
-				</el-row>
-			</el-col>
+				</ElRow>
+			</ElCol>
 		</template>
 		<template v-if="!error" #footer>
-			<el-row justify="end">
-				<el-col :span="5" :offset="19">
-					<n8n-button
+			<ElRow justify="end">
+				<ElCol :span="5" :offset="19">
+					<N8nButton
 						data-test-id="execute-workflow-button"
 						icon="flask-conical"
 						:label="i18n.baseText('fromAiParametersModal.execute')"
 						@click="onExecute"
 					/>
-				</el-col>
-			</el-row>
+				</ElCol>
+			</ElRow>
 		</template>
 	</Modal>
 </template>

--- a/packages/frontend/editor-ui/src/components/GoBackButton.vue
+++ b/packages/frontend/editor-ui/src/components/GoBackButton.vue
@@ -12,7 +12,7 @@ const navigateTo = () => {
 
 <template>
 	<div :class="$style.wrapper" @click="navigateTo">
-		<n8n-icon :class="$style.icon" icon="arrow-left" />
+		<N8nIcon :class="$style.icon" icon="arrow-left" />
 		<div :class="$style.text" v-text="i18n.baseText('template.buttons.goBackButton')" />
 	</div>
 </template>

--- a/packages/frontend/editor-ui/src/components/ImportCurlParameter.vue
+++ b/packages/frontend/editor-ui/src/components/ImportCurlParameter.vue
@@ -17,7 +17,7 @@ function onImportCurlClicked() {
 
 <template>
 	<div :class="$style.importSection">
-		<n8n-button
+		<N8nButton
 			type="secondary"
 			:label="i18n.baseText('importCurlParameter.label')"
 			:disabled="isReadOnly"

--- a/packages/frontend/editor-ui/src/components/ImportWorkflowUrlModal.vue
+++ b/packages/frontend/editor-ui/src/components/ImportWorkflowUrlModal.vue
@@ -42,7 +42,7 @@ const focusInput = async () => {
 	>
 		<template #content>
 			<div :class="$style.noScrollbar">
-				<n8n-input
+				<N8nInput
 					ref="inputRef"
 					v-model="url"
 					:placeholder="i18n.baseText('mainSidebar.prompt.workflowUrl')"
@@ -57,7 +57,7 @@ const focusInput = async () => {
 		</template>
 		<template #footer>
 			<div :class="$style.footer">
-				<n8n-button
+				<N8nButton
 					type="primary"
 					float="right"
 					:disabled="!url || !isValid"
@@ -65,15 +65,15 @@ const focusInput = async () => {
 					@click="confirm"
 				>
 					{{ i18n.baseText('mainSidebar.prompt.import') }}
-				</n8n-button>
-				<n8n-button
+				</N8nButton>
+				<N8nButton
 					type="secondary"
 					float="right"
 					data-test-id="cancel-workflow-import-url-button"
 					@click="closeModal"
 				>
 					{{ i18n.baseText('mainSidebar.prompt.cancel') }}
-				</n8n-button>
+				</N8nButton>
 			</div>
 		</template>
 	</Modal>

--- a/packages/frontend/editor-ui/src/components/InlineExpressionEditor/InlineExpressionTip.vue
+++ b/packages/frontend/editor-ui/src/components/InlineExpressionEditor/InlineExpressionTip.vue
@@ -106,20 +106,20 @@ watchDebounced(
 
 <template>
 	<div :class="[$style.tip, { [$style.drag]: tip === 'drag' }]">
-		<n8n-text size="small" :class="$style.tipText"
+		<N8nText size="small" :class="$style.tipText"
 			>{{ i18n.baseText('parameterInput.tip') }}:
-		</n8n-text>
+		</N8nText>
 
 		<div v-if="tip === 'drag'" :class="$style.content">
-			<n8n-text size="small" :class="$style.text">
+			<N8nText size="small" :class="$style.text">
 				{{ i18n.baseText('parameterInput.dragTipBeforePill') }}
-			</n8n-text>
+			</N8nText>
 			<div :class="[$style.pill, { [$style.highlight]: !ndvStore.isMappingOnboarded }]">
 				{{ i18n.baseText('parameterInput.inputField') }}
 			</div>
-			<n8n-text size="small" :class="$style.text">
+			<N8nText size="small" :class="$style.text">
 				{{ i18n.baseText('parameterInput.dragTipAfterPill') }}
-			</n8n-text>
+			</N8nText>
 		</div>
 
 		<div v-else-if="tip === 'executePrevious'" :class="$style.content">

--- a/packages/frontend/editor-ui/src/components/InlineExpressionEditor/OutputItemSelect.vue
+++ b/packages/frontend/editor-ui/src/components/InlineExpressionEditor/OutputItemSelect.vue
@@ -38,9 +38,9 @@ function prevItem() {
 
 <template>
 	<div :class="$style.item">
-		<n8n-text size="small" color="text-base" compact>
+		<N8nText size="small" color="text-base" compact>
 			{{ i18n.baseText('parameterInput.item') }}
-		</n8n-text>
+		</N8nText>
 
 		<div :class="$style.controls">
 			<N8nInputNumber

--- a/packages/frontend/editor-ui/src/components/InputNodeSelect.vue
+++ b/packages/frontend/editor-ui/src/components/InputNodeSelect.vue
@@ -117,7 +117,7 @@ function onInputNodeChange(value: string) {
 </script>
 
 <template>
-	<n8n-select
+	<N8nSelect
 		:model-value="modelValue"
 		:no-data-text="i18n.baseText('ndv.input.noNodesFound')"
 		:placeholder="i18n.baseText('ndv.input.parentNodes')"
@@ -137,7 +137,7 @@ function onInputNodeChange(value: string) {
 			/>
 		</template>
 
-		<n8n-option
+		<N8nOption
 			v-for="{ node, type, depth } of inputNodes"
 			:key="node.name"
 			:value="node.name"
@@ -160,8 +160,8 @@ function onInputNodeChange(value: string) {
 			<span :class="$style.subtitle">{{
 				connectedTo(node.name) ? connectedTo(node.name) : subtitle(node.name, depth)
 			}}</span>
-		</n8n-option>
-	</n8n-select>
+		</N8nOption>
+	</N8nSelect>
 </template>
 
 <style lang="scss" module>

--- a/packages/frontend/editor-ui/src/components/InputTriple/InputTriple.vue
+++ b/packages/frontend/editor-ui/src/components/InputTriple/InputTriple.vue
@@ -6,7 +6,7 @@ withDefaults(defineProps<Props>(), { middleWidth: '160px' });
 </script>
 
 <template>
-	<n8n-resize-observer
+	<N8nResizeObserver
 		:class="{ [$style.observer]: true }"
 		:breakpoints="[
 			{ bp: 'stacked', width: 400 },
@@ -40,7 +40,7 @@ withDefaults(defineProps<Props>(), { middleWidth: '160px' });
 				</div>
 			</div>
 		</template>
-	</n8n-resize-observer>
+	</N8nResizeObserver>
 </template>
 
 <style lang="scss" module>

--- a/packages/frontend/editor-ui/src/components/InviteUsersModal.vue
+++ b/packages/frontend/editor-ui/src/components/InviteUsersModal.vue
@@ -304,34 +304,34 @@ function getEmail(email: string): string {
 		@enter="onSubmit"
 	>
 		<template #content>
-			<n8n-notice v-if="!isAdvancedPermissionsEnabled">
+			<N8nNotice v-if="!isAdvancedPermissionsEnabled">
 				<I18nT keypath="settings.users.advancedPermissions.warning" scope="global">
 					<template #link>
-						<n8n-link size="small" @click="goToUpgradeAdvancedPermissions">
+						<N8nLink size="small" @click="goToUpgradeAdvancedPermissions">
 							{{ i18n.baseText('generic.upgrade') }}
-						</n8n-link>
+						</N8nLink>
 					</template>
 				</I18nT>
-			</n8n-notice>
+			</N8nNotice>
 			<div v-if="showInviteUrls">
-				<n8n-users-list :users="invitedUsers">
+				<N8nUsersList :users="invitedUsers">
 					<template #actions="{ user }">
-						<n8n-tooltip>
+						<N8nTooltip>
 							<template #content>
 								{{ i18n.baseText('settings.users.inviteLink.copy') }}
 							</template>
-							<n8n-icon-button
+							<N8nIconButton
 								icon="link"
 								type="tertiary"
 								data-test-id="copy-invite-link-button"
 								:data-invite-link="user.inviteAcceptUrl"
 								@click="onCopyInviteLink(user)"
-							></n8n-icon-button>
-						</n8n-tooltip>
+							></N8nIconButton>
+						</N8nTooltip>
 					</template>
-				</n8n-users-list>
+				</N8nUsersList>
 			</div>
-			<n8n-form-inputs
+			<N8nFormInputs
 				v-else-if="config"
 				:inputs="config"
 				:event-bus="formBus"
@@ -341,7 +341,7 @@ function getEmail(email: string): string {
 			/>
 		</template>
 		<template v-if="!showInviteUrls" #footer>
-			<n8n-button
+			<N8nButton
 				:loading="loading"
 				:disabled="!enabledButton"
 				:label="buttonLabel"

--- a/packages/frontend/editor-ui/src/components/MainHeader/CollaborationPane.vue
+++ b/packages/frontend/editor-ui/src/components/MainHeader/CollaborationPane.vue
@@ -44,7 +44,7 @@ onBeforeUnmount(() => {
 		:class="`collaboration-pane-container ${$style.container}`"
 		data-test-id="collaboration-pane"
 	>
-		<n8n-user-stack
+		<N8nUserStack
 			v-if="showUserStack"
 			:users="collaboratorsSorted"
 			:current-user-email="currentUserEmail"

--- a/packages/frontend/editor-ui/src/components/MainHeader/WorkflowHistoryButton.test.ts
+++ b/packages/frontend/editor-ui/src/components/MainHeader/WorkflowHistoryButton.test.ts
@@ -12,8 +12,7 @@ vi.mock('vue-router', () => ({
 const renderComponent = createComponentRenderer(WorkflowHistoryButton, {
 	global: {
 		stubs: {
-			RouterLink: true,
-			'router-link': {
+			RouterLink: {
 				template: '<div><slot /></div>',
 			},
 			N8nTooltip: {

--- a/packages/frontend/editor-ui/src/components/MainSidebarSourceControl.vue
+++ b/packages/frontend/editor-ui/src/components/MainSidebarSourceControl.vue
@@ -81,11 +81,11 @@ function pullWorkfolder() {
 			data-test-id="main-sidebar-source-control-connected"
 		>
 			<span :class="$style.branchName">
-				<n8n-icon icon="git-branch" />
+				<N8nIcon icon="git-branch" />
 				{{ currentBranch }}
 			</span>
 			<div :class="{ 'pt-xs': !isCollapsed }">
-				<n8n-tooltip
+				<N8nTooltip
 					:disabled="!isCollapsed && hasPullPermission"
 					:show-after="tooltipOpenDelay"
 					:placement="isCollapsed ? 'right' : 'top'"
@@ -99,7 +99,7 @@ function pullWorkfolder() {
 							}}
 						</div>
 					</template>
-					<n8n-button
+					<N8nButton
 						:class="{
 							'mr-2xs': !isCollapsed,
 							'mb-2xs': isCollapsed,
@@ -113,8 +113,8 @@ function pullWorkfolder() {
 						:label="isCollapsed ? '' : i18n.baseText('settings.sourceControl.button.pull')"
 						@click="pullWorkfolder"
 					/>
-				</n8n-tooltip>
-				<n8n-tooltip
+				</N8nTooltip>
+				<N8nTooltip
 					:disabled="
 						!isCollapsed && !sourceControlStore.preferences.branchReadOnly && hasPushPermission
 					"
@@ -130,7 +130,7 @@ function pullWorkfolder() {
 							}}
 						</div>
 					</template>
-					<n8n-button
+					<N8nButton
 						:square="isCollapsed"
 						:label="isCollapsed ? '' : i18n.baseText('settings.sourceControl.button.push')"
 						:disabled="sourceControlStore.preferences.branchReadOnly || !hasPushPermission"
@@ -140,7 +140,7 @@ function pullWorkfolder() {
 						size="mini"
 						@click="pushWorkfolder"
 					/>
-				</n8n-tooltip>
+				</N8nTooltip>
 			</div>
 		</div>
 	</div>

--- a/packages/frontend/editor-ui/src/components/MfaSetupModal.vue
+++ b/packages/frontend/editor-ui/src/components/MfaSetupModal.vue
@@ -173,12 +173,12 @@ onMounted(async () => {
 		<template #content>
 			<div v-if="!showRecoveryCodes" :class="[$style.container, $style.modalContent]">
 				<div :class="$style.textContainer">
-					<n8n-text size="large" color="text-dark" :bold="true">{{
+					<N8nText size="large" color="text-dark" :bold="true">{{
 						i18n.baseText('mfa.setup.step1.instruction1.title')
-					}}</n8n-text>
+					}}</N8nText>
 				</div>
 				<div>
-					<n8n-text size="medium" :bold="false">
+					<N8nText size="medium" :bold="false">
 						<I18nT keypath="mfa.setup.step1.instruction1.subtitle" tag="span" scope="global">
 							<template #part1>
 								{{ i18n.baseText('mfa.setup.step1.instruction1.subtitle.part1') }}
@@ -192,24 +192,24 @@ onMounted(async () => {
 								>
 							</template>
 						</I18nT>
-					</n8n-text>
+					</N8nText>
 				</div>
 				<div :class="$style.qrContainer">
 					<QrcodeVue :value="qrCode" :size="150" level="H" />
 				</div>
 				<div :class="$style.textContainer">
-					<n8n-text size="large" color="text-dark" :bold="true">{{
+					<N8nText size="large" color="text-dark" :bold="true">{{
 						i18n.baseText('mfa.setup.step1.instruction2.title')
-					}}</n8n-text>
+					}}</N8nText>
 				</div>
 				<div :class="[$style.form, infoTextErrorMessage ? $style.error : '']">
-					<n8n-input-label
+					<N8nInputLabel
 						size="medium"
 						:bold="false"
 						:class="$style.labelTooltip"
 						:label="i18n.baseText('mfa.setup.step1.input.label')"
 					>
-						<n8n-input
+						<N8nInput
 							v-model="authenticatorCode"
 							type="text"
 							:maxlength="6"
@@ -218,7 +218,7 @@ onMounted(async () => {
 							data-test-id="mfa-token-input"
 							@input="onInput"
 						/>
-					</n8n-input-label>
+					</N8nInputLabel>
 					<div :class="[$style.infoText, 'mt-4xs']">
 						<span size="small" v-text="infoTextErrorMessage"></span>
 					</div>
@@ -226,29 +226,29 @@ onMounted(async () => {
 			</div>
 			<div v-else :class="$style.container">
 				<div>
-					<n8n-text size="medium" :bold="false">{{
+					<N8nText size="medium" :bold="false">{{
 						i18n.baseText('mfa.setup.step2.description')
-					}}</n8n-text>
+					}}</N8nText>
 				</div>
 				<div :class="$style.recoveryCodesContainer">
 					<div v-for="recoveryCode in recoveryCodes" :key="recoveryCode">
-						<n8n-text size="medium">{{ recoveryCode }}</n8n-text>
+						<N8nText size="medium">{{ recoveryCode }}</N8nText>
 					</div>
 				</div>
-				<n8n-info-tip :bold="false" :class="$style['edit-mode-footer-infotip']">
+				<N8nInfoTip :bold="false" :class="$style['edit-mode-footer-infotip']">
 					<I18nT keypath="mfa.setup.step2.infobox.description" tag="span" scope="global">
 						<template #part1>
 							{{ i18n.baseText('mfa.setup.step2.infobox.description.part1') }}
 						</template>
 						<template #part2>
-							<n8n-text size="small" :bold="true" :class="$style.loseAccessText">
+							<N8nText size="small" :bold="true" :class="$style.loseAccessText">
 								{{ i18n.baseText('mfa.setup.step2.infobox.description.part2') }}
-							</n8n-text>
+							</N8nText>
 						</template>
 					</I18nT>
-				</n8n-info-tip>
+				</N8nInfoTip>
 				<div>
-					<n8n-button
+					<N8nButton
 						type="primary"
 						icon="hard-drive-download"
 						float="right"
@@ -262,7 +262,7 @@ onMounted(async () => {
 		<template #footer>
 			<div v-if="showRecoveryCodes">
 				<div>
-					<n8n-button
+					<N8nButton
 						float="right"
 						:disabled="!recoveryCodesDownloaded"
 						:label="i18n.baseText('mfa.setup.step2.button.save')"
@@ -274,7 +274,7 @@ onMounted(async () => {
 			</div>
 			<div v-else>
 				<div>
-					<n8n-button
+					<N8nButton
 						float="right"
 						:label="i18n.baseText('mfa.setup.step1.button.continue')"
 						size="large"

--- a/packages/frontend/editor-ui/src/components/Modal.vue
+++ b/packages/frontend/editor-ui/src/components/Modal.vue
@@ -165,10 +165,10 @@ function getCustomClass() {
 		<template v-else-if="title" #title>
 			<div :class="centerTitle ? $style.centerTitle : ''">
 				<div v-if="title">
-					<n8n-heading tag="h1" size="xlarge">{{ title }}</n8n-heading>
+					<N8nHeading tag="h1" size="xlarge">{{ title }}</N8nHeading>
 				</div>
 				<div v-if="subtitle" :class="$style.subtitle">
-					<n8n-heading tag="h3" size="small" color="text-light">{{ subtitle }}</n8n-heading>
+					<N8nHeading tag="h3" size="small" color="text-light">{{ subtitle }}</N8nHeading>
 				</div>
 			</div>
 		</template>
@@ -180,7 +180,7 @@ function getCustomClass() {
 		>
 			<slot v-if="!loading" name="content" />
 			<div v-else :class="$style.loader">
-				<n8n-spinner />
+				<N8nSpinner />
 			</div>
 		</div>
 		<div v-if="!loading && $slots.footer" :class="$style.footer">

--- a/packages/frontend/editor-ui/src/components/NDVFloatingNodes.vue
+++ b/packages/frontend/editor-ui/src/components/NDVFloatingNodes.vue
@@ -45,13 +45,11 @@ function moveNodeDirection(direction: FloatingNodePosition) {
 
 function onKeyDown(e: KeyboardEvent) {
 	if (e.shiftKey && e.altKey && (e.ctrlKey || e.metaKey)) {
-		/* eslint-disable @typescript-eslint/naming-convention */
 		const mapper = {
 			ArrowUp: FloatingNodePosition.top,
 			ArrowRight: FloatingNodePosition.right,
 			ArrowLeft: FloatingNodePosition.left,
 		};
-		/* eslint-enable @typescript-eslint/naming-convention */
 
 		const matchingDirection = mapper[e.key as keyof typeof mapper] || null;
 		if (matchingDirection) {
@@ -123,7 +121,7 @@ defineExpose({
 			:class="[$style.nodesList, $style[connectionGroup]]"
 		>
 			<template v-for="{ node, nodeType } in connectedNodes[connectionGroup]">
-				<n8n-tooltip
+				<N8nTooltip
 					v-if="node && nodeType"
 					:key="node.name"
 					:placement="tooltipPositionMapper[connectionGroup]"
@@ -147,7 +145,7 @@ defineExpose({
 							circle
 						/>
 					</li>
-				</n8n-tooltip>
+				</N8nTooltip>
 			</template>
 		</ul>
 	</aside>

--- a/packages/frontend/editor-ui/src/components/NDVSubConnections.vue
+++ b/packages/frontend/editor-ui/src/components/NDVSubConnections.vue
@@ -301,7 +301,7 @@ defineExpose({
 								}"
 								@click="onPlusClick(getConnectionContext(connection, index))"
 							>
-								<n8n-tooltip
+								<N8nTooltip
 									placement="top"
 									:teleported="true"
 									:offset="10"
@@ -320,13 +320,13 @@ defineExpose({
 											/>
 										</template>
 									</template>
-									<n8n-icon-button
+									<N8nIconButton
 										size="medium"
 										icon="plus"
 										type="tertiary"
 										:data-test-id="`add-subnode-${getConnectionKey(connection, index)}`"
 									/>
-								</n8n-tooltip>
+								</N8nTooltip>
 							</div>
 							<div
 								v-if="connectedNodes[getConnectionKey(connection, index)].length > 0"
@@ -344,7 +344,7 @@ defineExpose({
 									:data-node-name="node.node.name"
 									:style="`--node-index: ${nodeIndex}`"
 								>
-									<n8n-tooltip
+									<N8nTooltip
 										:key="node.node.name"
 										placement="top"
 										:teleported="true"
@@ -374,7 +374,7 @@ defineExpose({
 												circle
 											/>
 										</div>
-									</n8n-tooltip>
+									</N8nTooltip>
 								</div>
 							</div>
 						</div>

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreation.vue
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreation.vue
@@ -113,7 +113,7 @@ function onAskAssistantButtonClick() {
 			:shortcut="{ keys: ['Tab'] }"
 			placement="left"
 		>
-			<n8n-icon-button
+			<N8nIconButton
 				size="large"
 				icon="plus"
 				type="tertiary"
@@ -126,7 +126,7 @@ function onAskAssistantButtonClick() {
 			:shortcut="{ keys: ['s'], shiftKey: true }"
 			placement="left"
 		>
-			<n8n-icon-button
+			<N8nIconButton
 				size="large"
 				type="tertiary"
 				icon="sticky-note"
@@ -139,7 +139,7 @@ function onAskAssistantButtonClick() {
 			:shortcut="{ keys: ['f'], shiftKey: true }"
 			placement="left"
 		>
-			<n8n-icon-button
+			<N8nIconButton
 				type="tertiary"
 				size="large"
 				icon="panel-right"
@@ -149,9 +149,9 @@ function onAskAssistantButtonClick() {
 				@click="toggleFocusPanel"
 			/>
 		</KeyboardShortcutTooltip>
-		<n8n-tooltip v-if="assistantStore.canShowAssistantButtonsOnCanvas" placement="left">
+		<N8nTooltip v-if="assistantStore.canShowAssistantButtonsOnCanvas" placement="left">
 			<template #content> {{ i18n.baseText('aiAssistant.tooltip') }}</template>
-			<n8n-button
+			<N8nButton
 				type="tertiary"
 				size="large"
 				square
@@ -164,8 +164,8 @@ function onAskAssistantButtonClick() {
 						<AssistantIcon size="large" />
 					</div>
 				</template>
-			</n8n-button>
-		</n8n-tooltip>
+			</N8nButton>
+		</N8nTooltip>
 	</div>
 	<Suspense>
 		<LazyNodeCreator

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/ItemTypes/ActionItem.vue
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/ItemTypes/ActionItem.vue
@@ -98,7 +98,7 @@ const { draggableDataTransfer, dragging } = toRefs(state);
 </script>
 
 <template>
-	<n8n-node-creator-node
+	<N8nNodeCreatorNode
 		draggable
 		:class="$style.action"
 		:title="action.displayName"
@@ -116,7 +116,7 @@ const { draggableDataTransfer, dragging } = toRefs(state);
 		<template #icon>
 			<NodeIcon :node-type="action" />
 		</template>
-	</n8n-node-creator-node>
+	</N8nNodeCreatorNode>
 </template>
 
 <style lang="scss" module>

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/ItemTypes/CategoryItem.vue
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/ItemTypes/CategoryItem.vue
@@ -28,11 +28,11 @@ const categoryName = computed(() => {
 		<div :class="{ [$style.category]: true, [$style.active]: active }">
 			<span :class="$style.name">
 				<span v-text="categoryName" />
-				<n8n-icon v-if="isTrigger" icon="bolt-filled" size="xsmall" :class="$style.triggerIcon" />
+				<N8nIcon v-if="isTrigger" icon="bolt-filled" size="xsmall" :class="$style.triggerIcon" />
 				<slot />
 			</span>
-			<n8n-icon v-if="expanded" icon="chevron-down" color="text-light" size="large" />
-			<n8n-icon v-else icon="chevron-up" color="text-light" size="large" />
+			<N8nIcon v-if="expanded" icon="chevron-down" color="text-light" size="large" />
+			<N8nIcon v-else icon="chevron-up" color="text-light" size="large" />
 		</div>
 	</div>
 </template>

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/ItemTypes/LinkItem.vue
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/ItemTypes/LinkItem.vue
@@ -9,7 +9,7 @@ defineProps<Props>();
 </script>
 
 <template>
-	<n8n-node-creator-node
+	<N8nNodeCreatorNode
 		:class="$style.creatorLink"
 		:title="link.title"
 		:is-trigger="false"
@@ -18,7 +18,7 @@ defineProps<Props>();
 		:show-action-arrow="true"
 	>
 		<template #icon>
-			<n8n-node-icon
+			<N8nNodeIcon
 				type="icon"
 				:name="link.icon"
 				:circle="false"
@@ -26,7 +26,7 @@ defineProps<Props>();
 				:use-updated-icons="true"
 			/>
 		</template>
-	</n8n-node-creator-node>
+	</N8nNodeCreatorNode>
 </template>
 
 <style lang="scss" module>

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/ItemTypes/NodeItem.vue
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/ItemTypes/NodeItem.vue
@@ -219,7 +219,7 @@ function onCommunityNodeTooltipClick(event: MouseEvent) {
 						@click="onCommunityNodeTooltipClick"
 					/>
 				</template>
-				<n8n-icon size="small" :class="$style.icon" icon="box" />
+				<N8nIcon size="small" :class="$style.icon" icon="box" />
 			</N8nTooltip>
 		</template>
 		<template #dragContent>
@@ -233,8 +233,8 @@ function onCommunityNodeTooltipClick(event: MouseEvent) {
 					:node-type="nodeType"
 					:size="40"
 					:shrink="false"
-					@click.capture.stop
 					color-default="var(--color-foreground-xdark)"
+					@click.capture.stop
 				/>
 			</div>
 		</template>

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/ItemTypes/OpenTemplateItem.vue
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/ItemTypes/OpenTemplateItem.vue
@@ -18,7 +18,7 @@ defineProps<Props>();
 		:is-trigger="false"
 	>
 		<template v-if="openTemplate.icon" #icon>
-			<n8n-node-icon
+			<N8nNodeIcon
 				type="icon"
 				:name="openTemplate.icon"
 				:circle="false"

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/ItemTypes/SubcategoryItem.vue
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/ItemTypes/SubcategoryItem.vue
@@ -15,7 +15,7 @@ const subcategoryName = computed(() => camelCase(props.item.subcategory || props
 </script>
 
 <template>
-	<n8n-node-creator-node
+	<N8nNodeCreatorNode
 		:class="$style.subCategory"
 		:title="i18n.baseText(`nodeCreator.subcategoryNames.${subcategoryName}` as BaseTextKey)"
 		:is-trigger="false"
@@ -25,7 +25,7 @@ const subcategoryName = computed(() => camelCase(props.item.subcategory || props
 		:show-action-arrow="true"
 	>
 		<template #icon>
-			<n8n-node-icon
+			<N8nNodeIcon
 				type="icon"
 				:name="item.icon"
 				:circle="false"
@@ -34,7 +34,7 @@ const subcategoryName = computed(() => camelCase(props.item.subcategory || props
 				v-bind="item.iconProps"
 			/>
 		</template>
-	</n8n-node-creator-node>
+	</N8nNodeCreatorNode>
 </template>
 
 <style lang="scss" module>

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/ItemTypes/ViewItem.vue
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/ItemTypes/ViewItem.vue
@@ -9,7 +9,7 @@ defineProps<Props>();
 </script>
 
 <template>
-	<n8n-node-creator-node
+	<N8nNodeCreatorNode
 		:class="$style.view"
 		:title="view.title"
 		:tag="view.tag"
@@ -18,7 +18,7 @@ defineProps<Props>();
 		:show-action-arrow="true"
 	>
 		<template #icon>
-			<n8n-node-icon
+			<N8nNodeIcon
 				type="icon"
 				:name="view.icon"
 				:circle="false"
@@ -26,7 +26,7 @@ defineProps<Props>();
 				:use-updated-icons="true"
 			/>
 		</template>
-	</n8n-node-creator-node>
+	</N8nNodeCreatorNode>
 </template>
 
 <style lang="scss" module>

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/ItemsRenderer.test.ts
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/ItemsRenderer.test.ts
@@ -48,7 +48,7 @@ describe('ItemsRenderer', () => {
 			pinia: createTestingPinia(),
 			props: { elements: items },
 			global: {
-				stubs: ['n8n-loading'],
+				stubs: ['N8nLoading'],
 			},
 		});
 

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/Modes/ActionsMode.vue
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/Modes/ActionsMode.vue
@@ -280,7 +280,7 @@ const callouts = computed<INodeCreateElement[]>(() =>
 				>
 					<!-- Empty state -->
 					<template v-if="hasNoTriggerActions" #empty>
-						<n8n-callout
+						<N8nCallout
 							v-if="hasNoTriggerActions"
 							theme="info"
 							iconless
@@ -294,7 +294,7 @@ const callouts = computed<INodeCreateElement[]>(() =>
 									})
 								"
 							/>
-						</n8n-callout>
+						</N8nCallout>
 						<ItemsRenderer :elements="placeholderTriggerActions" @selected="onSelected" />
 					</template>
 					<template v-else #empty>
@@ -316,7 +316,7 @@ const callouts = computed<INodeCreateElement[]>(() =>
 					:expanded="!isTriggerRootView || parsedTriggerActions.length === 0"
 					@selected="onSelected"
 				>
-					<n8n-callout
+					<N8nCallout
 						v-if="!userActivated && isTriggerRootView"
 						theme="info"
 						iconless
@@ -324,10 +324,10 @@ const callouts = computed<INodeCreateElement[]>(() =>
 						data-test-id="actions-panel-activation-callout"
 					>
 						<span v-n8n-html="i18n.baseText('nodeCreator.actionsCallout.triggersStartWorkflow')" />
-					</n8n-callout>
+					</N8nCallout>
 					<!-- Empty state -->
 					<template #empty>
-						<n8n-info-tip v-if="!search" theme="info" type="note" :class="$style.actionsEmpty">
+						<N8nInfoTip v-if="!search" theme="info" type="note" :class="$style.actionsEmpty">
 							<span
 								v-n8n-html="
 									i18n.baseText('nodeCreator.actionsCallout.noActionItems', {
@@ -335,7 +335,7 @@ const callouts = computed<INodeCreateElement[]>(() =>
 									})
 								"
 							/>
-						</n8n-info-tip>
+						</N8nInfoTip>
 						<p
 							v-else
 							v-n8n-html="i18n.baseText('nodeCreator.actionsCategory.noMatchingActions')"

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/Panel/NoResults.vue
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/Panel/NoResults.vue
@@ -35,13 +35,13 @@ const i18n = useI18n();
 				:class="$style.action"
 			>
 				{{ i18n.baseText('nodeCreator.noResults.dontWorryYouCanProbablyDoItWithThe') }}
-				<n8n-link v-if="rootView === REGULAR_NODE_CREATOR_VIEW" @click="$emit('addHttpNode')">
+				<N8nLink v-if="rootView === REGULAR_NODE_CREATOR_VIEW" @click="$emit('addHttpNode')">
 					{{ i18n.baseText('nodeCreator.noResults.httpRequest') }}
-				</n8n-link>
+				</N8nLink>
 
-				<n8n-link v-if="rootView === TRIGGER_NODE_CREATOR_VIEW" @click="$emit('addWebhookNode')">
+				<N8nLink v-if="rootView === TRIGGER_NODE_CREATOR_VIEW" @click="$emit('addWebhookNode')">
 					{{ i18n.baseText('nodeCreator.noResults.webhook') }}
-				</n8n-link>
+				</N8nLink>
 				{{ i18n.baseText('nodeCreator.noResults.node') }}
 			</div>
 		</div>
@@ -49,17 +49,17 @@ const i18n = useI18n();
 		<div v-if="showRequest" :class="$style.request">
 			<p v-text="i18n.baseText('nodeCreator.noResults.wantUsToMakeItFaster')" />
 			<div>
-				<n8n-link :to="REQUEST_NODE_FORM_URL">
+				<N8nLink :to="REQUEST_NODE_FORM_URL">
 					<span>{{ i18n.baseText('nodeCreator.noResults.requestTheNode') }}</span
 					>&nbsp;
 					<span>
-						<n8n-icon
+						<N8nIcon
 							:class="$style.external"
 							icon="external-link"
 							:title="i18n.baseText('nodeCreator.noResults.requestTheNode')"
 						/>
 					</span>
-				</n8n-link>
+				</N8nLink>
 			</div>
 		</div>
 	</div>

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/Panel/NodesListPanel.vue
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/Panel/NodesListPanel.vue
@@ -160,7 +160,7 @@ function onBackButton() {
 </script>
 
 <template>
-	<transition
+	<Transition
 		v-if="viewStacks.length > 0"
 		:name="`panel-slide-${activeViewStack.transitionDirection}`"
 		@after-leave="onTransitionEnd"
@@ -184,7 +184,7 @@ function onBackButton() {
 						:class="$style.backButton"
 						@click="onBackButton"
 					>
-						<n8n-icon :class="$style.backButtonIcon" icon="arrow-left" :size="22" />
+						<N8nIcon :class="$style.backButtonIcon" icon="arrow-left" :size="22" />
 					</button>
 					<NodeIcon
 						v-if="activeViewStack.nodeIcon"
@@ -223,7 +223,7 @@ function onBackButton() {
 			<CommunityNodeInfo v-if="communityNodeDetails && !isActionsMode" />
 
 			<div :class="$style.renderedItems">
-				<n8n-notice
+				<N8nNotice
 					v-if="activeViewStack.info && !activeViewStack.search"
 					:class="$style.info"
 					:content="activeViewStack.info"
@@ -242,7 +242,7 @@ function onBackButton() {
 				:show-manage="communityNodeDetails.installed && isInstanceOwner"
 			/>
 		</aside>
-	</transition>
+	</Transition>
 </template>
 
 <style lang="scss" module>

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/Panel/SearchBar.vue
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/Panel/SearchBar.vue
@@ -53,7 +53,7 @@ defineExpose({
 <template>
 	<div :class="$style.searchContainer" data-test-id="search-bar">
 		<div :class="{ [$style.prefix]: true, [$style.active]: modelValue.length > 0 }">
-			<n8n-icon icon="search" size="small" />
+			<N8nIcon icon="search" size="small" />
 		</div>
 		<div :class="$style.text">
 			<input
@@ -68,7 +68,7 @@ defineExpose({
 			/>
 		</div>
 		<div v-if="modelValue.length > 0" :class="[$style.suffix, $style.clickable]" @click="clear">
-			<n8n-icon size="small" icon="circle-x" />
+			<N8nIcon size="small" icon="circle-x" />
 		</div>
 	</div>
 </template>

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/Renderers/CategorizedItemsRenderer.vue
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/Renderers/CategorizedItemsRenderer.vue
@@ -112,12 +112,12 @@ registerKeyHook(`CategoryLeft_${props.category}`, {
 			@click="toggleExpanded"
 		>
 			<span v-if="mouseOverTooltip" :class="$style.mouseOverTooltip">
-				<n8n-tooltip placement="top" :popper-class="$style.tooltipPopper">
-					<n8n-icon icon="circle-help" size="small" />
+				<N8nTooltip placement="top" :popper-class="$style.tooltipPopper">
+					<N8nIcon icon="circle-help" size="small" />
 					<template #content>
 						<div v-n8n-html="mouseOverTooltip" />
 					</template>
-				</n8n-tooltip>
+				</N8nTooltip>
 			</span>
 		</CategoryItem>
 

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/Renderers/ItemsRenderer.vue
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/Renderers/ItemsRenderer.vue
@@ -215,7 +215,7 @@ watch(
 					/>
 				</div>
 			</div>
-			<n8n-loading v-else :loading="true" :rows="1" variant="p" :class="$style.itemSkeleton" />
+			<N8nLoading v-else :loading="true" :rows="1" variant="p" :class="$style.itemSkeleton" />
 		</div>
 	</div>
 	<div v-else :class="$style.empty">

--- a/packages/frontend/editor-ui/src/components/NodeDetailsView.vue
+++ b/packages/frontend/editor-ui/src/components/NodeDetailsView.vue
@@ -696,7 +696,7 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-	<el-dialog
+	<ElDialog
 		id="ndv"
 		:model-value="(!!activeNode || renaming) && !isActiveStickyNode"
 		:before-close="close"
@@ -708,7 +708,7 @@ onBeforeUnmount(() => {
 		data-test-id="ndv"
 		:z-index="APP_Z_INDEXES.NDV"
 	>
-		<n8n-tooltip
+		<N8nTooltip
 			placement="bottom-start"
 			:visible="showTriggerWaitingWarning"
 			:disabled="!showTriggerWaitingWarning"
@@ -719,12 +719,12 @@ onBeforeUnmount(() => {
 				</div>
 			</template>
 			<div :class="$style.backToCanvas" data-test-id="back-to-canvas" @click="close">
-				<n8n-icon icon="arrow-left" color="text-xlight" size="medium" />
-				<n8n-text color="text-xlight" size="medium" :bold="true">
+				<N8nIcon icon="arrow-left" color="text-xlight" size="medium" />
+				<N8nText color="text-xlight" size="medium" :bold="true">
 					{{ i18n.baseText('ndv.backToCanvas') }}
-				</n8n-text>
+				</N8nText>
 			</div>
-		</n8n-tooltip>
+		</N8nTooltip>
 
 		<div
 			v-if="activeNode"
@@ -832,13 +832,13 @@ onBeforeUnmount(() => {
 						target="_blank"
 						@click="onFeatureRequestClick"
 					>
-						<n8n-icon icon="lightbulb" />
+						<N8nIcon icon="lightbulb" />
 						{{ i18n.baseText('ndv.featureRequest') }}
 					</a>
 				</template>
 			</NDVDraggablePanels>
 		</div>
-	</el-dialog>
+	</ElDialog>
 </template>
 
 <style lang="scss">

--- a/packages/frontend/editor-ui/src/components/NodeDetailsViewV2.vue
+++ b/packages/frontend/editor-ui/src/components/NodeDetailsViewV2.vue
@@ -272,7 +272,7 @@ const maxInputRun = computed(() => {
 		node = activeNode.value;
 	}
 
-	if (!node || !runData || !runData.hasOwnProperty(node.name)) {
+	if (!node || !runData?.hasOwnProperty(node.name)) {
 		return 0;
 	}
 

--- a/packages/frontend/editor-ui/src/components/NodeSettingsHint.vue
+++ b/packages/frontend/editor-ui/src/components/NodeSettingsHint.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue';
 import { useI18n } from '@n8n/i18n';
 import type { INodeUi } from '@/Interface';
-import type { IconName } from '@n8n/design-system/src/components/N8nIcon/icons';
+import type { IconName } from '@n8n/design-system/components/N8nIcon/icons';
 
 interface Props {
 	node: INodeUi | null;

--- a/packages/frontend/editor-ui/src/components/NodeWebhooks.vue
+++ b/packages/frontend/editor-ui/src/components/NodeWebhooks.vue
@@ -188,20 +188,20 @@ watch(
 			:title="isMinimized ? baseText.clickToDisplay : baseText.clickToHide"
 			@click="isMinimized = !isMinimized"
 		>
-			<n8n-icon icon="chevron-right" class="minimize-button minimize-icon" />
+			<N8nIcon icon="chevron-right" class="minimize-button minimize-icon" />
 			{{ baseText.toggleTitle }}
 		</div>
-		<el-collapse-transition>
+		<ElCollapseTransition>
 			<div v-if="!isMinimized" class="node-webhooks">
 				<div v-if="!isProductionOnly" class="url-selection">
-					<el-row>
-						<el-col :span="24">
-							<n8n-radio-buttons v-model="showUrlFor" :options="urlOptions" />
-						</el-col>
-					</el-row>
+					<ElRow>
+						<ElCol :span="24">
+							<N8nRadioButtons v-model="showUrlFor" :options="urlOptions" />
+						</ElCol>
+					</ElRow>
 				</div>
 
-				<n8n-tooltip
+				<N8nTooltip
 					v-for="(webhook, index) in visibleWebhookUrls"
 					:key="index"
 					class="item"
@@ -225,9 +225,9 @@ watch(
 							</div>
 						</div>
 					</div>
-				</n8n-tooltip>
+				</N8nTooltip>
 			</div>
-		</el-collapse-transition>
+		</ElCollapseTransition>
 	</div>
 </template>
 

--- a/packages/frontend/editor-ui/src/components/NodesInWorkflowTable.test.ts
+++ b/packages/frontend/editor-ui/src/components/NodesInWorkflowTable.test.ts
@@ -56,7 +56,7 @@ describe('NodesInWorkflowTable', () => {
 			},
 			global: {
 				stubs: {
-					'router-link': {
+					RouterLink: {
 						template: '<a><slot /></a>',
 					},
 				},

--- a/packages/frontend/editor-ui/src/components/NodesInWorkflowTable.vue
+++ b/packages/frontend/editor-ui/src/components/NodesInWorkflowTable.vue
@@ -74,9 +74,9 @@ const getWorkflowLink = (workflowId: string): RouteLocationRaw => ({
 			:page-sizes="[sortedItems.length + 1]"
 		>
 			<template #[`item.name`]="{ item }">
-				<router-link :to="getWorkflowLink(item.id)" target="_blank">
+				<RouterLink :to="getWorkflowLink(item.id)" target="_blank">
 					<N8nText class="ellipsis" style="color: var(--color-text-base)">{{ item.name }}</N8nText>
-				</router-link>
+				</RouterLink>
 			</template>
 			<template #[`item.homeProject.name`]="{ item }">
 				<div>

--- a/packages/frontend/editor-ui/src/components/NpsSurvey.vue
+++ b/packages/frontend/editor-ui/src/components/NpsSurvey.vue
@@ -142,7 +142,7 @@ watch(
 	>
 		<template #header>
 			<div :class="$style.title">
-				<n8n-heading tag="h2" size="medium" color="text-xlight">{{ modalTitle }}</n8n-heading>
+				<N8nHeading tag="h2" size="medium" color="text-xlight">{{ modalTitle }}</N8nHeading>
 			</div>
 		</template>
 		<template #content>
@@ -150,7 +150,7 @@ watch(
 				<div v-if="showButtons" :class="$style.wrapper">
 					<div :class="$style.buttons" data-test-id="nps-survey-ratings">
 						<div v-for="value in 11" :key="value - 1" :class="$style.container">
-							<n8n-button
+							<N8nButton
 								type="tertiary"
 								:label="(value - 1).toString()"
 								square
@@ -159,13 +159,13 @@ watch(
 						</div>
 					</div>
 					<div :class="$style.text">
-						<n8n-text size="small" color="text-xlight">{{ NOT_LIKELY_OPTION }}</n8n-text>
-						<n8n-text size="small" color="text-xlight">{{ VERY_LIKELY_OPTION }}</n8n-text>
+						<N8nText size="small" color="text-xlight">{{ NOT_LIKELY_OPTION }}</N8nText>
+						<N8nText size="small" color="text-xlight">{{ VERY_LIKELY_OPTION }}</N8nText>
 					</div>
 				</div>
 				<div v-else-if="showFeedback" :class="$style.feedback">
 					<div :class="$style.input" data-test-id="nps-survey-feedback">
-						<n8n-input
+						<N8nInput
 							v-model="form.feedback"
 							type="textarea"
 							:rows="2"
@@ -174,7 +174,7 @@ watch(
 						/>
 					</div>
 					<div :class="$style.button" data-test-id="nps-survey-feedback-button">
-						<n8n-button
+						<N8nButton
 							:label="SEND"
 							float="right"
 							:disabled="!form.feedback.trim()"

--- a/packages/frontend/editor-ui/src/components/PanelDragButton.vue
+++ b/packages/frontend/editor-ui/src/components/PanelDragButton.vue
@@ -40,13 +40,13 @@ const onDragStart = () => {
 					v-if="canMoveLeft"
 					:class="{ [$style.leftArrow]: true, [$style.visible]: isDragging }"
 				>
-					<n8n-icon icon="arrow-left" />
+					<N8nIcon icon="arrow-left" />
 				</span>
 				<span
 					v-if="canMoveRight"
 					:class="{ [$style.rightArrow]: true, [$style.visible]: isDragging }"
 				>
-					<n8n-icon icon="arrow-right" />
+					<N8nIcon icon="arrow-right" />
 				</span>
 				<div :class="$style.grid">
 					<div>

--- a/packages/frontend/editor-ui/src/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/components/ParameterInput.vue
@@ -1329,7 +1329,7 @@ onUpdated(async () => {
 					remoteParameterOptionsLoadingIssues !== null
 				"
 			>
-				<el-dialog
+				<ElDialog
 					width="calc(100% - var(--spacing-3xl))"
 					:class="$style.modal"
 					:model-value="codeEditDialogVisible"
@@ -1399,7 +1399,7 @@ onUpdated(async () => {
 							@update:model-value="valueChangedDebounced"
 						/>
 					</div>
-				</el-dialog>
+				</ElDialog>
 
 				<TextEdit
 					:dialog-visible="textEditDialogVisible"
@@ -1610,7 +1610,7 @@ onUpdated(async () => {
 			</div>
 
 			<div v-else-if="parameter.type === 'color'" ref="inputField" class="color-input">
-				<el-color-picker
+				<ElColorPicker
 					size="small"
 					class="color-picker"
 					:model-value="displayValue"
@@ -1634,7 +1634,7 @@ onUpdated(async () => {
 				/>
 			</div>
 
-			<el-date-picker
+			<ElDatePicker
 				v-else-if="parameter.type === 'dateTime'"
 				ref="inputField"
 				v-model="tempValue"
@@ -1776,7 +1776,7 @@ onUpdated(async () => {
 				:disabled="isReadOnly"
 				:title="displayTitle"
 			/>
-			<el-switch
+			<ElSwitch
 				v-else-if="parameter.type === 'boolean'"
 				ref="inputField"
 				:class="{ 'switch-input': true, 'ph-no-capture': shouldRedactValue }"

--- a/packages/frontend/editor-ui/src/components/ParameterInputExpanded.vue
+++ b/packages/frontend/editor-ui/src/components/ParameterInputExpanded.vue
@@ -114,7 +114,7 @@ function onDocumentationUrlClick(): void {
 </script>
 
 <template>
-	<n8n-input-label
+	<N8nInputLabel
 		:label="i18n.credText(activeCredentialType).inputLabelDisplayName(parameter)"
 		:tooltip-text="i18n.credText(activeCredentialType).inputLabelDescription(parameter)"
 		:required="parameter.required"
@@ -153,9 +153,9 @@ function onDocumentationUrlClick(): void {
 			@update="valueChanged"
 		/>
 		<div v-if="showRequiredErrors" :class="$style.errors">
-			<n8n-text color="danger" size="small">
+			<N8nText color="danger" size="small">
 				{{ i18n.baseText('parameterInputExpanded.thisFieldIsRequired') }}
-				<n8n-link
+				<N8nLink
 					v-if="documentationUrl"
 					:to="documentationUrl"
 					size="small"
@@ -163,10 +163,10 @@ function onDocumentationUrlClick(): void {
 					@click="onDocumentationUrlClick"
 				>
 					{{ i18n.baseText('parameterInputExpanded.openDocs') }}
-				</n8n-link>
-			</n8n-text>
+				</N8nLink>
+			</N8nText>
 		</div>
-	</n8n-input-label>
+	</N8nInputLabel>
 </template>
 
 <style lang="scss" module>

--- a/packages/frontend/editor-ui/src/components/ParameterInputHint.vue
+++ b/packages/frontend/editor-ui/src/components/ParameterInputHint.vue
@@ -38,7 +38,7 @@ const simplyText = computed(() => {
 </script>
 
 <template>
-	<n8n-text v-if="hint" size="small" color="text-base" tag="div">
+	<N8nText v-if="hint" size="small" color="text-base" tag="div">
 		<div
 			v-if="!renderHTML"
 			:class="{
@@ -54,7 +54,7 @@ const simplyText = computed(() => {
 			v-n8n-html="sanitizeHtml(hint)"
 			:class="{ [$style.singleline]: singleLine, [$style.highlight]: highlight }"
 		></div>
-	</n8n-text>
+	</N8nText>
 </template>
 
 <style lang="scss" module>

--- a/packages/frontend/editor-ui/src/components/ParameterOptions.vue
+++ b/packages/frontend/editor-ui/src/components/ParameterOptions.vue
@@ -163,10 +163,10 @@ const onViewSelected = (selected: string) => {
 <template>
 	<div :class="$style.container" data-test-id="parameter-options-container">
 		<div v-if="loading" :class="$style.loader" data-test-id="parameter-options-loader">
-			<n8n-text v-if="loading" size="small">
-				<n8n-icon icon="refresh-cw" size="xsmall" :spin="true" />
+			<N8nText v-if="loading" size="small">
+				<N8nIcon icon="refresh-cw" size="xsmall" :spin="true" />
 				{{ loadingMessage }}
-			</n8n-text>
+			</N8nText>
 		</div>
 		<div v-else :class="$style.controlsContainer">
 			<N8nTooltip v-if="canBeOpenedInFocusPanel">
@@ -183,7 +183,7 @@ const onViewSelected = (selected: string) => {
 					[$style.noExpressionSelector]: !shouldShowExpressionSelector,
 				}"
 			>
-				<n8n-action-toggle
+				<N8nActionToggle
 					v-if="shouldShowOptions"
 					placement="bottom-end"
 					size="small"
@@ -195,7 +195,7 @@ const onViewSelected = (selected: string) => {
 					@visible-change="onMenuToggle"
 				/>
 			</div>
-			<n8n-radio-buttons
+			<N8nRadioButtons
 				v-if="shouldShowExpressionSelector"
 				size="small"
 				:model-value="selectedView"

--- a/packages/frontend/editor-ui/src/components/PersonalizationModal.vue
+++ b/packages/frontend/editor-ui/src/components/PersonalizationModal.vue
@@ -620,7 +620,7 @@ const onSubmit = async (values: object) => {
 	>
 		<template #content>
 			<div :class="$style.container">
-				<n8n-form-inputs
+				<N8nFormInputs
 					v-model="formValues"
 					:inputs="survey"
 					:column-view="true"
@@ -633,7 +633,7 @@ const onSubmit = async (values: object) => {
 		</template>
 		<template #footer>
 			<div>
-				<n8n-button
+				<N8nButton
 					:loading="isSaving"
 					:label="i18n.baseText('personalizationModal.getStarted')"
 					float="right"

--- a/packages/frontend/editor-ui/src/components/Projects/ProjectCardBadge.test.ts
+++ b/packages/frontend/editor-ui/src/components/Projects/ProjectCardBadge.test.ts
@@ -5,7 +5,7 @@ import { truncate } from '@n8n/utils/string/truncate';
 const renderComponent = createComponentRenderer(ProjectCardBadge, {
 	global: {
 		stubs: {
-			'router-link': {
+			RouterLink: {
 				template: '<div><slot /></div>',
 			},
 		},

--- a/packages/frontend/editor-ui/src/components/Projects/ProjectCardBadge.vue
+++ b/packages/frontend/editor-ui/src/components/Projects/ProjectCardBadge.vue
@@ -165,9 +165,9 @@ const projectLocation = computed(() => {
 				:show-border="showBadgeBorder"
 			>
 				<ProjectIcon :icon="badgeIcon" :border-less="true" size="mini" />
-				<router-link v-if="projectLocation" :to="projectLocation">
+				<RouterLink v-if="projectLocation" :to="projectLocation">
 					<span v-n8n-truncate:20="badgeText" :class="$style.nowrap" />
-				</router-link>
+				</RouterLink>
 				<span v-else v-n8n-truncate:20="badgeText" :class="$style.nowrap" />
 			</N8nBadge>
 			<template #content>

--- a/packages/frontend/editor-ui/src/components/Projects/ProjectDeleteDialog.vue
+++ b/packages/frontend/editor-ui/src/components/Projects/ProjectDeleteDialog.vue
@@ -54,7 +54,7 @@ const onDelete = () => {
 };
 </script>
 <template>
-	<el-dialog
+	<ElDialog
 		v-model="visible"
 		:title="
 			locale.baseText('projects.settings.delete.title', {
@@ -63,28 +63,26 @@ const onDelete = () => {
 		"
 		width="650"
 	>
-		<n8n-text v-if="!hasMovableResources" color="text-base">{{
+		<N8nText v-if="!hasMovableResources" color="text-base">{{
 			locale.baseText('projects.settings.delete.message.empty')
-		}}</n8n-text>
+		}}</N8nText>
 		<div v-else-if="hasMovableResources">
-			<n8n-text color="text-base">{{
-				locale.baseText('projects.settings.delete.message')
-			}}</n8n-text>
+			<N8nText color="text-base">{{ locale.baseText('projects.settings.delete.message') }}</N8nText>
 			<div class="pt-l">
-				<el-radio
+				<ElRadio
 					:model-value="operation"
 					label="transfer"
 					class="mb-s"
 					@update:model-value="operation = 'transfer'"
 				>
-					<n8n-text color="text-dark">{{
+					<N8nText color="text-dark">{{
 						locale.baseText('projects.settings.delete.question.transfer.label')
-					}}</n8n-text>
-				</el-radio>
+					}}</N8nText>
+				</ElRadio>
 				<div v-if="operation === 'transfer'" :class="$style.operation">
-					<n8n-text color="text-dark">{{
+					<N8nText color="text-dark">{{
 						locale.baseText('projects.settings.delete.question.transfer.title')
-					}}</n8n-text>
+					}}</N8nText>
 					<ProjectSharing
 						v-model="selectedProject"
 						class="pt-2xs"
@@ -93,24 +91,24 @@ const onDelete = () => {
 					/>
 				</div>
 
-				<el-radio
+				<ElRadio
 					:model-value="operation"
 					label="wipe"
 					class="mb-s"
 					@update:model-value="operation = 'wipe'"
 				>
-					<n8n-text color="text-dark">{{
+					<N8nText color="text-dark">{{
 						locale.baseText('projects.settings.delete.question.wipe.label')
-					}}</n8n-text>
-				</el-radio>
+					}}</N8nText>
+				</ElRadio>
 				<div v-if="operation === 'wipe'" :class="$style.operation">
-					<n8n-input-label :label="locale.baseText('projects.settings.delete.question.wipe.title')">
-						<n8n-input
+					<N8nInputLabel :label="locale.baseText('projects.settings.delete.question.wipe.title')">
+						<N8nInput
 							v-model="wipeConfirmText"
 							data-test-id="project-delete-confirm-input"
 							:placeholder="locale.baseText('projects.settings.delete.question.wipe.placeholder')"
 						/>
-					</n8n-input-label>
+					</N8nInputLabel>
 				</div>
 			</div>
 		</div>
@@ -124,7 +122,7 @@ const onDelete = () => {
 				>{{ locale.baseText('projects.settings.danger.deleteProject') }}</N8nButton
 			>
 		</template>
-	</el-dialog>
+	</ElDialog>
 </template>
 
 <style lang="scss" module>

--- a/packages/frontend/editor-ui/src/components/Projects/ProjectMoveResourceModalCredentialsList.vue
+++ b/packages/frontend/editor-ui/src/components/Projects/ProjectMoveResourceModalCredentialsList.vue
@@ -45,13 +45,13 @@ const getCredentialRouterLocation = (
 <template>
 	<ul :class="$style.credentialsList">
 		<li v-for="credential in props.credentials" :key="credential.id">
-			<router-link
+			<RouterLink
 				v-if="isCredentialReadable(credential)"
 				target="_blank"
 				:to="getCredentialRouterLocation(credential)"
 			>
 				{{ credential.name }}
-			</router-link>
+			</RouterLink>
 			<span v-else>{{ credential.name }}</span>
 		</li>
 	</ul>

--- a/packages/frontend/editor-ui/src/components/Projects/ProjectMoveSuccessToastMessage.test.ts
+++ b/packages/frontend/editor-ui/src/components/Projects/ProjectMoveSuccessToastMessage.test.ts
@@ -7,7 +7,7 @@ import { ProjectTypes } from '@/types/projects.types';
 const renderComponent = createComponentRenderer(ProjectMoveSuccessToastMessage, {
 	global: {
 		stubs: {
-			'router-link': {
+			RouterLink: {
 				template: '<a href="#"><slot /></a>',
 			},
 		},

--- a/packages/frontend/editor-ui/src/components/Projects/ProjectMoveSuccessToastMessage.vue
+++ b/packages/frontend/editor-ui/src/components/Projects/ProjectMoveSuccessToastMessage.vue
@@ -33,7 +33,7 @@ const targetProjectName = computed(() => {
 			<span v-else>{{ i18n.baseText('projects.move.resource.success.message.workflow') }}</span>
 		</N8nText>
 		<p v-if="isTargetProjectTeam" class="pt-s">
-			<router-link
+			<RouterLink
 				:to="{
 					name: props.routeName,
 					params: { projectId: props.targetProject.id },
@@ -44,7 +44,7 @@ const targetProjectName = computed(() => {
 						interpolate: { targetProjectName },
 					})
 				}}
-			</router-link>
+			</RouterLink>
 		</p>
 	</div>
 </template>

--- a/packages/frontend/editor-ui/src/components/Projects/ProjectRoleUpgradeDialog.vue
+++ b/packages/frontend/editor-ui/src/components/Projects/ProjectRoleUpgradeDialog.vue
@@ -19,7 +19,7 @@ const goToUpgrade = async () => {
 };
 </script>
 <template>
-	<el-dialog
+	<ElDialog
 		v-model="visible"
 		:title="locale.baseText('projects.settings.role.upgrade.title')"
 		width="500"
@@ -45,5 +45,5 @@ const goToUpgrade = async () => {
 				locale.baseText('projects.create.limitReached.link')
 			}}</N8nButton>
 		</template>
-	</el-dialog>
+	</ElDialog>
 </template>

--- a/packages/frontend/editor-ui/src/components/Projects/ProjectTabs.test.ts
+++ b/packages/frontend/editor-ui/src/components/Projects/ProjectTabs.test.ts
@@ -14,7 +14,7 @@ vi.mock('vue-router', async () => {
 const renderComponent = createComponentRenderer(ProjectTabs, {
 	global: {
 		stubs: {
-			'router-link': {
+			RouterLink: {
 				template: '<div><slot /></div>',
 			},
 		},

--- a/packages/frontend/editor-ui/src/components/PromptMfaCodeModal/PromptMfaCodeModal.vue
+++ b/packages/frontend/editor-ui/src/components/PromptMfaCodeModal/PromptMfaCodeModal.vue
@@ -65,7 +65,7 @@ function onFormReady(isReady: boolean) {
 	>
 		<template #content>
 			<div :class="[$style.formContainer]">
-				<n8n-form-inputs
+				<N8nFormInputs
 					data-test-id="mfa-code-or-recovery-code-input"
 					:inputs="formFields"
 					:event-bus="formBus"
@@ -76,7 +76,7 @@ function onFormReady(isReady: boolean) {
 		</template>
 		<template #footer>
 			<div>
-				<n8n-button
+				<N8nButton
 					float="right"
 					:disabled="!readyToSubmit"
 					:label="i18n.baseText('settings.personal.save')"

--- a/packages/frontend/editor-ui/src/components/PushConnectionTracker.vue
+++ b/packages/frontend/editor-ui/src/components/PushConnectionTracker.vue
@@ -18,15 +18,15 @@ const showConnectionLostError = computed(() => {
 <template>
 	<span>
 		<div v-if="showConnectionLostError" class="push-connection-lost primary-color">
-			<n8n-tooltip placement="bottom-end">
+			<N8nTooltip placement="bottom-end">
 				<template #content>
 					<div v-n8n-html="i18n.baseText('pushConnectionTracker.cannotConnectToServer')"></div>
 				</template>
 				<span>
-					<n8n-icon icon="triangle-alert" />&nbsp;
+					<N8nIcon icon="triangle-alert" />&nbsp;
 					{{ i18n.baseText('pushConnectionTracker.connectionLost') }}
 				</span>
-			</n8n-tooltip>
+			</N8nTooltip>
 		</div>
 		<slot v-else />
 	</span>

--- a/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocator.test.ts
+++ b/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocator.test.ts
@@ -68,7 +68,7 @@ const renderComponent = createComponentRenderer(ResourceLocator, {
 			ExpressionParameterInput: true,
 			ParameterIssues: true,
 			N8nCallout: true,
-			'font-awesome-icon': true,
+			FontAwesomeIcon: true,
 			FromAiOverrideField: true,
 			FromAiOverrideButton: true,
 			ParameterOverrideSelectableList: true,

--- a/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocator.vue
+++ b/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocator.vue
@@ -952,23 +952,23 @@ function removeOverride() {
 		>
 			<template #error>
 				<div :class="$style.errorContainer" data-test-id="rlc-error-container">
-					<n8n-text
+					<N8nText
 						v-if="credentialsRequiredAndNotSet || currentResponse.errorDetails"
 						color="text-dark"
 						align="center"
 						tag="div"
 					>
 						{{ i18n.baseText('resourceLocator.mode.list.error.title') }}
-					</n8n-text>
+					</N8nText>
 					<div v-if="currentResponse.errorDetails" :class="$style.errorDetails">
-						<n8n-text size="small">
+						<N8nText size="small">
 							<span v-if="currentResponse.errorDetails.httpCode" data-test-id="rlc-error-code">
 								{{ currentResponse.errorDetails.httpCode }} -
 							</span>
 							<span data-test-id="rlc-error-message">{{
 								currentResponse.errorDetails.message
 							}}</span>
-						</n8n-text>
+						</N8nText>
 						<N8nNotice
 							v-if="currentResponse.errorDetails.description"
 							theme="warning"
@@ -1011,7 +1011,7 @@ function removeOverride() {
 					]"
 				></div>
 				<div v-if="hasMultipleModes" :class="$style.modeSelector">
-					<n8n-select
+					<N8nSelect
 						:model-value="selectedMode"
 						:size="inputSize"
 						:disabled="isReadOnly"
@@ -1019,7 +1019,7 @@ function removeOverride() {
 						data-test-id="rlc-mode-selector"
 						@update:model-value="onModeSelected"
 					>
-						<n8n-option
+						<N8nOption
 							v-for="mode in parameter.modes"
 							:key="mode.name"
 							:data-test-id="`mode-${mode.name}`"
@@ -1033,8 +1033,8 @@ function removeOverride() {
 							"
 						>
 							{{ getModeLabel(mode) }}
-						</n8n-option>
-					</n8n-select>
+						</N8nOption>
+					</N8nSelect>
 				</div>
 
 				<div :class="$style.inputContainer" data-test-id="rlc-input-container">
@@ -1073,7 +1073,7 @@ function removeOverride() {
 									@update:model-value="onInputChange"
 									@modal-opener-click="emit('modalOpenerClick')"
 								/>
-								<n8n-input
+								<N8nInput
 									v-else
 									ref="inputRef"
 									:class="[
@@ -1106,7 +1106,7 @@ function removeOverride() {
 											}"
 										/>
 									</template>
-								</n8n-input>
+								</N8nInput>
 								<div v-if="showOverrideButton" :class="$style.overrideButtonInline">
 									<FromAiOverrideButton @click="applyOverride" />
 								</div>
@@ -1119,9 +1119,9 @@ function removeOverride() {
 						:class="$style['parameter-issues']"
 					/>
 					<div v-else-if="urlValue" :class="$style.openResourceLink">
-						<n8n-link theme="text" @click.stop="openResource(urlValue)">
-							<n8n-icon icon="external-link" :title="getLinkAlt(valueToDisplay)" />
-						</n8n-link>
+						<N8nLink theme="text" @click.stop="openResource(urlValue)">
+							<N8nIcon icon="external-link" :title="getLinkAlt(valueToDisplay)" />
+						</N8nLink>
 					</div>
 				</div>
 			</div>

--- a/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocatorDropdown.vue
+++ b/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocatorDropdown.vue
@@ -222,7 +222,7 @@ defineExpose({ isWithinDropdown });
 </script>
 
 <template>
-	<n8n-popover
+	<N8nPopover
 		placement="bottom"
 		:width="props.width"
 		:popper-class="$style.popover"
@@ -251,7 +251,7 @@ defineExpose({ isWithinDropdown });
 				@update:model-value="onFilterInput"
 			>
 				<template #prefix>
-					<n8n-icon :class="$style.searchIcon" icon="search" />
+					<N8nIcon :class="$style.searchIcon" icon="search" />
 				</template>
 			</N8nInput>
 		</div>
@@ -293,7 +293,7 @@ defineExpose({ isWithinDropdown });
 			>
 				<div :class="$style.resourceNameContainer">
 					<span :class="$style.addResourceText">{{ props.allowNewResources.label }}</span>
-					<n8n-icon :class="$style.addResourceIcon" icon="plus" />
+					<N8nIcon :class="$style.addResourceIcon" icon="plus" />
 				</div>
 			</div>
 			<div
@@ -319,7 +319,7 @@ defineExpose({ isWithinDropdown });
 					</span>
 				</div>
 				<div :class="$style.urlLink">
-					<n8n-icon
+					<N8nIcon
 						v-if="showHoverUrl && result.url && hoverIndex === i + 1"
 						icon="external-link"
 						:title="result.linkAlt || i18n.baseText('resourceLocator.mode.list.openUrl')"
@@ -336,7 +336,7 @@ defineExpose({ isWithinDropdown });
 		<template #reference>
 			<slot />
 		</template>
-	</n8n-popover>
+	</N8nPopover>
 </template>
 
 <style lang="scss" module>

--- a/packages/frontend/editor-ui/src/components/ResourceMapper/MatchingColumnsSelect.vue
+++ b/packages/frontend/editor-ui/src/components/ResourceMapper/MatchingColumnsSelect.vue
@@ -199,14 +199,14 @@ defineExpose({
 				:teleported="teleported"
 				@update:model-value="onSelectionChange"
 			>
-				<n8n-option
+				<N8nOption
 					v-for="field in availableMatchingFields"
 					:key="field.id"
 					:value="field.id"
 					:data-test-id="`matching-column-option-${field.id}`"
 				>
 					{{ field.displayName }}
-				</n8n-option>
+				</N8nOption>
 			</N8nSelect>
 			<N8nText size="small">
 				{{ fieldDescription }}

--- a/packages/frontend/editor-ui/src/components/RunDataAi/RunDataAi.vue
+++ b/packages/frontend/editor-ui/src/components/RunDataAi/RunDataAi.vue
@@ -126,9 +126,9 @@ watch(() => props.runIndex, selectFirst, { immediate: true });
 								:class="$style.treeToggle"
 								@click="toggleTreeItem(currentNode)"
 							>
-								<n8n-icon :icon="currentNode.expanded ? 'chevron-down' : 'chevron-right'" />
+								<N8nIcon :icon="currentNode.expanded ? 'chevron-down' : 'chevron-right'" />
 							</button>
-							<n8n-tooltip :disabled="!slim" placement="right">
+							<N8nTooltip :disabled="!slim" placement="right">
 								<template #content>
 									{{ currentNode.label }}
 								</template>
@@ -140,14 +140,14 @@ watch(() => props.runIndex, selectFirst, { immediate: true });
 									/>
 									<span v-if="!slim" v-text="currentNode.label" />
 								</span>
-							</n8n-tooltip>
+							</N8nTooltip>
 						</div>
 					</template>
 				</ElTree>
 			</div>
 			<div :class="$style.runData">
 				<div v-if="selectedRun.length === 0" :class="$style.empty">
-					<n8n-text size="large">
+					<N8nText size="large">
 						{{
 							i18n.baseText('ndv.output.ai.empty', {
 								interpolate: {
@@ -155,7 +155,7 @@ watch(() => props.runIndex, selectFirst, { immediate: true });
 								},
 							})
 						}}
-					</n8n-text>
+					</N8nText>
 				</div>
 				<div
 					v-for="(data, index) in selectedRun"

--- a/packages/frontend/editor-ui/src/components/RunDataAi/RunDataAiContent.vue
+++ b/packages/frontend/editor-ui/src/components/RunDataAi/RunDataAiContent.vue
@@ -92,7 +92,7 @@ const outputError = computed(() => {
 				<ul :class="$style.meta">
 					<li v-if="runMeta?.startTimeMs">{{ runMeta?.executionTimeMs }}ms</li>
 					<li v-if="runMeta?.startTimeMs">
-						<n8n-tooltip>
+						<N8nTooltip>
 							<template #content>
 								{{ new Date(runMeta?.startTimeMs).toLocaleString() }}
 							</template>
@@ -103,7 +103,7 @@ const outputError = computed(() => {
 									},
 								})
 							}}
-						</n8n-tooltip>
+						</N8nTooltip>
 					</li>
 					<li v-if="runMeta">
 						<ViewSubExecution :task-metadata="runMeta" :display-mode="'ai'" :inline="true" />
@@ -116,9 +116,9 @@ const outputError = computed(() => {
 								},
 							})
 						}}
-						<n8n-info-tip type="tooltip" theme="info-light" tooltip-placement="right">
+						<N8nInfoTip type="tooltip" theme="info-light" tooltip-placement="right">
 							<ConsumedTokensDetails :consumed-tokens="consumedTokensSum" />
-						</n8n-info-tip>
+						</N8nInfoTip>
 					</li>
 				</ul>
 			</div>

--- a/packages/frontend/editor-ui/src/components/RunDataPaginationBar.vue
+++ b/packages/frontend/editor-ui/src/components/RunDataPaginationBar.vue
@@ -15,7 +15,7 @@ const pageSizes = [1, 10, 25, 50, 100];
 
 <template>
 	<div :class="$style.pagination" data-test-id="ndv-data-pagination">
-		<el-pagination
+		<ElPagination
 			background
 			:hide-on-single-page="true"
 			:current-page="currentPage"
@@ -25,7 +25,7 @@ const pageSizes = [1, 10, 25, 50, 100];
 			:total="total"
 			@update:current-page="(value: number) => emit('update:current-page', value)"
 		>
-		</el-pagination>
+		</ElPagination>
 
 		<div :class="$style.pageSizeSelector">
 			<N8nSelect

--- a/packages/frontend/editor-ui/src/components/RunDataPinButton.test.ts
+++ b/packages/frontend/editor-ui/src/components/RunDataPinButton.test.ts
@@ -7,7 +7,7 @@ import { STORES } from '@n8n/stores';
 
 const renderComponent = createComponentRenderer(RunDataPinButton, {
 	global: {
-		stubs: ['font-awesome-icon'],
+		stubs: ['FontAwesomeIcon'],
 		plugins: [
 			createTestingPinia({
 				initialState: {

--- a/packages/frontend/editor-ui/src/components/RunDataSearch.vue
+++ b/packages/frontend/editor-ui/src/components/RunDataSearch.vue
@@ -161,7 +161,7 @@ watch(
 </script>
 
 <template>
-	<n8n-input
+	<N8nInput
 		ref="inputRef"
 		data-test-id="ndv-search"
 		:class="{
@@ -177,9 +177,9 @@ watch(
 		@blur="onBlur"
 	>
 		<template #prefix>
-			<n8n-icon :class="$style.ioSearchIcon" icon="search" size="large" />
+			<N8nIcon :class="$style.ioSearchIcon" icon="search" size="large" />
 		</template>
-	</n8n-input>
+	</N8nInput>
 </template>
 
 <style lang="scss" module>

--- a/packages/frontend/editor-ui/src/components/RunDataTable.vue
+++ b/packages/frontend/editor-ui/src/components/RunDataTable.vue
@@ -621,7 +621,7 @@ watch(
 											/>
 										</N8nTooltip>
 										<div v-if="mappingEnabled" :class="$style.dragButton">
-											<n8n-icon icon="grip-vertical" />
+											<N8nIcon icon="grip-vertical" />
 										</div>
 									</div>
 								</template>
@@ -647,7 +647,7 @@ watch(
 								</div>
 							</template>
 							<span>
-								<n8n-icon :class="$style['warningTooltip']" icon="triangle-alert" />
+								<N8nIcon :class="$style['warningTooltip']" icon="triangle-alert" />
 								{{ i18n.baseText('dataMapping.tableView.tableColumnsExceeded') }}
 							</span>
 						</N8nTooltip>

--- a/packages/frontend/editor-ui/src/components/RunInfo.vue
+++ b/packages/frontend/editor-ui/src/components/RunInfo.vue
@@ -66,22 +66,20 @@ const runMetadata = computed(() => {
 			tooltip-placement="right"
 		>
 			<div>
-				<n8n-text :bold="true" size="small"
+				<N8nText :bold="true" size="small"
 					>{{
 						runTaskData?.error
 							? i18n.baseText('runData.executionStatus.failed')
 							: runTaskData?.executionStatus === 'canceled'
 								? i18n.baseText('runData.executionStatus.canceled')
 								: i18n.baseText('runData.executionStatus.success')
-					}} </n8n-text
+					}} </N8nText
 				><br />
-				<n8n-text :bold="true" size="small">{{
-					i18n.baseText('runData.startTime') + ':'
-				}}</n8n-text>
+				<N8nText :bold="true" size="small">{{ i18n.baseText('runData.startTime') + ':' }}</N8nText>
 				{{ runMetadata.startTime }}<br />
-				<n8n-text :bold="true" size="small">{{
+				<N8nText :bold="true" size="small">{{
 					i18n.baseText('runData.executionTime') + ':'
-				}}</n8n-text>
+				}}</N8nText>
 				{{ runMetadata.executionTime }} {{ i18n.baseText('runData.ms') }}
 			</div>
 		</N8nInfoTip>

--- a/packages/frontend/editor-ui/src/components/SSOLogin.test.ts
+++ b/packages/frontend/editor-ui/src/components/SSOLogin.test.ts
@@ -13,7 +13,7 @@ let ssoStore: ReturnType<typeof useSSOStore>;
 const renderComponent = createComponentRenderer(SSOLogin, {
 	global: {
 		stubs: {
-			'n8n-button': {
+			N8nButton: {
 				template: '<button data-test-id="sso-button"></button>',
 			},
 		},

--- a/packages/frontend/editor-ui/src/components/SaveButton.vue
+++ b/packages/frontend/editor-ui/src/components/SaveButton.vue
@@ -45,7 +45,7 @@ const shortcutTooltipLabel = computed(() => {
 				:shortcut="{ keys: ['s'], metaKey: true }"
 				placement="bottom"
 			>
-				<n8n-button
+				<N8nButton
 					:label="saveButtonLabel"
 					:loading="isSaving"
 					:disabled="disabled"
@@ -53,7 +53,7 @@ const shortcutTooltipLabel = computed(() => {
 					:type="type"
 				/>
 			</KeyboardShortcutTooltip>
-			<n8n-button
+			<N8nButton
 				v-else
 				:label="saveButtonLabel"
 				:loading="isSaving"

--- a/packages/frontend/editor-ui/src/components/ScopesNotice.vue
+++ b/packages/frontend/editor-ui/src/components/ScopesNotice.vue
@@ -46,5 +46,5 @@ const scopesFullContent = computed((): string => {
 </script>
 
 <template>
-	<n8n-notice :content="scopesShortContent" :full-content="scopesFullContent" />
+	<N8nNotice :content="scopesShortContent" :full-content="scopesFullContent" />
 </template>

--- a/packages/frontend/editor-ui/src/components/SettingsLogStreaming/EventDestinationCard.ee.vue
+++ b/packages/frontend/editor-ui/src/components/SettingsLogStreaming/EventDestinationCard.ee.vue
@@ -133,31 +133,31 @@ async function onAction(action: string) {
 </script>
 
 <template>
-	<n8n-card :class="$style.cardLink" data-test-id="destination-card" @click="onClick">
+	<N8nCard :class="$style.cardLink" data-test-id="destination-card" @click="onClick">
 		<template #header>
 			<div>
-				<n8n-heading tag="h2" bold :class="$style.cardHeading">
+				<N8nHeading tag="h2" bold :class="$style.cardHeading">
 					{{ destination.label }}
-				</n8n-heading>
+				</N8nHeading>
 				<div :class="$style.cardDescription">
-					<n8n-text color="text-light" size="small">
+					<N8nText color="text-light" size="small">
 						<span>{{ i18n.baseText(typeLabelName) }}</span>
-					</n8n-text>
+					</N8nText>
 				</div>
 			</div>
 		</template>
 		<template #append>
 			<div ref="cardActions" :class="$style.cardActions">
 				<div :class="$style.activeStatusText" data-test-id="destination-activator-status">
-					<n8n-text v-if="nodeParameters.enabled" :color="'success'" size="small" bold>
+					<N8nText v-if="nodeParameters.enabled" :color="'success'" size="small" bold>
 						{{ i18n.baseText('workflowActivator.active') }}
-					</n8n-text>
-					<n8n-text v-else color="text-base" size="small" bold>
+					</N8nText>
+					<N8nText v-else color="text-base" size="small" bold>
 						{{ i18n.baseText('workflowActivator.inactive') }}
-					</n8n-text>
+					</N8nText>
 				</div>
 
-				<el-switch
+				<ElSwitch
 					class="mr-s"
 					:disabled="readonly"
 					:model-value="nodeParameters.enabled"
@@ -171,12 +171,12 @@ async function onAction(action: string) {
 					data-test-id="workflow-activate-switch"
 					@update:model-value="onEnabledSwitched($event)"
 				>
-				</el-switch>
+				</ElSwitch>
 
-				<n8n-action-toggle :actions="actions" theme="dark" @action="onAction" />
+				<N8nActionToggle :actions="actions" theme="dark" @action="onAction" />
 			</div>
 		</template>
-	</n8n-card>
+	</N8nCard>
 </template>
 
 <style lang="scss" module>

--- a/packages/frontend/editor-ui/src/components/SettingsLogStreaming/EventDestinationSettingsModal.ee.vue
+++ b/packages/frontend/editor-ui/src/components/SettingsLogStreaming/EventDestinationSettingsModal.ee.vue
@@ -394,7 +394,7 @@ const { width } = useElementSize(defNameRef);
 						}}</N8nText>
 					</div>
 					<div :class="$style.destinationActions">
-						<n8n-button
+						<N8nButton
 							v-if="nodeParameters && hasOnceBeenSaved && unchanged"
 							:icon="testMessageSent ? (testMessageResult ? 'check' : 'triangle-alert') : undefined"
 							:title="
@@ -409,7 +409,7 @@ const { width } = useElementSize(defNameRef);
 							@click="sendTestEvent"
 						/>
 						<template v-if="canManageLogStreaming">
-							<n8n-icon-button
+							<N8nIconButton
 								v-if="nodeParameters && hasOnceBeenSaved"
 								:title="i18n.baseText('settings.log-streaming.delete')"
 								icon="trash-2"
@@ -435,7 +435,7 @@ const { width } = useElementSize(defNameRef);
 		<template #content>
 			<div :class="$style.container">
 				<template v-if="isTypeAbstract">
-					<n8n-input-label
+					<N8nInputLabel
 						:class="$style.typeSelector"
 						:label="i18n.baseText('settings.log-streaming.selecttype')"
 						:tooltip-text="i18n.baseText('settings.log-streaming.selecttypehint')"
@@ -443,7 +443,7 @@ const { width } = useElementSize(defNameRef);
 						size="medium"
 						:underline="false"
 					>
-						<n8n-select
+						<N8nSelect
 							ref="typeSelectRef"
 							:model-value="typeSelectValue"
 							:placeholder="typeSelectPlaceholder"
@@ -451,28 +451,28 @@ const { width } = useElementSize(defNameRef);
 							name="name"
 							@update:model-value="onTypeSelectInput"
 						>
-							<n8n-option
+							<N8nOption
 								v-for="option in typeSelectOptions || []"
 								:key="option.value"
 								:value="option.value"
 								:label="i18n.baseText(option.label)"
 							/>
-						</n8n-select>
+						</N8nSelect>
 						<div class="mt-m text-right">
-							<n8n-button
+							<N8nButton
 								size="large"
 								data-test-id="select-destination-button"
 								:disabled="!typeSelectValue"
 								@click="onContinueAddClicked"
 							>
 								{{ i18n.baseText(`settings.log-streaming.continue`) }}
-							</n8n-button>
+							</N8nButton>
 						</div>
-					</n8n-input-label>
+					</N8nInputLabel>
 				</template>
 				<template v-else>
 					<div :class="$style.sidebar">
-						<n8n-menu mode="tabs" :items="sidebarItems" @select="onTabSelect"></n8n-menu>
+						<N8nMenu mode="tabs" :items="sidebarItems" @select="onTabSelect"></N8nMenu>
 					</div>
 					<div v-if="activeTab === 'settings'" ref="content" :class="$style.mainContent">
 						<template v-if="isTypeWebhook">
@@ -508,7 +508,7 @@ const { width } = useElementSize(defNameRef);
 					</div>
 					<div v-if="activeTab === 'events'" :class="$style.mainContent">
 						<div class="">
-							<n8n-input-label
+							<N8nInputLabel
 								class="mb-m mt-m"
 								:label="i18n.baseText('settings.log-streaming.tab.events.title')"
 								:bold="true"

--- a/packages/frontend/editor-ui/src/components/SettingsLogStreaming/EventSelection.ee.vue
+++ b/packages/frontend/editor-ui/src/components/SettingsLogStreaming/EventSelection.ee.vue
@@ -79,17 +79,17 @@ export default defineComponent({
 				@change="onCheckboxChecked(group.name, $event)"
 			>
 				<strong>{{ groupLabelName(group.name) }}</strong>
-				<n8n-tooltip
+				<N8nTooltip
 					v-if="groupLabelInfo(group.name)"
 					placement="top"
 					:popper-class="$style.tooltipPopper"
 					class="ml-xs"
 				>
-					<n8n-icon icon="circle-help" size="small" class="ml-4xs" />
+					<N8nIcon icon="circle-help" size="small" class="ml-4xs" />
 					<template #content>
 						{{ groupLabelInfo(group.name) }}
 					</template>
-				</n8n-tooltip>
+				</N8nTooltip>
 			</Checkbox>
 			<Checkbox
 				v-if="group.name === 'n8n.audit'"
@@ -99,12 +99,12 @@ export default defineComponent({
 				@change="anonymizeAuditMessagesChanged"
 			>
 				{{ i18n.baseText('settings.log-streaming.tab.events.anonymize') }}
-				<n8n-tooltip placement="top" :popper-class="$style.tooltipPopper">
-					<n8n-icon icon="circle-help" size="small" class="ml-4xs" />
+				<N8nTooltip placement="top" :popper-class="$style.tooltipPopper">
+					<N8nIcon icon="circle-help" size="small" class="ml-4xs" />
 					<template #content>
 						{{ i18n.baseText('settings.log-streaming.tab.events.anonymize.info') }}
 					</template>
-				</n8n-tooltip>
+				</N8nTooltip>
 			</Checkbox>
 			<!-- </template> -->
 			<ul :class="$style.eventList">
@@ -117,11 +117,11 @@ export default defineComponent({
 						@change="onCheckboxChecked(event.name, $event)"
 					>
 						{{ event.label }}
-						<n8n-tooltip placement="top" :popper-class="$style.tooltipPopper">
+						<N8nTooltip placement="top" :popper-class="$style.tooltipPopper">
 							<template #content>
 								{{ event.name }}
 							</template>
-						</n8n-tooltip>
+						</N8nTooltip>
 					</Checkbox>
 				</li>
 			</ul>

--- a/packages/frontend/editor-ui/src/components/SettingsSidebar.vue
+++ b/packages/frontend/editor-ui/src/components/SettingsSidebar.vue
@@ -130,23 +130,23 @@ const sidebarMenuItems = computed<IMenuItem[]>(() => {
 
 <template>
 	<div :class="$style.container">
-		<n8n-menu :items="sidebarMenuItems">
+		<N8nMenu :items="sidebarMenuItems">
 			<template #header>
 				<div :class="$style.returnButton" data-test-id="settings-back" @click="emit('return')">
 					<i class="mr-xs">
-						<n8n-icon icon="arrow-left" />
+						<N8nIcon icon="arrow-left" />
 					</i>
-					<n8n-heading size="large" :bold="true">{{ i18n.baseText('settings') }}</n8n-heading>
+					<N8nHeading size="large" :bold="true">{{ i18n.baseText('settings') }}</N8nHeading>
 				</div>
 			</template>
 			<template #menuSuffix>
 				<div :class="$style.versionContainer">
-					<n8n-link size="small" @click="uiStore.openModal(ABOUT_MODAL_KEY)">
+					<N8nLink size="small" @click="uiStore.openModal(ABOUT_MODAL_KEY)">
 						{{ i18n.baseText('settings.version') }} {{ rootStore.versionCli }}
-					</n8n-link>
+					</N8nLink>
 				</div>
 			</template>
-		</n8n-menu>
+		</N8nMenu>
 	</div>
 </template>
 

--- a/packages/frontend/editor-ui/src/components/SetupWorkflowCredentialsButton/SetupWorkflowCredentialsButton.vue
+++ b/packages/frontend/editor-ui/src/components/SetupWorkflowCredentialsButton/SetupWorkflowCredentialsButton.vue
@@ -58,7 +58,7 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-	<n8n-button
+	<N8nButton
 		v-if="showButton"
 		:label="i18n.baseText('nodeView.setupTemplate')"
 		data-test-id="setup-credentials-button"

--- a/packages/frontend/editor-ui/src/components/SetupWorkflowCredentialsModal/SetupWorkflowCredentialsModal.vue
+++ b/packages/frontend/editor-ui/src/components/SetupWorkflowCredentialsModal/SetupWorkflowCredentialsModal.vue
@@ -79,7 +79,7 @@ onUnmounted(() => {
 
 		<template #footer>
 			<div :class="$style.footer">
-				<n8n-button
+				<N8nButton
 					size="large"
 					:label="i18n.baseText('templateSetup.continue.button')"
 					:disabled="numFilledCredentials === 0"

--- a/packages/frontend/editor-ui/src/components/SourceControlPullModal.ee.test.ts
+++ b/packages/frontend/editor-ui/src/components/SourceControlPullModal.ee.test.ts
@@ -96,7 +96,7 @@ const renderModal = createComponentRenderer(SourceControlPullModalEe, {
 				template: '<button><slot></slot></button>',
 				props: ['icon', 'type', 'class'],
 			},
-			'router-link': {
+			RouterLink: {
 				template: '<a><slot /></a>',
 				props: ['to'],
 			},

--- a/packages/frontend/editor-ui/src/components/SourceControlPushModal.ee.test.ts
+++ b/packages/frontend/editor-ui/src/components/SourceControlPushModal.ee.test.ts
@@ -121,7 +121,7 @@ const renderModal = createComponentRenderer(SourceControlPushModal, {
 					</div>
 				`,
 			},
-			'router-link': {
+			RouterLink: {
 				template: '<a><slot /></a>',
 				props: ['to'],
 			},

--- a/packages/frontend/editor-ui/src/components/TagsContainer.vue
+++ b/packages/frontend/editor-ui/src/components/TagsContainer.vue
@@ -136,7 +136,7 @@ onBeforeUnmount(() => {
 				:class="{ clickable: !tag.hidden }"
 				@click="(e) => onClick(e, tag)"
 			>
-				<el-tag
+				<ElTag
 					v-if="tag.isCount"
 					:title="tag.title"
 					type="info"
@@ -145,7 +145,7 @@ onBeforeUnmount(() => {
 					:disable-transitions="true"
 				>
 					{{ tag.name }}
-				</el-tag>
+				</ElTag>
 				<IntersectionObserved
 					v-else
 					:class="{ hideTag: tag.hidden }"
@@ -153,7 +153,7 @@ onBeforeUnmount(() => {
 					:enabled="responsive"
 					:event-bus="intersectionEventBus"
 				>
-					<el-tag
+					<ElTag
 						:title="tag.name"
 						type="info"
 						size="mini"
@@ -161,7 +161,7 @@ onBeforeUnmount(() => {
 						:disable-transitions="true"
 					>
 						{{ tag.name }}
-					</el-tag>
+					</ElTag>
 				</IntersectionObserved>
 			</span>
 		</span>

--- a/packages/frontend/editor-ui/src/components/TagsDropdown.vue
+++ b/packages/frontend/editor-ui/src/components/TagsDropdown.vue
@@ -237,7 +237,7 @@ onClickOutside(
 				:value="CREATE_KEY"
 				class="ops"
 			>
-				<n8n-icon icon="circle-plus" />
+				<N8nIcon icon="circle-plus" />
 				<span>
 					{{ i18n.baseText('tagsDropdown.createTag', { interpolate: { filter } }) }}
 				</span>
@@ -261,7 +261,7 @@ onClickOutside(
 			/>
 
 			<N8nOption v-if="manageEnabled" :key="MANAGE_KEY" :value="MANAGE_KEY" class="ops manage-tags">
-				<n8n-icon icon="cog" />
+				<N8nIcon icon="cog" />
 				<span>{{ i18n.baseText('tagsDropdown.manageTags') }}</span>
 			</N8nOption>
 		</N8nSelect>

--- a/packages/frontend/editor-ui/src/components/TagsManager/NoTagsView.vue
+++ b/packages/frontend/editor-ui/src/components/TagsManager/NoTagsView.vue
@@ -17,20 +17,20 @@ const i18n = useI18n();
 
 <template>
 	<div :class="$style.container">
-		<el-col class="notags" :span="16">
+		<ElCol class="notags" :span="16">
 			<div class="icon">🗄️</div>
 			<div>
 				<div class="mb-s">
-					<n8n-heading size="large">
+					<N8nHeading size="large">
 						{{ i18n.baseText(titleLocaleKey) }}
-					</n8n-heading>
+					</N8nHeading>
 				</div>
 				<div class="description">
 					{{ i18n.baseText(descriptionLocaleKey) }}
 				</div>
 			</div>
-			<n8n-button label="Create a tag" size="large" @click="$emit('enableCreate')" />
-		</el-col>
+			<N8nButton label="Create a tag" size="large" @click="$emit('enableCreate')" />
+		</ElCol>
 	</div>
 </template>
 

--- a/packages/frontend/editor-ui/src/components/TagsManager/TagsManager.vue
+++ b/packages/frontend/editor-ui/src/components/TagsManager/TagsManager.vue
@@ -155,7 +155,7 @@ function onEnter() {
 		@enter="onEnter"
 	>
 		<template #content>
-			<el-row>
+			<ElRow>
 				<TagsView
 					v-if="hasTags || isCreating"
 					:is-loading="isLoading"
@@ -173,10 +173,10 @@ function onEnter() {
 					:description-locale-key="noTagsDescriptionLocaleKey"
 					@enable-create="onEnableCreate"
 				/>
-			</el-row>
+			</ElRow>
 		</template>
 		<template #footer="{ close }">
-			<n8n-button :label="i18n.baseText('tagsManager.done')" float="right" @click="close" />
+			<N8nButton :label="i18n.baseText('tagsManager.done')" float="right" @click="close" />
 		</template>
 	</Modal>
 </template>

--- a/packages/frontend/editor-ui/src/components/TagsManager/TagsView/TagsTable.vue
+++ b/packages/frontend/editor-ui/src/components/TagsManager/TagsView/TagsTable.vue
@@ -143,10 +143,10 @@ onMounted(() => {
 		:span-method="getSpan"
 		:row-class-name="getRowClasses"
 	>
-		<el-table-column :label="i18n.baseText('tagsTable.name')">
+		<ElTableColumn :label="i18n.baseText('tagsTable.name')">
 			<template #default="scope">
 				<div :key="scope.row.id" :class="$style.name" @keydown.stop>
-					<transition name="fade" mode="out-in">
+					<Transition name="fade" mode="out-in">
 						<N8nInput
 							v-if="scope.row.create || scope.row.update"
 							ref="nameInput"
@@ -161,72 +161,72 @@ onMounted(() => {
 						<span v-else :class="{ [$style.disabled]: scope.row.disable }">
 							{{ scope.row.tag.name }}
 						</span>
-					</transition>
+					</Transition>
 				</div>
 			</template>
-		</el-table-column>
-		<el-table-column :label="i18n.baseText(usageColumnTitleLocaleKey)" width="170">
+		</ElTableColumn>
+		<ElTableColumn :label="i18n.baseText(usageColumnTitleLocaleKey)" width="170">
 			<template #default="scope">
-				<transition name="fade" mode="out-in">
+				<Transition name="fade" mode="out-in">
 					<div
 						v-if="!scope.row.create && !scope.row.delete"
 						:class="{ [$style.disabled]: scope.row.disable }"
 					>
 						{{ scope.row.usage }}
 					</div>
-				</transition>
+				</Transition>
 			</template>
-		</el-table-column>
-		<el-table-column>
+		</ElTableColumn>
+		<ElTableColumn>
 			<template #default="scope">
-				<transition name="fade" mode="out-in">
+				<Transition name="fade" mode="out-in">
 					<div v-if="scope.row.create" :class="$style.ops">
-						<n8n-button
+						<N8nButton
 							:label="i18n.baseText('tagsTable.cancel')"
 							type="secondary"
 							:disabled="isSaving"
 							@click.stop="cancel"
 						/>
-						<n8n-button
+						<N8nButton
 							:label="i18n.baseText('tagsTable.createTag')"
 							:loading="isSaving"
 							@click.stop="apply"
 						/>
 					</div>
 					<div v-else-if="scope.row.update" :class="$style.ops">
-						<n8n-button
+						<N8nButton
 							:label="i18n.baseText('tagsTable.cancel')"
 							type="secondary"
 							:disabled="isSaving"
 							@click.stop="cancel"
 						/>
-						<n8n-button
+						<N8nButton
 							:label="i18n.baseText('tagsTable.saveChanges')"
 							:loading="isSaving"
 							@click.stop="apply"
 						/>
 					</div>
 					<div v-else-if="scope.row.delete" :class="$style.ops">
-						<n8n-button
+						<N8nButton
 							:label="i18n.baseText('tagsTable.cancel')"
 							type="secondary"
 							:disabled="isSaving"
 							@click.stop="cancel"
 						/>
-						<n8n-button
+						<N8nButton
 							:label="i18n.baseText('tagsTable.deleteTag')"
 							:loading="isSaving"
 							@click.stop="apply"
 						/>
 					</div>
 					<div v-else-if="!scope.row.disable" :class="[$style.ops, $style.main]">
-						<n8n-icon-button
+						<N8nIconButton
 							:title="i18n.baseText('tagsTable.editTag')"
 							icon="pen"
 							data-test-id="edit-tag-button"
 							@click.stop="enableUpdate(scope.row)"
 						/>
-						<n8n-icon-button
+						<N8nIconButton
 							v-if="scope.row.canDelete"
 							:title="i18n.baseText('tagsTable.deleteTag')"
 							icon="trash-2"
@@ -234,9 +234,9 @@ onMounted(() => {
 							@click.stop="enableDelete(scope.row)"
 						/>
 					</div>
-				</transition>
+				</Transition>
 			</template>
-		</el-table-column>
+		</ElTableColumn>
 	</ElTable>
 </template>
 

--- a/packages/frontend/editor-ui/src/components/TagsManager/TagsView/TagsTableHeader.vue
+++ b/packages/frontend/editor-ui/src/components/TagsManager/TagsView/TagsTableHeader.vue
@@ -33,9 +33,9 @@ const onSearchChange = (search: string) => {
 </script>
 
 <template>
-	<el-row class="tags-header">
-		<el-col :span="10">
-			<n8n-input
+	<ElRow class="tags-header">
+		<ElCol :span="10">
+			<N8nInput
 				:placeholder="i18n.baseText('tagsTableHeader.searchTags')"
 				:model-value="search"
 				:disabled="disabled"
@@ -44,12 +44,12 @@ const onSearchChange = (search: string) => {
 				@update:model-value="onSearchChange"
 			>
 				<template #prefix>
-					<n8n-icon icon="search" />
+					<N8nIcon icon="search" />
 				</template>
-			</n8n-input>
-		</el-col>
-		<el-col :span="14">
-			<n8n-button
+			</N8nInput>
+		</ElCol>
+		<ElCol :span="14">
+			<N8nButton
 				:disabled="disabled"
 				icon="plus"
 				:label="i18n.baseText('tagsTableHeader.addNew')"
@@ -57,8 +57,8 @@ const onSearchChange = (search: string) => {
 				float="right"
 				@click="onAddNew"
 			/>
-		</el-col>
-	</el-row>
+		</ElCol>
+	</ElRow>
 </template>
 
 <style lang="scss" scoped>

--- a/packages/frontend/editor-ui/src/components/TemplateCard.vue
+++ b/packages/frontend/editor-ui/src/components/TemplateCard.vue
@@ -54,28 +54,28 @@ function onCardClick(e: MouseEvent) {
 		@click="onCardClick"
 	>
 		<div v-if="loading" :class="$style.loading">
-			<n8n-loading :rows="2" :shrink-last="false" :loading="loading" />
+			<N8nLoading :rows="2" :shrink-last="false" :loading="loading" />
 		</div>
 		<div v-else-if="workflow">
-			<n8n-heading :bold="true" size="small">{{ workflow.name }}</n8n-heading>
+			<N8nHeading :bold="true" size="small">{{ workflow.name }}</N8nHeading>
 			<div v-if="!simpleView" :class="$style.content">
 				<span v-if="workflow.totalViews">
-					<n8n-text size="small" color="text-light">
-						<n8n-icon icon="eye" size="xsmall" />
+					<N8nText size="small" color="text-light">
+						<N8nIcon icon="eye" size="xsmall" />
 						{{ abbreviateNumber(workflow.totalViews) }}
-					</n8n-text>
+					</N8nText>
 				</span>
 				<div v-if="workflow.totalViews" :class="$style.line" v-text="'|'" />
-				<n8n-text size="small" color="text-light">
+				<N8nText size="small" color="text-light">
 					<TimeAgo :date="workflow.createdAt" />
-				</n8n-text>
+				</N8nText>
 				<div v-if="workflow.user" :class="$style.line" v-text="'|'" />
-				<n8n-text v-if="workflow.user" size="small" color="text-light">
+				<N8nText v-if="workflow.user" size="small" color="text-light">
 					{{
 						i18n.baseText('template.byAuthor' as BaseTextKey, {
 							interpolate: { name: workflow.user.username },
 						})
-					}}</n8n-text
+					}}</N8nText
 				>
 			</div>
 		</div>
@@ -86,7 +86,7 @@ function onCardClick(e: MouseEvent) {
 			<NodeList v-if="workflow.nodes" :nodes="workflow.nodes" :limit="nodesToBeShown" size="md" />
 		</div>
 		<div v-if="useWorkflowButton" :class="$style.buttonContainer">
-			<n8n-button
+			<N8nButton
 				v-if="useWorkflowButton"
 				outline
 				label="Use workflow"

--- a/packages/frontend/editor-ui/src/components/TemplateDetails.vue
+++ b/packages/frontend/editor-ui/src/components/TemplateDetails.vue
@@ -50,7 +50,7 @@ const redirectToSearchPage = (node: ITemplatesNode) => {
 
 <template>
 	<div>
-		<n8n-loading :loading="loading" :rows="5" variant="p" />
+		<N8nLoading :loading="loading" :rows="5" variant="p" />
 
 		<TemplateDetailsBlock
 			v-if="!loading && template && template.nodes.length > 0"
@@ -76,7 +76,7 @@ const redirectToSearchPage = (node: ITemplatesNode) => {
 			v-if="!loading && isFullTemplatesCollection(template) && categoriesAsTags.length > 0"
 			:title="i18n.baseText('template.details.categories')"
 		>
-			<n8n-tags :tags="categoriesAsTags" @click:tag="redirectToCategory" />
+			<N8nTags :tags="categoriesAsTags" @click:tag="redirectToCategory" />
 		</TemplateDetailsBlock>
 
 		<TemplateDetailsBlock
@@ -84,15 +84,15 @@ const redirectToSearchPage = (node: ITemplatesNode) => {
 			:title="i18n.baseText('template.details.details')"
 		>
 			<div :class="$style.text">
-				<n8n-text v-if="isTemplatesWorkflow(template)" size="small" color="text-base">
+				<N8nText v-if="isTemplatesWorkflow(template)" size="small" color="text-base">
 					{{ i18n.baseText('template.details.created') }}
 					<TimeAgo :date="template.createdAt" />
 					{{ i18n.baseText('template.details.by') }}
 					{{ template.user ? template.user.username : 'n8n team' }}
-				</n8n-text>
+				</N8nText>
 			</div>
 			<div :class="$style.text">
-				<n8n-text
+				<N8nText
 					v-if="isTemplatesWorkflow(template) && template.totalViews !== 0"
 					size="small"
 					color="text-base"
@@ -100,7 +100,7 @@ const redirectToSearchPage = (node: ITemplatesNode) => {
 					{{ i18n.baseText('template.details.viewed') }}
 					{{ abbreviateNumber(template.totalViews) }}
 					{{ i18n.baseText('template.details.times') }}
-				</n8n-text>
+				</N8nText>
 			</div>
 		</TemplateDetailsBlock>
 	</div>

--- a/packages/frontend/editor-ui/src/components/TemplateDetailsBlock.vue
+++ b/packages/frontend/editor-ui/src/components/TemplateDetailsBlock.vue
@@ -7,7 +7,7 @@ defineProps<{
 <template>
 	<div :class="$style.block">
 		<div :class="$style.header">
-			<n8n-heading tag="h3" size="small" color="text-base">{{ title }}</n8n-heading>
+			<N8nHeading tag="h3" size="small" color="text-base">{{ title }}</N8nHeading>
 		</div>
 		<div :class="$style.content">
 			<slot></slot>

--- a/packages/frontend/editor-ui/src/components/TemplateFilters.vue
+++ b/packages/frontend/editor-ui/src/components/TemplateFilters.vue
@@ -93,13 +93,13 @@ watch(
 	<div :class="$style.filters" class="template-filters" data-test-id="templates-filter-container">
 		<div :class="$style.title" v-text="i18n.baseText('templates.categoriesHeading')" />
 		<div v-if="loading" :class="$style.list">
-			<n8n-loading :loading="loading" :rows="expandLimit" />
+			<N8nLoading :loading="loading" :rows="expandLimit" />
 		</div>
 		<ul v-if="!loading" :class="$style.categories">
 			<li :class="$style.item" data-test-id="template-filter-all-categories">
-				<el-checkbox :model-value="allSelected" @update:model-value="() => resetCategories()">
+				<ElCheckbox :model-value="allSelected" @update:model-value="() => resetCategories()">
 					{{ i18n.baseText('templates.allCategories') }}
-				</el-checkbox>
+				</ElCheckbox>
 			</li>
 			<li
 				v-for="(category, index) in collapsed
@@ -109,12 +109,12 @@ watch(
 				:class="$style.item"
 				:data-test-id="`template-filter-${category.name.toLowerCase().replaceAll(' ', '-')}`"
 			>
-				<el-checkbox
+				<ElCheckbox
 					:model-value="isSelected(category)"
 					@update:model-value="(value: boolean) => handleCheckboxChanged(value, category)"
 				>
 					{{ category.name }}
-				</el-checkbox>
+				</ElCheckbox>
 			</li>
 		</ul>
 		<div
@@ -123,9 +123,9 @@ watch(
 			data-test-id="expand-categories-button"
 			@click="collapseAction"
 		>
-			<n8n-text size="small" color="primary">
+			<N8nText size="small" color="primary">
 				+ {{ `${sortedCategories.length - expandLimit} more` }}
-			</n8n-text>
+			</N8nText>
 		</div>
 	</div>
 </template>

--- a/packages/frontend/editor-ui/src/components/TemplateList.vue
+++ b/packages/frontend/editor-ui/src/components/TemplateList.vue
@@ -78,11 +78,11 @@ function onUseWorkflow(event: MouseEvent, id: number) {
 <template>
 	<div v-if="loading || workflows.length" :class="$style.list">
 		<div v-if="!simpleView" :class="$style.header">
-			<n8n-heading :bold="true" size="medium" color="text-light">
+			<N8nHeading :bold="true" size="medium" color="text-light">
 				{{ i18n.baseText('templates.workflows') }}
 				<span v-if="totalCount > 0" data-test-id="template-count-label">({{ totalCount }})</span>
 				<span v-if="!loading && totalWorkflows" v-text="`(${totalWorkflows})`" />
-			</n8n-heading>
+			</N8nHeading>
 		</div>
 		<div :class="$style.container">
 			<TemplateCard

--- a/packages/frontend/editor-ui/src/components/TemplatesInfoCard.vue
+++ b/packages/frontend/editor-ui/src/components/TemplatesInfoCard.vue
@@ -24,10 +24,10 @@ const i18n = useI18n();
 	<Card :loading="loading" :title="collection.name" :style="{ width }">
 		<template #footer>
 			<span>
-				<n8n-text v-show="showItemCount" size="small" color="text-light">
+				<N8nText v-show="showItemCount" size="small" color="text-light">
 					{{ collection.workflows.length }}
 					{{ i18n.baseText('templates.workflows') }}
-				</n8n-text>
+				</N8nText>
 			</span>
 			<NodeList :nodes="collection.nodes" :show-more="false" />
 		</template>

--- a/packages/frontend/editor-ui/src/components/TemplatesInfoCarousel.vue
+++ b/packages/frontend/editor-ui/src/components/TemplatesInfoCarousel.vue
@@ -125,14 +125,14 @@ onBeforeMount(() => {
 			:class="{ [$style.leftButton]: true }"
 			@click="scrollLeft"
 		>
-			<n8n-icon icon="chevron-left" />
+			<N8nIcon icon="chevron-left" />
 		</button>
 		<button
 			v-show="showNavigation && !scrollEnd"
 			:class="{ [$style.rightButton]: true }"
 			@click="scrollRight"
 		>
-			<n8n-icon icon="chevron-right" />
+			<N8nIcon icon="chevron-right" />
 		</button>
 	</div>
 </template>

--- a/packages/frontend/editor-ui/src/components/TextEdit.vue
+++ b/packages/frontend/editor-ui/src/components/TextEdit.vue
@@ -67,7 +67,7 @@ const closeDialog = () => {
 
 <template>
 	<div v-if="dialogVisible">
-		<el-dialog
+		<ElDialog
 			:model-value="dialogVisible"
 			:append-to="`#${APP_MODALS_ELEMENT_ID}`"
 			width="80%"
@@ -77,11 +77,11 @@ const closeDialog = () => {
 			:before-close="closeDialog"
 		>
 			<div class="ignore-key-press-canvas">
-				<n8n-input-label
+				<N8nInputLabel
 					:label="i18n.nodeText(activeNode?.type).inputLabelDisplayName(parameter, path)"
 				>
 					<div @keydown.stop @keydown.esc="onKeyDownEsc">
-						<n8n-input
+						<N8nInput
 							ref="inputField"
 							v-model="tempValue"
 							type="textarea"
@@ -91,8 +91,8 @@ const closeDialog = () => {
 							@update:model-value="valueChanged"
 						/>
 					</div>
-				</n8n-input-label>
+				</N8nInputLabel>
 			</div>
-		</el-dialog>
+		</ElDialog>
 	</div>
 </template>

--- a/packages/frontend/editor-ui/src/components/TriggerPanel.vue
+++ b/packages/frontend/editor-ui/src/components/TriggerPanel.vue
@@ -374,24 +374,24 @@ const onNodeExecute = () => {
 
 <template>
 	<div :class="$style.container">
-		<transition name="fade" mode="out-in">
+		<Transition name="fade" mode="out-in">
 			<div v-if="hasIssues || hideContent" key="empty"></div>
 			<div v-else-if="isListeningForEvents" key="listening" data-test-id="trigger-listening">
-				<n8n-pulse>
+				<N8nPulse>
 					<NodeIcon :node-type="nodeType" :size="40"></NodeIcon>
-				</n8n-pulse>
+				</N8nPulse>
 				<div v-if="isWebhookNode">
-					<n8n-text tag="div" size="large" color="text-dark" class="mb-2xs" bold>{{
+					<N8nText tag="div" size="large" color="text-dark" class="mb-2xs" bold>{{
 						i18n.baseText('ndv.trigger.webhookNode.listening')
-					}}</n8n-text>
+					}}</N8nText>
 					<div :class="[$style.shake, 'mb-xs']">
-						<n8n-text>
+						<N8nText>
 							{{
 								i18n.baseText('ndv.trigger.webhookNode.requestHint', {
 									interpolate: { type: webhookHttpMethod ?? '' },
 								})
 							}}
-						</n8n-text>
+						</N8nText>
 					</div>
 					<CopyInput
 						:value="webhookTestUrl"
@@ -411,18 +411,18 @@ const onNodeExecute = () => {
 					/>
 				</div>
 				<div v-else>
-					<n8n-text tag="div" size="large" color="text-dark" class="mb-2xs" bold>{{
+					<N8nText tag="div" size="large" color="text-dark" class="mb-2xs" bold>{{
 						listeningTitle
-					}}</n8n-text>
+					}}</N8nText>
 					<div :class="[$style.shake, 'mb-xs']">
-						<n8n-text tag="div">
+						<N8nText tag="div">
 							{{ listeningHint }}
-						</n8n-text>
+						</N8nText>
 					</div>
 					<div v-if="displayChatButton">
-						<n8n-button class="mb-xl" @click="openWebhookUrl()">
+						<N8nButton class="mb-xl" @click="openWebhookUrl()">
 							{{ i18n.baseText('ndv.trigger.chatTrigger.openChat') }}
-						</n8n-button>
+						</N8nButton>
 					</div>
 
 					<NodeExecuteButton
@@ -436,17 +436,17 @@ const onNodeExecute = () => {
 			</div>
 			<div v-else key="default">
 				<div v-if="isActivelyPolling" class="mb-xl">
-					<n8n-spinner type="ring" />
+					<N8nSpinner type="ring" />
 				</div>
 
 				<div :class="$style.action">
 					<div data-test-id="trigger-header" :class="$style.header">
-						<n8n-heading v-if="header" tag="h1" bold>
+						<N8nHeading v-if="header" tag="h1" bold>
 							{{ header }}
-						</n8n-heading>
-						<n8n-text v-if="subheader">
+						</N8nHeading>
+						<N8nText v-if="subheader">
 							<span v-text="subheader" />
-						</n8n-text>
+						</N8nText>
 					</div>
 
 					<NodeExecuteButton
@@ -458,16 +458,16 @@ const onNodeExecute = () => {
 					/>
 				</div>
 
-				<n8n-text v-if="activationHint" size="small" @click="onLinkClick">
+				<N8nText v-if="activationHint" size="small" @click="onLinkClick">
 					<span v-n8n-html="activationHint"></span>&nbsp;
-				</n8n-text>
-				<n8n-link
+				</N8nText>
+				<N8nLink
 					v-if="activationHint && executionsHelp"
 					size="small"
 					@click="expandExecutionHelp"
-					>{{ i18n.baseText('ndv.trigger.moreInfo') }}</n8n-link
+					>{{ i18n.baseText('ndv.trigger.moreInfo') }}</N8nLink
 				>
-				<n8n-info-accordion
+				<N8nInfoAccordion
 					v-if="executionsHelp"
 					ref="help"
 					:class="$style.accordion"
@@ -475,9 +475,9 @@ const onNodeExecute = () => {
 					:description="executionsHelp"
 					:event-bus="executionsHelpEventBus"
 					@click:body="onLinkClick"
-				></n8n-info-accordion>
+				></N8nInfoAccordion>
 			</div>
-		</transition>
+		</Transition>
 	</div>
 </template>
 

--- a/packages/frontend/editor-ui/src/components/UpdatesPanel.vue
+++ b/packages/frontend/editor-ui/src/components/UpdatesPanel.vue
@@ -50,7 +50,7 @@ const i18n = useI18n();
 					{{ i18n.baseText('updatesPanel.behindTheLatest') }}
 				</p>
 
-				<n8n-button
+				<N8nButton
 					v-if="versionsStore.infoUrl"
 					:text="true"
 					type="primary"
@@ -59,11 +59,11 @@ const i18n = useI18n();
 					:bold="true"
 					@click="pageRedirectionHelper.goToVersions()"
 				>
-					<n8n-icon icon="info" class="mr-2xs" />
+					<N8nIcon icon="info" class="mr-2xs" />
 					<span>
 						{{ i18n.baseText('updatesPanel.howToUpdateYourN8nVersion') }}
 					</span>
-				</n8n-button>
+				</N8nButton>
 			</section>
 			<section :class="$style.versions">
 				<div

--- a/packages/frontend/editor-ui/src/components/WarningTooltip.vue
+++ b/packages/frontend/editor-ui/src/components/WarningTooltip.vue
@@ -1,11 +1,11 @@
 <template>
 	<span>
-		<n8n-tooltip content=" " placement="top">
+		<N8nTooltip content=" " placement="top">
 			<template #content>
 				<slot />
 			</template>
-			<n8n-icon :class="$style['icon']" icon="triangle-alert" />
-		</n8n-tooltip>
+			<N8nIcon :class="$style['icon']" icon="triangle-alert" />
+		</N8nTooltip>
 	</span>
 </template>
 

--- a/packages/frontend/editor-ui/src/components/WhatsNewModal.vue
+++ b/packages/frontend/editor-ui/src/components/WhatsNewModal.vue
@@ -128,7 +128,7 @@ modalBus.on('opened', () => {
 					:content="i18n.baseText('whatsNew.updateNudgeTooltip')"
 					placement="bottom"
 				>
-					<n8n-button
+					<N8nButton
 						:size="'large'"
 						:label="i18n.baseText('whatsNew.update')"
 						:disabled="!usersStore.canUserUpdateVersion"

--- a/packages/frontend/editor-ui/src/components/WorkerList.ee.vue
+++ b/packages/frontend/editor-ui/src/components/WorkerList.ee.vue
@@ -69,10 +69,10 @@ onBeforeUnmount(() => {
 	<div>
 		<PushConnectionTracker class="actions"></PushConnectionTracker>
 		<div :class="$style.workerListHeader">
-			<n8n-heading tag="h1" size="2xlarge">{{ pageTitle }}</n8n-heading>
+			<N8nHeading tag="h1" size="2xlarge">{{ pageTitle }}</N8nHeading>
 		</div>
 		<div v-if="!initialStatusReceived">
-			<n8n-spinner />
+			<N8nSpinner />
 		</div>
 		<div v-else>
 			<div v-if="workerIds.length === 0">{{ i18n.baseText('workerList.empty') }}</div>

--- a/packages/frontend/editor-ui/src/components/Workers/WorkerAccordion.ee.vue
+++ b/packages/frontend/editor-ui/src/components/Workers/WorkerAccordion.ee.vue
@@ -26,11 +26,11 @@ function toggle() {
 <template>
 	<div :class="['accordion', $style.container]">
 		<div :class="{ [$style.header]: true, [$style.expanded]: expanded }" @click="toggle">
-			<n8n-icon :icon="icon" :color="iconColor" size="small" class="mr-2xs" />
-			<n8n-text :class="$style.headerText" color="text-base" size="small" align="left" bold>
+			<N8nIcon :icon="icon" :color="iconColor" size="small" class="mr-2xs" />
+			<N8nText :class="$style.headerText" color="text-base" size="small" align="left" bold>
 				<slot name="title"></slot>
-			</n8n-text>
-			<n8n-icon :icon="expanded ? 'chevron-up' : 'chevron-down'" bold />
+			</N8nText>
+			<N8nIcon :icon="expanded ? 'chevron-up' : 'chevron-down'" bold />
 		</div>
 		<div v-if="expanded" :class="{ [$style.description]: true, [$style.collapsed]: !expanded }">
 			<slot name="content"></slot>

--- a/packages/frontend/editor-ui/src/components/Workers/WorkerCard.ee.vue
+++ b/packages/frontend/editor-ui/src/components/Workers/WorkerCard.ee.vue
@@ -59,9 +59,9 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-	<n8n-card v-if="worker" :class="$style.cardLink">
+	<N8nCard v-if="worker" :class="$style.cardLink">
 		<template #header>
-			<n8n-heading
+			<N8nHeading
 				tag="h2"
 				bold
 				:class="stale ? [$style.cardHeading, $style.stale] : [$style.cardHeading]"
@@ -71,10 +71,10 @@ onBeforeUnmount(() => {
 				Average Load: {{ averageWorkerLoadFromLoadsAsString(worker.loadAvg ?? [0]) }} | Free Memory:
 				{{ memAsGb(worker.freeMem).toFixed(2) }}GB / {{ memAsGb(worker.totalMem).toFixed(2) }}GB
 				{{ stale ? ' (stale)' : '' }}
-			</n8n-heading>
+			</N8nHeading>
 		</template>
 		<div :class="$style.cardDescription">
-			<n8n-text color="text-light" size="small" :class="$style.container">
+			<N8nText color="text-light" size="small" :class="$style.container">
 				<span
 					>{{ i18n.baseText('workerList.item.lastUpdated') }} {{ secondsSinceLastUpdateString }}s
 					ago | n8n-Version: {{ worker.version }} | Architecture: {{ worker.arch }} (
@@ -83,14 +83,14 @@ onBeforeUnmount(() => {
 				<WorkerJobAccordion :items="worker.runningJobsSummary" />
 				<WorkerNetAccordion :items="sortedWorkerInterfaces" />
 				<WorkerChartsAccordion :worker-id="worker.senderId" />
-			</n8n-text>
+			</N8nText>
 		</div>
 		<template #append>
 			<div ref="cardActions" :class="$style.cardActions">
 				<!-- For future Worker actions -->
 			</div>
 		</template>
-	</n8n-card>
+	</N8nCard>
 </template>
 
 <style lang="scss" module>

--- a/packages/frontend/editor-ui/src/components/Workers/WorkerJobAccordion.ee.vue
+++ b/packages/frontend/editor-ui/src/components/Workers/WorkerJobAccordion.ee.vue
@@ -30,12 +30,12 @@ function runningSince(started: Date): string {
 					<a :href="'/workflow/' + item.workflowId + '/executions/' + item.executionId">
 						Execution {{ item.executionId }} - {{ item.workflowName }}</a
 					>
-					<n8n-text color="text-base" size="small" align="left">
+					<N8nText color="text-base" size="small" align="left">
 						| Started at:
 						{{ new Date(item.startedAt)?.toLocaleTimeString() }} | Running for
 						{{ runningSince(new Date(item.startedAt)) }}
 						{{ item.retryOf ? `| Retry of: ${item.retryOf}` : '' }} |
-					</n8n-text>
+					</N8nText>
 					<a target="_blank" :href="'/workflow/' + item.workflowId"> (Open workflow)</a>
 				</div>
 			</div>

--- a/packages/frontend/editor-ui/src/components/WorkflowActivationConflictingWebhookModal.vue
+++ b/packages/frontend/editor-ui/src/components/WorkflowActivationConflictingWebhookModal.vue
@@ -75,28 +75,28 @@ const onClick = async () => {
 		:center="true"
 	>
 		<template #content>
-			<n8n-callout theme="danger" data-test-id="conflicting-webhook-callout">
+			<N8nCallout theme="danger" data-test-id="conflicting-webhook-callout">
 				A {{ webhookTypeUi.callout }} '{{ data.node }}' in the workflow '{{ data.workflowName }}'
 				uses a conflicting URL path, so this workflow cannot be activated
-			</n8n-callout>
+			</N8nCallout>
 			<div :class="$style.container">
 				<div>
-					<n8n-text color="text-base"> You can deactivate </n8n-text>
-					<n8n-link :to="workflowUrl" :underline="true"> {{ data.workflowName }} </n8n-link>
-					<n8n-text color="text-base" data-test-id="conflicting-webhook-suggestion">
+					<N8nText color="text-base"> You can deactivate </N8nText>
+					<N8nLink :to="workflowUrl" :underline="true"> {{ data.workflowName }} </N8nLink>
+					<N8nText color="text-base" data-test-id="conflicting-webhook-suggestion">
 						{{ webhookTypeUi.suggestion }}
-					</n8n-text>
+					</N8nText>
 				</div>
 			</div>
 			<div data-test-id="conflicting-webhook-path">
-				<n8n-text color="text-light"> {{ webhookUrl }}/</n8n-text>
-				<n8n-text color="text-dark" bold>
+				<N8nText color="text-light"> {{ webhookUrl }}/</N8nText>
+				<N8nText color="text-dark" bold>
 					{{ data.webhookPath }}
-				</n8n-text>
+				</N8nText>
 			</div>
 		</template>
 		<template #footer>
-			<n8n-button
+			<N8nButton
 				label="Done"
 				size="medium"
 				float="right"

--- a/packages/frontend/editor-ui/src/components/WorkflowActivator.vue
+++ b/packages/frontend/editor-ui/src/components/WorkflowActivator.vue
@@ -207,19 +207,19 @@ watch(
 <template>
 	<div class="workflow-activator">
 		<div :class="$style.activeStatusText" data-test-id="workflow-activator-status">
-			<n8n-text
+			<N8nText
 				v-if="workflowActive"
 				:color="couldNotBeStarted ? 'danger' : 'success'"
 				size="small"
 				bold
 			>
 				{{ i18n.baseText('workflowActivator.active') }}
-			</n8n-text>
-			<n8n-text v-else color="text-base" size="small" bold>
+			</N8nText>
+			<N8nText v-else color="text-base" size="small" bold>
 				{{ i18n.baseText('workflowActivator.inactive') }}
-			</n8n-text>
+			</N8nText>
 		</div>
-		<n8n-tooltip :disabled="!disabled" placement="bottom">
+		<N8nTooltip :disabled="!disabled" placement="bottom">
 			<template #content>
 				<div>
 					{{
@@ -233,7 +233,7 @@ watch(
 					}}
 				</div>
 			</template>
-			<el-switch
+			<ElSwitch
 				v-loading="workflowActivate.updatingWorkflowActivation.value"
 				:model-value="workflowActive"
 				:title="
@@ -251,19 +251,19 @@ watch(
 				data-test-id="workflow-activate-switch"
 				@update:model-value="activeChanged"
 			>
-			</el-switch>
-		</n8n-tooltip>
+			</ElSwitch>
+		</N8nTooltip>
 
 		<div v-if="couldNotBeStarted" class="could-not-be-started">
-			<n8n-tooltip placement="top">
+			<N8nTooltip placement="top">
 				<template #content>
 					<div
 						v-n8n-html="i18n.baseText('workflowActivator.theWorkflowIsSetToBeActiveBut')"
 						@click="displayActivationError"
 					></div>
 				</template>
-				<n8n-icon icon="triangle-alert" @click="displayActivationError" />
-			</n8n-tooltip>
+				<N8nIcon icon="triangle-alert" @click="displayActivationError" />
+			</N8nTooltip>
 		</div>
 	</div>
 </template>

--- a/packages/frontend/editor-ui/src/components/WorkflowCard.vue
+++ b/packages/frontend/editor-ui/src/components/WorkflowCard.vue
@@ -467,7 +467,7 @@ const tags = computed(
 </script>
 
 <template>
-	<n8n-card
+	<N8nCard
 		:class="{
 			[$style.cardLink]: true,
 			[$style.cardArchived]: data.isArchived,
@@ -476,7 +476,7 @@ const tags = computed(
 		@click="onClick"
 	>
 		<template #header>
-			<n8n-text
+			<N8nText
 				tag="h2"
 				bold
 				:class="{
@@ -489,7 +489,7 @@ const tags = computed(
 				<N8nBadge v-if="!workflowPermissions.update" class="ml-3xs" theme="tertiary" bold>
 					{{ locale.baseText('workflows.item.readonly') }}
 				</N8nBadge>
-			</n8n-text>
+			</N8nText>
 		</template>
 		<div :class="$style.cardDescription">
 			<span v-show="data"
@@ -505,20 +505,20 @@ const tags = computed(
 				:class="[$style['description-cell'], $style['description-cell--mcp']]"
 				data-test-id="workflow-card-mcp"
 			>
-				<n8n-tooltip
+				<N8nTooltip
 					placement="right"
 					:content="locale.baseText('workflows.item.availableInMCP')"
 					data-test-id="workflow-card-mcp-tooltip"
 				>
-					<n8n-icon icon="mcp" size="medium"></n8n-icon>
-				</n8n-tooltip>
+					<N8nIcon icon="mcp" size="medium"></N8nIcon>
+				</N8nTooltip>
 			</span>
 			<span
 				v-if="props.areTagsEnabled && data.tags && data.tags.length > 0"
 				v-show="data"
 				:class="$style.cardTags"
 			>
-				<n8n-tags
+				<N8nTags
 					:tags="tags"
 					:truncate-at="3"
 					truncate
@@ -540,7 +540,7 @@ const tags = computed(
 					:show-badge-border="false"
 				>
 					<div v-if="showCardBreadcrumbs" :class="$style.breadcrumbs">
-						<n8n-breadcrumbs
+						<N8nBreadcrumbs
 							:items="cardBreadcrumbs"
 							:hidden-items="
 								data.parentFolder?.parentFolderId !== null ? hiddenBreadcrumbsItemsAsync : undefined
@@ -554,11 +554,11 @@ const tags = computed(
 							@item-selected="onBreadcrumbItemClick"
 						>
 							<template #prepend></template>
-						</n8n-breadcrumbs>
+						</N8nBreadcrumbs>
 					</div>
 				</ProjectCardBadge>
 
-				<n8n-text
+				<N8nText
 					v-if="data.isArchived"
 					color="text-light"
 					size="small"
@@ -567,7 +567,7 @@ const tags = computed(
 					data-test-id="workflow-card-archived"
 				>
 					{{ locale.baseText('workflows.item.archived') }}
-				</n8n-text>
+				</N8nText>
 				<WorkflowActivator
 					v-else
 					class="mr-s"
@@ -579,7 +579,7 @@ const tags = computed(
 					@update:workflow-active="emitWorkflowActiveToggle"
 				/>
 
-				<n8n-action-toggle
+				<N8nActionToggle
 					:actions="actions"
 					theme="dark"
 					data-test-id="workflow-card-actions"
@@ -587,7 +587,7 @@ const tags = computed(
 				/>
 			</div>
 		</template>
-	</n8n-card>
+	</N8nCard>
 </template>
 
 <style lang="scss" module>

--- a/packages/frontend/editor-ui/src/components/WorkflowExtractionNameModal.vue
+++ b/packages/frontend/editor-ui/src/components/WorkflowExtractionNameModal.vue
@@ -88,14 +88,14 @@ onMounted(() => {
 		</template>
 		<template #footer="{ close }">
 			<div :class="$style.footer">
-				<n8n-button
+				<N8nButton
 					type="secondary"
 					:label="i18n.baseText('generic.cancel')"
 					float="right"
 					data-test-id="cancel-button"
 					@click="close"
 				/>
-				<n8n-button
+				<N8nButton
 					:label="i18n.baseText('generic.confirm')"
 					float="right"
 					:disabled="!workflowName"

--- a/packages/frontend/editor-ui/src/components/WorkflowHistory/WorkflowHistoryContent.vue
+++ b/packages/frontend/editor-ui/src/components/WorkflowHistory/WorkflowHistoryContent.vue
@@ -105,10 +105,10 @@ const onAction = ({
 					</section>
 				</template>
 				<template #action-toggle-button>
-					<n8n-button type="tertiary" size="large" data-test-id="action-toggle-button">
+					<N8nButton type="tertiary" size="large" data-test-id="action-toggle-button">
 						{{ i18n.baseText('workflowHistory.content.actions') }}
-						<n8n-icon class="ml-3xs" icon="chevron-down" size="small" />
-					</n8n-button>
+						<N8nIcon class="ml-3xs" icon="chevron-down" size="small" />
+					</N8nButton>
 				</template>
 			</WorkflowHistoryListItem>
 		</ul>

--- a/packages/frontend/editor-ui/src/components/WorkflowHistory/WorkflowHistoryList.vue
+++ b/packages/frontend/editor-ui/src/components/WorkflowHistory/WorkflowHistoryList.vue
@@ -131,9 +131,9 @@ const onItemMounted = ({
 			aria-busy="true"
 			:aria-label="i18n.baseText('generic.loading')"
 		>
-			<n8n-loading :rows="3" class="mb-xs" />
-			<n8n-loading :rows="3" class="mb-xs" />
-			<n8n-loading :rows="3" class="mb-xs" />
+			<N8nLoading :rows="3" class="mb-xs" />
+			<N8nLoading :rows="3" class="mb-xs" />
+			<N8nLoading :rows="3" class="mb-xs" />
 		</li>
 		<li v-if="props.shouldUpgrade" :class="$style.retention">
 			<span>

--- a/packages/frontend/editor-ui/src/components/WorkflowHistory/WorkflowHistoryListItem.vue
+++ b/packages/frontend/editor-ui/src/components/WorkflowHistory/WorkflowHistoryListItem.vue
@@ -103,21 +103,18 @@ onMounted(() => {
 		<slot :formatted-created-at="formattedCreatedAt">
 			<p @click="onItemClick">
 				<time :datetime="item.createdAt">{{ formattedCreatedAt }}</time>
-				<n8n-tooltip
-					placement="right-end"
-					:disabled="authors.size < 2 && !isAuthorElementTruncated"
-				>
+				<N8nTooltip placement="right-end" :disabled="authors.size < 2 && !isAuthorElementTruncated">
 					<template #content>{{ props.item.authors }}</template>
 					<span ref="authorElement">{{ authors.label }}</span>
-				</n8n-tooltip>
+				</N8nTooltip>
 				<data :value="item.versionId">{{ idLabel }}</data>
 			</p>
 		</slot>
 		<div :class="$style.tail">
-			<n8n-badge v-if="props.index === 0">
+			<N8nBadge v-if="props.index === 0">
 				{{ i18n.baseText('workflowHistory.item.latest') }}
-			</n8n-badge>
-			<n8n-action-toggle
+			</N8nBadge>
+			<N8nActionToggle
 				theme="dark"
 				:class="$style.actions"
 				:actions="props.actions"
@@ -127,7 +124,7 @@ onMounted(() => {
 				@visible-change="onVisibleChange"
 			>
 				<slot name="action-toggle-button" />
-			</n8n-action-toggle>
+			</N8nActionToggle>
 		</div>
 	</li>
 </template>

--- a/packages/frontend/editor-ui/src/components/WorkflowHistory/WorkflowHistoryVersionRestoreModal.vue
+++ b/packages/frontend/editor-ui/src/components/WorkflowHistory/WorkflowHistoryVersionRestoreModal.vue
@@ -30,13 +30,13 @@ const closeModal = () => {
 <template>
 	<Modal width="500px" :name="props.modalName" :before-close="props.data.beforeClose">
 		<template #header>
-			<n8n-heading tag="h2" size="xlarge">
+			<N8nHeading tag="h2" size="xlarge">
 				{{ i18n.baseText('workflowHistory.action.restore.modal.title') }}
-			</n8n-heading>
+			</N8nHeading>
 		</template>
 		<template #content>
 			<div>
-				<n8n-text>
+				<N8nText>
 					<I18nT keypath="workflowHistory.action.restore.modal.subtitle" tag="span" scope="global">
 						<template #date>
 							<strong>{{ props.data.formattedCreatedAt }}</strong>
@@ -56,12 +56,12 @@ const closeModal = () => {
 							}}&rdquo;
 						</template>
 					</I18nT>
-				</n8n-text>
+				</N8nText>
 			</div>
 		</template>
 		<template #footer>
 			<div :class="$style.footer">
-				<n8n-button
+				<N8nButton
 					v-for="(button, index) in props.data.buttons"
 					:key="index"
 					size="medium"
@@ -74,7 +74,7 @@ const closeModal = () => {
 					"
 				>
 					{{ button.text }}
-				</n8n-button>
+				</N8nButton>
 			</div>
 		</template>
 	</Modal>

--- a/packages/frontend/editor-ui/src/components/WorkflowPreview.vue
+++ b/packages/frontend/editor-ui/src/components/WorkflowPreview.vue
@@ -228,10 +228,10 @@ watch(
 <template>
 	<div :class="$style.container">
 		<div v-if="loaderType === 'image' && !showPreview" :class="$style.imageLoader">
-			<n8n-loading :loading="!showPreview" :rows="1" variant="image" />
+			<N8nLoading :loading="!showPreview" :rows="1" variant="image" />
 		</div>
 		<div v-else-if="loaderType === 'spinner' && !showPreview" :class="$style.spinner">
-			<n8n-spinner type="dots" />
+			<N8nSpinner type="dots" />
 		</div>
 		<iframe
 			ref="iframeRef"

--- a/packages/frontend/editor-ui/src/components/WorkflowSelectorParameterInput/WorkflowSelectorParameterInput.vue
+++ b/packages/frontend/editor-ui/src/components/WorkflowSelectorParameterInput/WorkflowSelectorParameterInput.vue
@@ -334,9 +334,9 @@ const onAddResourceClicked = async () => {
 		>
 			<template #error>
 				<div :class="$style.error" data-test-id="rlc-error-container">
-					<n8n-text color="text-dark" align="center" tag="div">
+					<N8nText color="text-dark" align="center" tag="div">
 						{{ i18n.baseText('resourceLocator.mode.list.error.title') }}
-					</n8n-text>
+					</N8nText>
 				</div>
 			</template>
 			<div
@@ -353,7 +353,7 @@ const onAddResourceClicked = async () => {
 					}"
 				/>
 				<div :class="$style.modeSelector">
-					<n8n-select
+					<N8nSelect
 						:model-value="selectedMode"
 						:size="inputSize"
 						:disabled="isReadOnly"
@@ -361,7 +361,7 @@ const onAddResourceClicked = async () => {
 						data-test-id="rlc-mode-selector"
 						@update:model-value="onModeSwitched"
 					>
-						<n8n-option
+						<N8nOption
 							v-for="mode in supportedModes"
 							:key="mode.name"
 							:value="mode.name"
@@ -374,8 +374,8 @@ const onAddResourceClicked = async () => {
 							"
 						>
 							{{ getModeLabel(mode) }}
-						</n8n-option>
-					</n8n-select>
+						</N8nOption>
+					</N8nSelect>
 				</div>
 
 				<div :class="$style.inputContainer" data-test-id="rlc-input-container">
@@ -404,7 +404,7 @@ const onAddResourceClicked = async () => {
 									@update:model-value="onInputChange"
 									@modal-opener-click="emit('modalOpenerClick')"
 								/>
-								<n8n-input
+								<N8nInput
 									v-else
 									ref="input"
 									:class="{ [$style.selectInput]: isListMode }"
@@ -430,7 +430,7 @@ const onAddResourceClicked = async () => {
 											}"
 										/>
 									</template>
-								</n8n-input>
+								</N8nInput>
 							</div>
 						</template>
 					</DraggableTarget>
@@ -445,9 +445,9 @@ const onAddResourceClicked = async () => {
 						:class="$style.openResourceLink"
 						data-test-id="rlc-open-resource-link"
 					>
-						<n8n-link theme="text" @click.stop="openWorkflow()">
-							<n8n-icon icon="external-link" :title="'Open resource link'" />
-						</n8n-link>
+						<N8nLink theme="text" @click.stop="openWorkflow()">
+							<N8nIcon icon="external-link" :title="'Open resource link'" />
+						</N8nLink>
 					</div>
 				</div>
 			</div>

--- a/packages/frontend/editor-ui/src/components/WorkflowSettings.vue
+++ b/packages/frontend/editor-ui/src/components/WorkflowSettings.vue
@@ -512,11 +512,11 @@ onBeforeUnmount(() => {
 				:class="$style['workflow-settings']"
 				data-test-id="workflow-settings-dialog"
 			>
-				<el-row>
-					<el-col :span="10" :class="$style['setting-name']">
+				<ElRow>
+					<ElCol :span="10" :class="$style['setting-name']">
 						{{ i18n.baseText('workflowSettings.executionOrder') }}
-					</el-col>
-					<el-col :span="14" class="ignore-key-press-canvas">
+					</ElCol>
+					<ElCol :span="14" class="ignore-key-press-canvas">
 						<N8nSelect
 							v-model="workflowSettings.executionOrder"
 							placeholder="Select Execution Order"
@@ -534,20 +534,20 @@ onBeforeUnmount(() => {
 							>
 							</N8nOption>
 						</N8nSelect>
-					</el-col>
-				</el-row>
+					</ElCol>
+				</ElRow>
 
-				<el-row data-test-id="error-workflow">
-					<el-col :span="10" :class="$style['setting-name']">
+				<ElRow data-test-id="error-workflow">
+					<ElCol :span="10" :class="$style['setting-name']">
 						{{ i18n.baseText('workflowSettings.errorWorkflow') }}
 						<N8nTooltip placement="top">
 							<template #content>
 								<div v-n8n-html="helpTexts.errorWorkflow"></div>
 							</template>
-							<n8n-icon icon="circle-help" />
+							<N8nIcon icon="circle-help" />
 						</N8nTooltip>
-					</el-col>
-					<el-col :span="14" class="ignore-key-press-canvas">
+					</ElCol>
+					<ElCol :span="14" class="ignore-key-press-canvas">
 						<N8nSelect
 							v-model="workflowSettings.errorWorkflow"
 							placeholder="Select Workflow"
@@ -567,21 +567,21 @@ onBeforeUnmount(() => {
 							>
 							</N8nOption>
 						</N8nSelect>
-					</el-col>
-				</el-row>
+					</ElCol>
+				</ElRow>
 				<div v-if="isSharingEnabled" data-test-id="workflow-caller-policy">
-					<el-row>
-						<el-col :span="10" :class="$style['setting-name']">
+					<ElRow>
+						<ElCol :span="10" :class="$style['setting-name']">
 							{{ i18n.baseText('workflowSettings.callerPolicy') }}
 							<N8nTooltip placement="top">
 								<template #content>
 									<div v-text="helpTexts.workflowCallerPolicy"></div>
 								</template>
-								<n8n-icon icon="circle-help" />
+								<N8nIcon icon="circle-help" />
 							</N8nTooltip>
-						</el-col>
+						</ElCol>
 
-						<el-col :span="14" class="ignore-key-press-canvas">
+						<ElCol :span="14" class="ignore-key-press-canvas">
 							<N8nSelect
 								v-model="workflowSettings.callerPolicy"
 								:disabled="readOnlyEnv || !workflowPermissions.update"
@@ -597,19 +597,19 @@ onBeforeUnmount(() => {
 								>
 								</N8nOption>
 							</N8nSelect>
-						</el-col>
-					</el-row>
-					<el-row v-if="workflowSettings.callerPolicy === 'workflowsFromAList'">
-						<el-col :span="10" :class="$style['setting-name']">
+						</ElCol>
+					</ElRow>
+					<ElRow v-if="workflowSettings.callerPolicy === 'workflowsFromAList'">
+						<ElCol :span="10" :class="$style['setting-name']">
 							{{ i18n.baseText('workflowSettings.callerIds') }}
 							<N8nTooltip placement="top">
 								<template #content>
 									<div v-text="helpTexts.workflowCallerIds"></div>
 								</template>
-								<n8n-icon icon="circle-help" />
+								<N8nIcon icon="circle-help" />
 							</N8nTooltip>
-						</el-col>
-						<el-col :span="14">
+						</ElCol>
+						<ElCol :span="14">
 							<N8nInput
 								v-model="workflowSettings.callerIds"
 								:disabled="readOnlyEnv || !workflowPermissions.update"
@@ -618,20 +618,20 @@ onBeforeUnmount(() => {
 								data-test-id="workflow-caller-policy-workflow-ids"
 								@update:model-value="onCallerIdsInput"
 							/>
-						</el-col>
-					</el-row>
+						</ElCol>
+					</ElRow>
 				</div>
-				<el-row>
-					<el-col :span="10" :class="$style['setting-name']">
+				<ElRow>
+					<ElCol :span="10" :class="$style['setting-name']">
 						{{ i18n.baseText('workflowSettings.timezone') }}
 						<N8nTooltip placement="top">
 							<template #content>
 								<div v-text="helpTexts.timezone"></div>
 							</template>
-							<n8n-icon icon="circle-help" />
+							<N8nIcon icon="circle-help" />
 						</N8nTooltip>
-					</el-col>
-					<el-col :span="14" class="ignore-key-press-canvas">
+					</ElCol>
+					<ElCol :span="14" class="ignore-key-press-canvas">
 						<N8nSelect
 							v-model="workflowSettings.timezone"
 							placeholder="Select Timezone"
@@ -648,19 +648,19 @@ onBeforeUnmount(() => {
 							>
 							</N8nOption>
 						</N8nSelect>
-					</el-col>
-				</el-row>
-				<el-row>
-					<el-col :span="10" :class="$style['setting-name']">
+					</ElCol>
+				</ElRow>
+				<ElRow>
+					<ElCol :span="10" :class="$style['setting-name']">
 						{{ i18n.baseText('workflowSettings.saveDataErrorExecution') }}
 						<N8nTooltip placement="top">
 							<template #content>
 								<div v-text="helpTexts.saveDataErrorExecution"></div>
 							</template>
-							<n8n-icon icon="circle-help" />
+							<N8nIcon icon="circle-help" />
 						</N8nTooltip>
-					</el-col>
-					<el-col :span="14" class="ignore-key-press-canvas">
+					</ElCol>
+					<ElCol :span="14" class="ignore-key-press-canvas">
 						<N8nSelect
 							v-model="workflowSettings.saveDataErrorExecution"
 							:placeholder="i18n.baseText('workflowSettings.selectOption')"
@@ -677,19 +677,19 @@ onBeforeUnmount(() => {
 							>
 							</N8nOption>
 						</N8nSelect>
-					</el-col>
-				</el-row>
-				<el-row>
-					<el-col :span="10" :class="$style['setting-name']">
+					</ElCol>
+				</ElRow>
+				<ElRow>
+					<ElCol :span="10" :class="$style['setting-name']">
 						{{ i18n.baseText('workflowSettings.saveDataSuccessExecution') }}
 						<N8nTooltip placement="top">
 							<template #content>
 								<div v-text="helpTexts.saveDataSuccessExecution"></div>
 							</template>
-							<n8n-icon icon="circle-help" />
+							<N8nIcon icon="circle-help" />
 						</N8nTooltip>
-					</el-col>
-					<el-col :span="14" class="ignore-key-press-canvas">
+					</ElCol>
+					<ElCol :span="14" class="ignore-key-press-canvas">
 						<N8nSelect
 							v-model="workflowSettings.saveDataSuccessExecution"
 							:placeholder="i18n.baseText('workflowSettings.selectOption')"
@@ -706,19 +706,19 @@ onBeforeUnmount(() => {
 							>
 							</N8nOption>
 						</N8nSelect>
-					</el-col>
-				</el-row>
-				<el-row>
-					<el-col :span="10" :class="$style['setting-name']">
+					</ElCol>
+				</ElRow>
+				<ElRow>
+					<ElCol :span="10" :class="$style['setting-name']">
 						{{ i18n.baseText('workflowSettings.saveManualExecutions') }}
 						<N8nTooltip placement="top">
 							<template #content>
 								<div v-text="helpTexts.saveManualExecutions"></div>
 							</template>
-							<n8n-icon icon="circle-help" />
+							<N8nIcon icon="circle-help" />
 						</N8nTooltip>
-					</el-col>
-					<el-col :span="14" class="ignore-key-press-canvas">
+					</ElCol>
+					<ElCol :span="14" class="ignore-key-press-canvas">
 						<N8nSelect
 							v-model="workflowSettings.saveManualExecutions"
 							:placeholder="i18n.baseText('workflowSettings.selectOption')"
@@ -735,19 +735,19 @@ onBeforeUnmount(() => {
 							>
 							</N8nOption>
 						</N8nSelect>
-					</el-col>
-				</el-row>
-				<el-row>
-					<el-col :span="10" :class="$style['setting-name']">
+					</ElCol>
+				</ElRow>
+				<ElRow>
+					<ElCol :span="10" :class="$style['setting-name']">
 						{{ i18n.baseText('workflowSettings.saveExecutionProgress') }}
 						<N8nTooltip placement="top">
 							<template #content>
 								<div v-text="helpTexts.saveExecutionProgress"></div>
 							</template>
-							<n8n-icon icon="circle-help" />
+							<N8nIcon icon="circle-help" />
 						</N8nTooltip>
-					</el-col>
-					<el-col :span="14" class="ignore-key-press-canvas">
+					</ElCol>
+					<ElCol :span="14" class="ignore-key-press-canvas">
 						<N8nSelect
 							v-model="workflowSettings.saveExecutionProgress"
 							:placeholder="i18n.baseText('workflowSettings.selectOption')"
@@ -764,45 +764,45 @@ onBeforeUnmount(() => {
 							>
 							</N8nOption>
 						</N8nSelect>
-					</el-col>
-				</el-row>
-				<el-row>
-					<el-col :span="10" :class="$style['setting-name']">
+					</ElCol>
+				</ElRow>
+				<ElRow>
+					<ElCol :span="10" :class="$style['setting-name']">
 						{{ i18n.baseText('workflowSettings.timeoutWorkflow') }}
 						<N8nTooltip placement="top">
 							<template #content>
 								<div v-text="helpTexts.executionTimeoutToggle"></div>
 							</template>
-							<n8n-icon icon="circle-help" />
+							<N8nIcon icon="circle-help" />
 						</N8nTooltip>
-					</el-col>
-					<el-col :span="14">
+					</ElCol>
+					<ElCol :span="14">
 						<div>
-							<el-switch
+							<ElSwitch
 								ref="inputField"
 								:disabled="readOnlyEnv || !workflowPermissions.update"
 								:model-value="(workflowSettings.executionTimeout ?? -1) > -1"
 								data-test-id="workflow-settings-timeout-workflow"
 								@update:model-value="toggleTimeout"
-							></el-switch>
+							></ElSwitch>
 						</div>
-					</el-col>
-				</el-row>
+					</ElCol>
+				</ElRow>
 				<div
 					v-if="(workflowSettings.executionTimeout ?? -1) > -1"
 					data-test-id="workflow-settings-timeout-form"
 				>
-					<el-row>
-						<el-col :span="10" :class="$style['setting-name']">
+					<ElRow>
+						<ElCol :span="10" :class="$style['setting-name']">
 							{{ i18n.baseText('workflowSettings.timeoutAfter') }}
 							<N8nTooltip placement="top">
 								<template #content>
 									<div v-text="helpTexts.executionTimeout"></div>
 								</template>
-								<n8n-icon icon="circle-help" />
+								<N8nIcon icon="circle-help" />
 							</N8nTooltip>
-						</el-col>
-						<el-col :span="4">
+						</ElCol>
+						<ElCol :span="4">
 							<N8nInput
 								:disabled="readOnlyEnv || !workflowPermissions.update"
 								:model-value="timeoutHMS.hours"
@@ -811,8 +811,8 @@ onBeforeUnmount(() => {
 							>
 								<template #append>{{ i18n.baseText('workflowSettings.hours') }}</template>
 							</N8nInput>
-						</el-col>
-						<el-col :span="4" :class="$style['timeout-input']">
+						</ElCol>
+						<ElCol :span="4" :class="$style['timeout-input']">
 							<N8nInput
 								:disabled="readOnlyEnv || !workflowPermissions.update"
 								:model-value="timeoutHMS.minutes"
@@ -822,8 +822,8 @@ onBeforeUnmount(() => {
 							>
 								<template #append>{{ i18n.baseText('workflowSettings.minutes') }}</template>
 							</N8nInput>
-						</el-col>
-						<el-col :span="4" :class="$style['timeout-input']">
+						</ElCol>
+						<ElCol :span="4" :class="$style['timeout-input']">
 							<N8nInput
 								:disabled="readOnlyEnv || !workflowPermissions.update"
 								:model-value="timeoutHMS.seconds"
@@ -833,46 +833,46 @@ onBeforeUnmount(() => {
 							>
 								<template #append>{{ i18n.baseText('workflowSettings.seconds') }}</template>
 							</N8nInput>
-						</el-col>
-					</el-row>
+						</ElCol>
+					</ElRow>
 				</div>
-				<el-row v-if="isMCPEnabled" data-test-id="workflow-settings-available-in-mcp">
-					<el-col :span="10" :class="$style['setting-name']">
+				<ElRow v-if="isMCPEnabled" data-test-id="workflow-settings-available-in-mcp">
+					<ElCol :span="10" :class="$style['setting-name']">
 						<label for="availableInMCP">
 							{{ i18n.baseText('workflowSettings.availableInMCP') }}
 							<N8nTooltip placement="top">
 								<template #content>
 									{{ i18n.baseText('workflowSettings.availableInMCP.tooltip') }}
 								</template>
-								<n8n-icon icon="circle-help" />
+								<N8nIcon icon="circle-help" />
 							</N8nTooltip>
 						</label>
-					</el-col>
-					<el-col :span="14">
+					</ElCol>
+					<ElCol :span="14">
 						<div>
-							<el-switch
+							<ElSwitch
 								ref="inputField"
 								:disabled="readOnlyEnv || !workflowPermissions.update"
 								:model-value="workflowSettings.availableInMCP ?? false"
 								data-test-id="workflow-settings-available-in-mcp"
 								@update:model-value="toggleAvailableInMCP"
-							></el-switch>
+							></ElSwitch>
 						</div>
-					</el-col>
-				</el-row>
-				<el-row>
-					<el-col :span="10" :class="$style['setting-name']">
+					</ElCol>
+				</ElRow>
+				<ElRow>
+					<ElCol :span="10" :class="$style['setting-name']">
 						<label for="timeSavedPerExecution">
 							{{ i18n.baseText('workflowSettings.timeSavedPerExecution') }}
 							<N8nTooltip placement="top">
 								<template #content>
 									{{ i18n.baseText('workflowSettings.timeSavedPerExecution.tooltip') }}
 								</template>
-								<n8n-icon icon="circle-help" />
+								<N8nIcon icon="circle-help" />
 							</N8nTooltip>
 						</label>
-					</el-col>
-					<el-col :span="14">
+					</ElCol>
+					<ElCol :span="14">
 						<div :class="$style['time-saved']">
 							<N8nInput
 								id="timeSavedPerExecution"
@@ -885,8 +885,8 @@ onBeforeUnmount(() => {
 							/>
 							<span>{{ i18n.baseText('workflowSettings.timeSavedPerExecution.hint') }}</span>
 						</div>
-					</el-col>
-				</el-row>
+					</ElCol>
+				</ElRow>
 			</div>
 		</template>
 		<template #footer>

--- a/packages/frontend/editor-ui/src/components/WorkflowShareModal.ee.vue
+++ b/packages/frontend/editor-ui/src/components/WorkflowShareModal.ee.vue
@@ -249,16 +249,16 @@ watch(
 	>
 		<template #content>
 			<div v-if="!isSharingEnabled" :class="$style.container">
-				<n8n-text>
+				<N8nText>
 					{{
 						i18n.baseText(
 							uiStore.contextBasedTranslationKeys.workflows.sharing.unavailable.description.modal,
 						)
 					}}
-				</n8n-text>
+				</N8nText>
 			</div>
 			<div v-else :class="$style.container">
-				<n8n-info-tip
+				<N8nInfoTip
 					v-if="!workflowPermissions.share && !isHomeTeamProject"
 					:bold="false"
 					class="mb-s"
@@ -268,8 +268,8 @@ watch(
 							interpolate: { workflowOwnerName },
 						})
 					}}
-				</n8n-info-tip>
-				<enterprise-edition :features="[EnterpriseEditionFeature.Sharing]" :class="$style.content">
+				</N8nInfoTip>
+				<EnterpriseEdition :features="[EnterpriseEditionFeature.Sharing]" :class="$style.content">
 					<div>
 						<ProjectSharing
 							v-model="sharedWithProjects"
@@ -282,7 +282,7 @@ watch(
 							@project-added="onProjectAdded"
 							@project-removed="onProjectRemoved"
 						/>
-						<n8n-info-tip v-if="isHomeTeamProject" :bold="false" class="mt-s">
+						<N8nInfoTip v-if="isHomeTeamProject" :bold="false" class="mt-s">
 							<I18nT keypath="workflows.shareModal.info.members" tag="span" scope="global">
 								<template #projectName>
 									{{ workflow.homeProject?.name }}
@@ -300,10 +300,10 @@ watch(
 									</strong>
 								</template>
 							</I18nT>
-						</n8n-info-tip>
+						</N8nInfoTip>
 					</div>
 					<template #fallback>
-						<n8n-text>
+						<N8nText>
 							<I18nT
 								:keypath="
 									uiStore.contextBasedTranslationKeys.workflows.sharing.unavailable.description
@@ -314,32 +314,32 @@ watch(
 							>
 								<template #action />
 							</I18nT>
-						</n8n-text>
+						</N8nText>
 					</template>
-				</enterprise-edition>
+				</EnterpriseEdition>
 			</div>
 		</template>
 
 		<template #footer>
 			<div v-if="!isSharingEnabled" :class="$style.actionButtons">
-				<n8n-button @click="goToUpgrade">
+				<N8nButton @click="goToUpgrade">
 					{{
 						i18n.baseText(uiStore.contextBasedTranslationKeys.workflows.sharing.unavailable.button)
 					}}
-				</n8n-button>
+				</N8nButton>
 			</div>
-			<enterprise-edition
+			<EnterpriseEdition
 				v-else
 				:features="[EnterpriseEditionFeature.Sharing]"
 				:class="$style.actionButtons"
 			>
-				<n8n-text v-show="isDirty" color="text-light" size="small" class="mr-xs">
+				<N8nText v-show="isDirty" color="text-light" size="small" class="mr-xs">
 					{{ i18n.baseText('workflows.shareModal.changesHint') }}
-				</n8n-text>
-				<n8n-button v-if="isHomeTeamProject" type="secondary" @click="modalBus.emit('close')">
+				</N8nText>
+				<N8nButton v-if="isHomeTeamProject" type="secondary" @click="modalBus.emit('close')">
 					{{ i18n.baseText('generic.close') }}
-				</n8n-button>
-				<n8n-button
+				</N8nButton>
+				<N8nButton
 					v-else
 					v-show="workflowPermissions.share"
 					:loading="loading"
@@ -348,8 +348,8 @@ watch(
 					@click="onSave"
 				>
 					{{ i18n.baseText('workflows.shareModal.save') }}
-				</n8n-button>
-			</enterprise-edition>
+				</N8nButton>
+			</EnterpriseEdition>
 		</template>
 	</Modal>
 </template>

--- a/packages/frontend/editor-ui/src/components/banners/BaseBanner.vue
+++ b/packages/frontend/editor-ui/src/components/banners/BaseBanner.vue
@@ -38,7 +38,7 @@ async function onCloseClick() {
 }
 </script>
 <template>
-	<n8n-callout
+	<N8nCallout
 		:class="$style.callout"
 		:theme="props.theme"
 		:icon="props.customIcon"
@@ -53,7 +53,7 @@ async function onCloseClick() {
 		<template #trailingContent>
 			<div :class="$style.trailingContent">
 				<slot name="trailingContent" />
-				<n8n-icon
+				<N8nIcon
 					v-if="dismissible"
 					size="small"
 					icon="x"
@@ -64,7 +64,7 @@ async function onCloseClick() {
 				/>
 			</div>
 		</template>
-	</n8n-callout>
+	</N8nCallout>
 </template>
 
 <style lang="scss" module>

--- a/packages/frontend/editor-ui/src/components/banners/EmailConfirmationBanner.vue
+++ b/packages/frontend/editor-ui/src/components/banners/EmailConfirmationBanner.vue
@@ -36,12 +36,12 @@ async function onConfirmEmailClick() {
 		<template #mainContent>
 			<span>
 				{{ locale.baseText('banners.confirmEmail.message.1') }}
-				<router-link to="/settings/personal">{{ userEmail }}</router-link>
+				<RouterLink to="/settings/personal">{{ userEmail }}</RouterLink>
 				{{ locale.baseText('banners.confirmEmail.message.2') }}
 			</span>
 		</template>
 		<template #trailingContent>
-			<n8n-button
+			<N8nButton
 				type="success"
 				icon="mail"
 				size="small"
@@ -49,7 +49,7 @@ async function onConfirmEmailClick() {
 				@click="onConfirmEmailClick"
 			>
 				{{ locale.baseText('banners.confirmEmail.button') }}
-			</n8n-button>
+			</N8nButton>
 		</template>
 	</BaseBanner>
 </template>

--- a/packages/frontend/editor-ui/src/components/banners/TrialBanner.vue
+++ b/packages/frontend/editor-ui/src/components/banners/TrialBanner.vue
@@ -85,9 +85,9 @@ function onUpdatePlanClick() {
 			</div>
 		</template>
 		<template #trailingContent>
-			<n8n-button type="success" icon="gem" size="small" @click="onUpdatePlanClick">{{
+			<N8nButton type="success" icon="gem" size="small" @click="onUpdatePlanClick">{{
 				locale.baseText('generic.upgradeNow')
-			}}</n8n-button>
+			}}</N8nButton>
 		</template>
 	</BaseBanner>
 </template>

--- a/packages/frontend/editor-ui/src/components/banners/TrialOverBanner.vue
+++ b/packages/frontend/editor-ui/src/components/banners/TrialOverBanner.vue
@@ -14,9 +14,9 @@ function onUpdatePlanClick() {
 			<span>{{ locale.baseText('banners.trialOver.message') }}</span>
 		</template>
 		<template #trailingContent>
-			<n8n-button type="success" icon="gem" size="small" @click="onUpdatePlanClick">{{
+			<N8nButton type="success" icon="gem" size="small" @click="onUpdatePlanClick">{{
 				locale.baseText('generic.upgradeNow')
-			}}</n8n-button>
+			}}</N8nButton>
 		</template>
 	</BaseBanner>
 </template>

--- a/packages/frontend/editor-ui/src/components/canvas/WorkflowCanvas.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/WorkflowCanvas.vue
@@ -79,8 +79,8 @@ defineExpose({
 		<div id="canvas" :class="$style.canvas">
 			<Canvas
 				v-if="workflow"
-				ref="canvas"
 				:id="id"
+				ref="canvas"
 				:nodes="executing ? mappedNodesThrottled : mappedNodes"
 				:connections="executing ? mappedConnectionsThrottled : mappedConnections"
 				:event-bus="eventBus"

--- a/packages/frontend/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeAIPrompt.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeAIPrompt.vue
@@ -175,7 +175,7 @@ function onAddNodeClick() {
 				type="button"
 				aria-label="Add node manually"
 			>
-				<n8n-icon icon="plus" :size="40" />
+				<N8nIcon icon="plus" :size="40" />
 			</button>
 			<div :class="$style.startManuallyLabel">
 				<strong :class="$style.startManuallyText">

--- a/packages/frontend/editor-ui/src/components/canvas/experimental/components/ExperimentalEmbeddedNdvMapper.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/experimental/components/ExperimentalEmbeddedNdvMapper.vue
@@ -2,9 +2,8 @@
 import InputPanel from '@/components/InputPanel.vue';
 import type { INodeUi } from '@/Interface';
 import { useNDVStore } from '@/stores/ndv.store';
-import { onBeforeUnmount, ref, watch } from 'vue';
 import type { Workflow } from 'n8n-workflow';
-import { computed, useTemplateRef } from 'vue';
+import { onBeforeUnmount, watch, computed, ref, useTemplateRef } from 'vue';
 import { N8nPopoverReka } from '@n8n/design-system';
 import { useStyles } from '@/composables/useStyles';
 import {

--- a/packages/frontend/editor-ui/src/components/executions/ConcurrentExecutionsHeader.vue
+++ b/packages/frontend/editor-ui/src/components/executions/ConcurrentExecutionsHeader.vue
@@ -42,8 +42,8 @@ const headerText = computed(() => {
 
 <template>
 	<div data-test-id="concurrent-executions-header">
-		<n8n-text>{{ headerText }}</n8n-text>
-		<n8n-tooltip>
+		<N8nText>{{ headerText }}</N8nText>
+		<N8nTooltip>
 			<template #content>
 				<div :class="$style.tooltip">
 					{{ tooltipText }}
@@ -65,8 +65,8 @@ const headerText = computed(() => {
 					>
 				</div>
 			</template>
-			<n8n-icon icon="info" class="ml-2xs" />
-		</n8n-tooltip>
+			<N8nIcon icon="info" class="ml-2xs" />
+		</N8nTooltip>
 	</div>
 </template>
 

--- a/packages/frontend/editor-ui/src/components/executions/ExecutionsFilter.vue
+++ b/packages/frontend/editor-ui/src/components/executions/ExecutionsFilter.vue
@@ -160,9 +160,9 @@ onBeforeMount(() => {
 });
 </script>
 <template>
-	<n8n-popover trigger="click" :placement="popoverPlacement" width="440">
+	<N8nPopover trigger="click" :placement="popoverPlacement" width="440">
 		<template #reference>
-			<n8n-button
+			<N8nButton
 				icon="funnel"
 				type="tertiary"
 				size="medium"
@@ -172,21 +172,21 @@ onBeforeMount(() => {
 				:class="$style.filterButton"
 			>
 				<template v-if="!!countSelectedFilterProps" #default>
-					<n8n-badge
+					<N8nBadge
 						theme="primary"
 						class="mr-4xs"
 						data-test-id="execution-filter-badge"
 						:class="$style.filterBadge"
 					>
 						{{ countSelectedFilterProps }}
-					</n8n-badge>
+					</N8nBadge>
 				</template>
-			</n8n-button>
+			</N8nButton>
 		</template>
 		<div data-test-id="execution-filter-form">
 			<div v-if="workflows && workflows.length > 0" :class="$style.group">
 				<label for="execution-filter-workflows">{{ locale.baseText('workflows.heading') }}</label>
-				<n8n-select
+				<N8nSelect
 					id="execution-filter-workflows"
 					v-model="filter.workflowId"
 					:placeholder="locale.baseText('executionsFilter.selectWorkflow')"
@@ -195,14 +195,14 @@ onBeforeMount(() => {
 					:teleported="teleported"
 				>
 					<div>
-						<n8n-option
+						<N8nOption
 							v-for="(item, idx) in props.workflows"
 							:key="idx"
 							:label="item.name"
 							:value="item.id"
 						/>
 					</div>
-				</n8n-select>
+				</N8nSelect>
 			</div>
 			<div v-if="showTags" :class="$style.group">
 				<label for="execution-filter-tags">{{ locale.baseText('workflows.filters.tags') }}</label>
@@ -217,7 +217,7 @@ onBeforeMount(() => {
 			</div>
 			<div :class="$style.group">
 				<label for="execution-filter-status">{{ locale.baseText('executionsList.status') }}</label>
-				<n8n-select
+				<N8nSelect
 					id="execution-filter-status"
 					v-model="filter.status"
 					:placeholder="locale.baseText('executionsFilter.selectStatus')"
@@ -225,20 +225,20 @@ onBeforeMount(() => {
 					data-test-id="executions-filter-status-select"
 					:teleported="teleported"
 				>
-					<n8n-option
+					<N8nOption
 						v-for="(item, idx) in statuses"
 						:key="idx"
 						:label="item.name"
 						:value="item.id"
 					/>
-				</n8n-select>
+				</N8nSelect>
 			</div>
 			<div :class="$style.group">
 				<label for="execution-filter-start-date">{{
 					locale.baseText('executionsFilter.start')
 				}}</label>
 				<div :class="$style.dates">
-					<el-date-picker
+					<ElDatePicker
 						id="execution-filter-start-date"
 						v-model="filter.startDate"
 						type="datetime"
@@ -248,7 +248,7 @@ onBeforeMount(() => {
 						data-test-id="executions-filter-start-date-picker"
 					/>
 					<span :class="$style.divider">to</span>
-					<el-date-picker
+					<ElDatePicker
 						id="execution-filter-end-date"
 						v-model="filter.endDate"
 						type="datetime"
@@ -276,7 +276,7 @@ onBeforeMount(() => {
 				<label for="execution-filter-annotation-vote">{{
 					locale.baseText('executionsFilter.annotation.rating')
 				}}</label>
-				<n8n-select
+				<N8nSelect
 					id="execution-filter-annotation-vote"
 					v-model="filter.vote"
 					:placeholder="locale.baseText('executionsFilter.annotation.selectVoteFilter')"
@@ -284,29 +284,29 @@ onBeforeMount(() => {
 					data-test-id="executions-filter-annotation-vote-select"
 					:teleported="teleported"
 				>
-					<n8n-option
+					<N8nOption
 						v-for="(item, idx) in voteFilterOptions"
 						:key="idx"
 						:label="item.name"
 						:value="item.id"
 					/>
-				</n8n-select>
+				</N8nSelect>
 			</div>
 			<div :class="$style.group">
-				<n8n-tooltip placement="right">
+				<N8nTooltip placement="right">
 					<template #content>
 						<I18nT tag="span" keypath="executionsFilter.customData.docsTooltip" scope="global" />
 					</template>
 					<span :class="[$style.label, $style.savedDataLabel]">
 						<span>{{ locale.baseText('executionsFilter.savedData') }}</span>
-						<n8n-icon :class="$style.tooltipIcon" icon="circle-help" size="medium" />
+						<N8nIcon :class="$style.tooltipIcon" icon="circle-help" size="medium" />
 					</span>
-				</n8n-tooltip>
+				</N8nTooltip>
 				<div :class="$style.subGroup">
 					<label for="execution-filter-saved-data-key">{{
 						locale.baseText('executionsFilter.savedDataKey')
 					}}</label>
-					<n8n-tooltip :disabled="isAdvancedExecutionFilterEnabled" placement="top">
+					<N8nTooltip :disabled="isAdvancedExecutionFilterEnabled" placement="top">
 						<template #content>
 							<I18nT tag="span" keypath="executionsFilter.customData.inputTooltip" scope="global">
 								<template #link>
@@ -319,7 +319,7 @@ onBeforeMount(() => {
 								</template>
 							</I18nT>
 						</template>
-						<n8n-input
+						<N8nInput
 							id="execution-filter-saved-data-key"
 							name="execution-filter-saved-data-key"
 							type="text"
@@ -329,9 +329,9 @@ onBeforeMount(() => {
 							data-test-id="execution-filter-saved-data-key-input"
 							@update:model-value="onFilterMetaChange(0, 'key', $event)"
 						/>
-					</n8n-tooltip>
+					</N8nTooltip>
 					<div :class="$style.checkboxWrapper">
-						<n8n-tooltip :disabled="isAdvancedExecutionFilterEnabled" placement="top">
+						<N8nTooltip :disabled="isAdvancedExecutionFilterEnabled" placement="top">
 							<template #content>
 								<I18nT tag="span" keypath="executionsFilter.customData.inputTooltip" scope="global">
 									<template #link>
@@ -341,19 +341,19 @@ onBeforeMount(() => {
 									</template>
 								</I18nT>
 							</template>
-							<n8n-checkbox
+							<N8nCheckbox
 								:label="locale.baseText('executionsFilter.savedDataExactMatch')"
 								:model-value="filter.metadata[0]?.exactMatch"
 								:disabled="!isAdvancedExecutionFilterEnabled"
 								data-test-id="execution-filter-saved-data-exact-match-checkbox"
 								@update:model-value="onExactMatchChange"
 							/>
-						</n8n-tooltip>
+						</N8nTooltip>
 					</div>
 					<label for="execution-filter-saved-data-value">{{
 						locale.baseText('executionsFilter.savedDataValue')
 					}}</label>
-					<n8n-tooltip :disabled="isAdvancedExecutionFilterEnabled" placement="top">
+					<N8nTooltip :disabled="isAdvancedExecutionFilterEnabled" placement="top">
 						<template #content>
 							<I18nT tag="span" keypath="executionsFilter.customData.inputTooltip" scope="global">
 								<template #link>
@@ -363,7 +363,7 @@ onBeforeMount(() => {
 								</template>
 							</I18nT>
 						</template>
-						<n8n-input
+						<N8nInput
 							id="execution-filter-saved-data-value"
 							name="execution-filter-saved-data-value"
 							type="text"
@@ -373,10 +373,10 @@ onBeforeMount(() => {
 							data-test-id="execution-filter-saved-data-value-input"
 							@update:model-value="onFilterMetaChange(0, 'value', $event)"
 						/>
-					</n8n-tooltip>
+					</N8nTooltip>
 				</div>
 			</div>
-			<n8n-button
+			<N8nButton
 				v-if="!!countSelectedFilterProps"
 				:class="$style.resetBtn"
 				size="large"
@@ -385,9 +385,9 @@ onBeforeMount(() => {
 				@click="onFilterReset"
 			>
 				{{ locale.baseText('executionsFilter.reset') }}
-			</n8n-button>
+			</N8nButton>
 		</div>
-	</n8n-popover>
+	</N8nPopover>
 </template>
 <style lang="scss" module>
 .group {

--- a/packages/frontend/editor-ui/src/components/executions/global/GlobalExecutionsList.test.ts
+++ b/packages/frontend/editor-ui/src/components/executions/global/GlobalExecutionsList.test.ts
@@ -106,7 +106,7 @@ const renderComponent = createComponentRenderer(ExecutionsList, {
 				params: {},
 			},
 		},
-		stubs: ['font-awesome-icon'],
+		stubs: ['FontAwesomeIcon'],
 	},
 });
 

--- a/packages/frontend/editor-ui/src/components/executions/global/GlobalExecutionsListItem.test.ts
+++ b/packages/frontend/editor-ui/src/components/executions/global/GlobalExecutionsListItem.test.ts
@@ -20,12 +20,11 @@ const globalExecutionsListItemQueuedTooltipRenderSpy = vi.fn();
 
 const renderComponent = createComponentRenderer(GlobalExecutionsListItem, {
 	global: {
-		//stubs: ['font-awesome-icon', 'n8n-tooltip', 'n8n-button', 'i18n-t'],
 		stubs: {
-			'font-awesome-icon': true,
-			'n8n-tooltip': true,
-			'n8n-button': true,
-			'i18n-t': true,
+			FontAwesomeIcon: true,
+			N8nTooltip: true,
+			N8nButton: true,
+			I18nT: true,
 			GlobalExecutionsListItemQueuedTooltip: {
 				render: globalExecutionsListItemQueuedTooltipRenderSpy,
 			},

--- a/packages/frontend/editor-ui/src/components/executions/workflow/VoteButtons.vue
+++ b/packages/frontend/editor-ui/src/components/executions/workflow/VoteButtons.vue
@@ -16,7 +16,7 @@ const onVoteClick = (vote: AnnotationVote) => {
 
 <template>
 	<div :class="$style.ratingIcon">
-		<n8n-icon-button
+		<N8nIconButton
 			:class="[$style.icon, vote === 'up' && $style.up]"
 			type="tertiary"
 			text
@@ -24,7 +24,7 @@ const onVoteClick = (vote: AnnotationVote) => {
 			icon="thumbs-up"
 			@click="onVoteClick('up')"
 		/>
-		<n8n-icon-button
+		<N8nIconButton
 			:class="[$style.icon, vote === 'down' && $style.down]"
 			type="tertiary"
 			text

--- a/packages/frontend/editor-ui/src/components/executions/workflow/WorkflowExecutionAnnotationPanel.ee.vue
+++ b/packages/frontend/editor-ui/src/components/executions/workflow/WorkflowExecutionAnnotationPanel.ee.vue
@@ -62,9 +62,9 @@ function onDropdownVisibleChange(visible: boolean) {
 			data-test-id="execution-preview-ellipsis-button"
 			@blur="onEllipsisButtonBlur"
 		>
-			<n8n-badge v-if="customDataLength > 0" :class="$style.badge" theme="primary">
+			<N8nBadge v-if="customDataLength > 0" :class="$style.badge" theme="primary">
 				{{ customDataLength.toString() }}
-			</n8n-badge>
+			</N8nBadge>
 		</N8nButton>
 		<template #dropdown>
 			<div
@@ -74,9 +74,9 @@ function onDropdownVisibleChange(visible: boolean) {
 			>
 				<div :class="$style.section">
 					<div :class="$style.heading">
-						<n8n-heading tag="h3" size="small" color="text-dark">
+						<N8nHeading tag="h3" size="small" color="text-dark">
 							{{ i18n.baseText('generic.annotationData') }}
-						</n8n-heading>
+						</N8nHeading>
 					</div>
 					<div
 						v-if="execution?.customData && Object.keys(execution?.customData).length > 0"
@@ -87,12 +87,12 @@ function onDropdownVisibleChange(visible: boolean) {
 							:key="attr"
 							:class="$style.customDataEntry"
 						>
-							<n8n-text :class="$style.key" size="small" color="text-base">
+							<N8nText :class="$style.key" size="small" color="text-base">
 								{{ attr }}
-							</n8n-text>
-							<n8n-text :class="$style.value" size="small" color="text-base">
+							</N8nText>
+							<N8nText :class="$style.value" size="small" color="text-base">
 								{{ execution?.customData[attr] }}
-							</n8n-text>
+							</N8nText>
 						</div>
 					</div>
 					<div
@@ -100,9 +100,9 @@ function onDropdownVisibleChange(visible: boolean) {
 						:class="$style.noResultsContainer"
 						data-test-id="execution-annotation-data-empty"
 					>
-						<n8n-text color="text-base" size="small" align="center">
+						<N8nText color="text-base" size="small" align="center">
 							<span v-n8n-html="i18n.baseText('executionAnnotationView.data.notFound')" />
-						</n8n-text>
+						</N8nText>
 					</div>
 				</div>
 			</div>

--- a/packages/frontend/editor-ui/src/components/executions/workflow/WorkflowExecutionAnnotationTags.ee.vue
+++ b/packages/frontend/editor-ui/src/components/executions/workflow/WorkflowExecutionAnnotationTags.ee.vue
@@ -119,9 +119,9 @@ const onTagsEditEsc = () => {
 				@click="onTagsEditEnable"
 			>
 				<span v-for="tag in tags" :key="tag.id" class="clickable">
-					<el-tag :title="tag.name" type="info" size="small" :disable-transitions="true">
+					<ElTag :title="tag.name" type="info" size="small" :disable-transitions="true">
 						{{ tag.name }}
-					</el-tag>
+					</ElTag>
 				</span>
 				<span :class="$style.addTagWrapper">
 					<N8nButton

--- a/packages/frontend/editor-ui/src/components/executions/workflow/WorkflowExecutionsCard.test.ts
+++ b/packages/frontend/editor-ui/src/components/executions/workflow/WorkflowExecutionsCard.test.ts
@@ -33,7 +33,7 @@ const initialState = {
 const renderComponent = createComponentRenderer(WorkflowExecutionsCard, {
 	global: {
 		stubs: {
-			'router-link': {
+			RouterLink: {
 				template: '<div><slot /></div>',
 			},
 		},

--- a/packages/frontend/editor-ui/src/components/executions/workflow/WorkflowExecutionsCard.vue
+++ b/packages/frontend/editor-ui/src/components/executions/workflow/WorkflowExecutionsCard.vue
@@ -73,7 +73,7 @@ function onRetryMenuItemSelect(action: string): void {
 			[$style.showGap]: showGap,
 		}"
 	>
-		<router-link
+		<RouterLink
 			:class="$style.executionLink"
 			:to="{
 				name: VIEWS.EXECUTION_PREVIEW,
@@ -175,7 +175,7 @@ function onRetryMenuItemSelect(action: string): void {
 					<N8nIcon :class="[$style.icon, $style.evaluation]" icon="check-check" />
 				</N8nTooltip>
 			</div>
-		</router-link>
+		</RouterLink>
 	</div>
 </template>
 

--- a/packages/frontend/editor-ui/src/components/executions/workflow/WorkflowExecutionsList.vue
+++ b/packages/frontend/editor-ui/src/components/executions/workflow/WorkflowExecutionsList.vue
@@ -92,7 +92,7 @@ onBeforeRouteLeave(async (to, _, next) => {
 			@retry-execution="onRetryExecution"
 		/>
 		<div v-if="!hidePreview" :class="$style.content">
-			<router-view
+			<RouterView
 				name="executionPreview"
 				:execution="execution"
 				@delete-current-execution="onDeleteCurrentExecution"

--- a/packages/frontend/editor-ui/src/components/executions/workflow/WorkflowExecutionsPreview.test.ts
+++ b/packages/frontend/editor-ui/src/components/executions/workflow/WorkflowExecutionsPreview.test.ts
@@ -74,7 +74,7 @@ const renderComponent = createComponentRenderer(WorkflowExecutionsPreview, {
 	global: {
 		stubs: {
 			// UN STUB router-link
-			'router-link': RouterLink,
+			RouterLink,
 		},
 		plugins: [router],
 	},

--- a/packages/frontend/editor-ui/src/components/executions/workflow/WorkflowExecutionsSidebar.vue
+++ b/packages/frontend/editor-ui/src/components/executions/workflow/WorkflowExecutionsSidebar.vue
@@ -186,9 +186,9 @@ const goToUpgrade = () => {
 		data-test-id="executions-sidebar"
 	>
 		<div :class="$style.heading">
-			<n8n-heading tag="h2" size="medium" color="text-dark">
+			<N8nHeading tag="h2" size="medium" color="text-dark">
 				{{ i18n.baseText('generic.executions') }}
-			</n8n-heading>
+			</N8nHeading>
 
 			<ConcurrentExecutionsHeader
 				v-if="showConcurrencyHeader"
@@ -199,13 +199,13 @@ const goToUpgrade = () => {
 			/>
 		</div>
 		<div :class="$style.controls">
-			<el-checkbox
+			<ElCheckbox
 				v-model="executionsStore.autoRefresh"
 				data-test-id="auto-refresh-checkbox"
 				@update:model-value="onAutoRefreshChange"
 			>
 				{{ i18n.baseText('executionsList.autoRefresh') }}
-			</el-checkbox>
+			</ElCheckbox>
 			<ExecutionsFilter popover-placement="right-start" @filter-changed="onFilterChanged" />
 		</div>
 		<div
@@ -215,16 +215,16 @@ const goToUpgrade = () => {
 			@scroll="loadMore(20)"
 		>
 			<div v-if="loading" class="mr-l">
-				<n8n-loading variant="rect" />
+				<N8nLoading variant="rect" />
 			</div>
 			<div
 				v-if="!loading && executions.length === 0"
 				:class="$style.noResultsContainer"
 				data-test-id="execution-list-empty"
 			>
-				<n8n-text color="text-base" size="medium" align="center">
+				<N8nText color="text-base" size="medium" align="center">
 					{{ i18n.baseText('executionsLandingPage.noResults') }}
-				</n8n-text>
+				</N8nText>
 			</div>
 			<WorkflowExecutionsCard
 				v-else-if="temporaryExecution"
@@ -248,7 +248,7 @@ const goToUpgrade = () => {
 				/>
 			</TransitionGroup>
 			<div v-if="loadingMore" class="mr-m">
-				<n8n-loading variant="p" :rows="1" />
+				<N8nLoading variant="p" :rows="1" />
 			</div>
 		</div>
 		<div :class="$style.infoAccordion">

--- a/packages/frontend/editor-ui/src/components/forms/ResourceFiltersDropdown.vue
+++ b/packages/frontend/editor-ui/src/components/forms/ResourceFiltersDropdown.vue
@@ -108,9 +108,9 @@ onBeforeMount(async () => {
 </script>
 
 <template>
-	<n8n-popover trigger="click" width="304" size="large">
+	<N8nPopover trigger="click" width="304" size="large">
 		<template #reference>
-			<n8n-button
+			<N8nButton
 				icon="funnel"
 				type="tertiary"
 				size="small"
@@ -121,26 +121,26 @@ onBeforeMount(async () => {
 				}"
 				data-test-id="resources-list-filters-trigger"
 			>
-				<n8n-badge
+				<N8nBadge
 					v-if="filtersLength > 0"
 					:class="$style['filter-button-count']"
 					data-test-id="resources-list-filters-count"
 					theme="primary"
 				>
 					{{ filtersLength }}
-				</n8n-badge>
+				</N8nBadge>
 				<span v-if="!justIcon" :class="$style['filter-button-text']">
 					{{ i18n.baseText('forms.resourceFiltersDropdown.filters') }}
 				</span>
-			</n8n-button>
+			</N8nButton>
 		</template>
 		<div :class="$style['filters-dropdown']" data-test-id="resources-list-filters-dropdown">
 			<slot :filters="modelValue" :set-key-value="setKeyValue" />
-			<enterprise-edition
+			<EnterpriseEdition
 				v-if="shareable && projectsStore.isProjectHome"
 				:features="[EnterpriseEditionFeature.Sharing]"
 			>
-				<n8n-input-label
+				<N8nInputLabel
 					:label="i18n.baseText('forms.resourceFiltersDropdown.owner')"
 					:bold="false"
 					size="small"
@@ -154,14 +154,14 @@ onBeforeMount(async () => {
 					:empty-options-text="i18n.baseText('projects.sharing.noMatchingProjects')"
 					@update:model-value="setKeyValue('homeProject', ($event as ProjectSharingData).id)"
 				/>
-			</enterprise-edition>
+			</EnterpriseEdition>
 			<div v-if="hasFilters" :class="[$style['filters-dropdown-footer'], 'mt-s']">
-				<n8n-link @click="resetFilters">
+				<N8nLink @click="resetFilters">
 					{{ i18n.baseText('forms.resourceFiltersDropdown.reset') }}
-				</n8n-link>
+				</N8nLink>
 			</div>
 		</div>
-	</n8n-popover>
+	</N8nPopover>
 </template>
 
 <style lang="scss" module>

--- a/packages/frontend/editor-ui/src/components/layouts/ResourcesListLayout.vue
+++ b/packages/frontend/editor-ui/src/components/layouts/ResourcesListLayout.vue
@@ -563,12 +563,12 @@ defineExpose({
 			<slot name="header" />
 		</template>
 		<div v-if="loading" class="resource-list-loading">
-			<n8n-loading :rows="25" :shrink-last="false" />
+			<N8nLoading :rows="25" :shrink-last="false" />
 		</div>
 		<template v-else>
 			<div v-if="showEmptyState">
 				<slot name="empty">
-					<n8n-action-box
+					<N8nActionBox
 						data-test-id="empty-resources-list"
 						emoji="👋"
 						:heading="
@@ -587,7 +587,7 @@ defineExpose({
 						<template #disabledButtonTooltip>
 							{{ getResourceText('empty.button.disabled.tooltip') }}
 						</template>
-					</n8n-action-box>
+					</N8nActionBox>
 				</slot>
 			</div>
 			<PageViewLayoutList v-else>
@@ -595,7 +595,7 @@ defineExpose({
 					<div :class="$style['filters-row']">
 						<div :class="$style.filters">
 							<slot name="breadcrumbs"></slot>
-							<n8n-input
+							<N8nInput
 								v-if="props.uiConfig.searchEnabled"
 								ref="search"
 								:model-value="filtersModel.search"
@@ -607,24 +607,24 @@ defineExpose({
 								@update:model-value="onSearch"
 							>
 								<template #prefix>
-									<n8n-icon icon="search" />
+									<N8nIcon icon="search" />
 								</template>
-							</n8n-input>
+							</N8nInput>
 							<div v-if="props.uiConfig.sortEnabled" :class="$style['sort-and-filter']">
-								<n8n-select
+								<N8nSelect
 									v-model="sortBy"
 									size="small"
 									data-test-id="resources-list-sort"
 									@change="setSorting(sortBy)"
 								>
-									<n8n-option
+									<N8nOption
 										v-for="sortOption in sortOptions"
 										:key="sortOption"
 										data-test-id="resources-list-sort-item"
 										:value="sortOption"
 										:label="getResourceText(`sort.${sortOption}`, `sort.${sortOption}`)"
 									/>
-								</n8n-select>
+								</N8nSelect>
 							</div>
 							<div v-if="props.uiConfig.showFiltersDropdown" :class="$style['sort-and-filter']">
 								<ResourceFiltersDropdown
@@ -653,16 +653,16 @@ defineExpose({
 						class="mt-xs"
 						data-test-id="resources-list-filters-applied-info"
 					>
-						<n8n-info-tip :bold="false">
+						<N8nInfoTip :bold="false">
 							{{
 								hasOnlyFiltersThatShowMoreResults
 									? getResourceText('filters.active.shortText', 'filters.active.shortText')
 									: getResourceText('filters.active', 'filters.active')
 							}}
-							<n8n-link data-test-id="workflows-filter-reset" size="small" @click="resetFilters">
+							<N8nLink data-test-id="workflows-filter-reset" size="small" @click="resetFilters">
 								{{ getResourceText('filters.active.reset', 'filters.active.reset') }}
-							</n8n-link>
-						</n8n-info-tip>
+							</N8nLink>
+						</N8nInfoTip>
 					</div>
 
 					<div class="pb-xs" />
@@ -671,7 +671,7 @@ defineExpose({
 				<slot name="preamble" />
 
 				<div v-if="resourcesRefreshing" class="resource-list-loading resource-list-loading-instant">
-					<n8n-loading :rows="rowsPerPage" :shrink-last="false" />
+					<N8nLoading :rows="rowsPerPage" :shrink-last="false" />
 				</div>
 				<div
 					v-else-if="filteredAndSortedResources.length > 0"
@@ -680,7 +680,7 @@ defineExpose({
 					:class="$style.listWrapper"
 				>
 					<!-- FULL SCROLLING LIST (Shows all resources, filtering and sorting is done in this component) -->
-					<n8n-recycle-scroller
+					<N8nRecycleScroller
 						v-if="type === 'list-full'"
 						data-test-id="resources-list"
 						:items="filteredAndSortedResources"
@@ -690,7 +690,7 @@ defineExpose({
 						<template #default="{ item, updateItemSize }">
 							<slot :data="item" :update-item-size="updateItemSize" />
 						</template>
-					</n8n-recycle-scroller>
+					</N8nRecycleScroller>
 					<!-- PAGINATED LIST -->
 					<div
 						v-else-if="type === 'list-paginated'"
@@ -705,7 +705,7 @@ defineExpose({
 							</div>
 						</div>
 						<div :class="$style.listPagination">
-							<el-pagination
+							<ElPagination
 								v-model:current-page="currentPage"
 								v-model:page-size="rowsPerPage"
 								background
@@ -715,11 +715,11 @@ defineExpose({
 								data-test-id="resources-list-pagination"
 								@update:current-page="setCurrentPage"
 								@size-change="setRowsPerPage"
-							></el-pagination>
+							></ElPagination>
 						</div>
 					</div>
 					<!-- DATATABLE -->
-					<n8n-datatable
+					<N8nDatatable
 						v-if="type === 'datatable'"
 						data-test-id="resources-table"
 						:class="$style.datatable"
@@ -733,17 +733,17 @@ defineExpose({
 						<template #row="{ columns, row }">
 							<slot :data="row" :columns="columns" />
 						</template>
-					</n8n-datatable>
+					</N8nDatatable>
 				</div>
 
-				<n8n-text
+				<N8nText
 					v-else-if="hasAppliedFilters() || filtersModel.search !== ''"
 					color="text-base"
 					size="medium"
 					data-test-id="resources-list-empty"
 				>
 					{{ getResourceText('noResults', 'noResults') }}
-				</n8n-text>
+				</N8nText>
 
 				<slot name="postamble" />
 			</PageViewLayoutList>

--- a/packages/frontend/editor-ui/src/components/transitions/SlideTransition.vue
+++ b/packages/frontend/editor-ui/src/components/transitions/SlideTransition.vue
@@ -1,7 +1,7 @@
 <template>
-	<transition name="slide">
+	<Transition name="slide">
 		<slot />
-	</transition>
+	</Transition>
 </template>
 
 <style lang="scss" scoped>

--- a/packages/frontend/editor-ui/src/features/dataStore/DataStoreDetailsView.vue
+++ b/packages/frontend/editor-ui/src/features/dataStore/DataStoreDetailsView.vue
@@ -105,26 +105,26 @@ onMounted(async () => {
 <template>
 	<div :class="$style['data-store-details-view']">
 		<div v-if="loading" data-test-id="data-store-details-loading">
-			<n8n-loading
+			<N8nLoading
 				variant="h1"
 				:loading="true"
 				:rows="1"
 				:shrink-last="false"
 				:class="$style['header-loading']"
 			/>
-			<n8n-loading :loading="true" variant="h1" :rows="10" :shrink-last="false" />
+			<N8nLoading :loading="true" variant="h1" :rows="10" :shrink-last="false" />
 		</div>
 		<div v-else-if="dataStore">
 			<div :class="$style.header">
 				<DataStoreBreadcrumbs :data-store="dataStore" />
 				<div v-if="saving" :class="$style.saving">
-					<n8n-spinner />
-					<n8n-text>{{ i18n.baseText('generic.saving') }}...</n8n-text>
+					<N8nSpinner />
+					<N8nText>{{ i18n.baseText('generic.saving') }}...</N8nText>
 				</div>
 				<div :class="$style.actions">
-					<n8n-button @click="dataStoreTableRef?.addRow">{{
+					<N8nButton @click="dataStoreTableRef?.addRow">{{
 						i18n.baseText('dataStore.addRow.label')
-					}}</n8n-button>
+					}}</N8nButton>
 					<AddColumnButton
 						:use-text-trigger="true"
 						:popover-id="'ds-details-add-column-popover'"

--- a/packages/frontend/editor-ui/src/features/dataStore/DataStoreView.vue
+++ b/packages/frontend/editor-ui/src/features/dataStore/DataStoreView.vue
@@ -139,7 +139,7 @@ watch(
 			</ProjectHeader>
 		</template>
 		<template #empty>
-			<n8n-action-box
+			<N8nActionBox
 				data-test-id="empty-shared-action-box"
 				:heading="i18n.baseText('dataStore.empty.label')"
 				:description="i18n.baseText('dataStore.empty.description')"

--- a/packages/frontend/editor-ui/src/features/dataStore/components/AddDataStoreModal.vue
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/AddDataStoreModal.vue
@@ -75,12 +75,12 @@ const redirectToDataStores = () => {
 		</template>
 		<template #content>
 			<div :class="$style.content">
-				<n8n-input-label
+				<N8nInputLabel
 					:label="i18n.baseText('dataStore.add.input.name.label')"
 					:required="true"
 					input-name="dataStoreName"
 				>
-					<n8n-input
+					<N8nInput
 						ref="inputRef"
 						v-model="dataStoreName"
 						type="text"
@@ -89,18 +89,18 @@ const redirectToDataStores = () => {
 						name="dataStoreName"
 						@keyup.enter="onSubmit"
 					/>
-				</n8n-input-label>
+				</N8nInputLabel>
 			</div>
 		</template>
 		<template #footer>
 			<div :class="$style.footer">
-				<n8n-button
+				<N8nButton
 					:disabled="!dataStoreName"
 					:label="i18n.baseText('generic.create')"
 					data-test-id="confirm-add-data-store-button"
 					@click="onSubmit"
 				/>
-				<n8n-button
+				<N8nButton
 					type="secondary"
 					:label="i18n.baseText('generic.cancel')"
 					data-test-id="cancel-add-data-store-button"

--- a/packages/frontend/editor-ui/src/features/dataStore/components/DataStoreBreadcrumbs.vue
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/DataStoreBreadcrumbs.vue
@@ -99,7 +99,7 @@ watch(
 
 <template>
 	<div :class="$style['data-store-breadcrumbs']">
-		<n8n-breadcrumbs
+		<N8nBreadcrumbs
 			:items="breadcrumbs"
 			:separator="BREADCRUMBS_SEPARATOR"
 			:highlight-last-item="false"
@@ -122,7 +122,7 @@ watch(
 					@update:model-value="onNameSubmit"
 				/>
 			</template>
-		</n8n-breadcrumbs>
+		</N8nBreadcrumbs>
 		<div :class="$style['data-store-actions']">
 			<DataStoreActions
 				:data-store="props.dataStore"

--- a/packages/frontend/editor-ui/src/features/dataStore/components/DataStoreCard.vue
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/DataStoreCard.vue
@@ -51,9 +51,9 @@ const getDataStoreSize = computed(() => {
 				</template>
 				<template #header>
 					<div :class="$style['card-header']">
-						<n8n-text tag="h2" bold data-test-id="data-store-card-name">
+						<N8nText tag="h2" bold data-test-id="data-store-card-name">
 							{{ props.dataStore.name }}
-						</n8n-text>
+						</N8nText>
 						<N8nBadge v-if="props.readOnly" class="ml-3xs" theme="tertiary" bold>
 							{{ i18n.baseText('workflows.item.readonly') }}
 						</N8nBadge>

--- a/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/AddColumnButton.vue
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/AddColumnButton.vue
@@ -160,9 +160,9 @@ const onInput = debounce(validateName, { debounceTime: 100 });
 									@input="onInput"
 								/>
 								<div v-if="error" class="error-message">
-									<n8n-text v-if="error.message" size="small" color="danger" tag="span">
+									<N8nText v-if="error.message" size="small" color="danger" tag="span">
 										{{ error.message }}
-									</n8n-text>
+									</N8nText>
 									<Tooltip
 										:content="error.description"
 										placement="top"

--- a/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/DataStoreTable.vue
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/DataStoreTable.vue
@@ -208,7 +208,7 @@ defineExpose({
 				@filter-changed="onFilterChanged"
 			/>
 			<div :class="$style.footer">
-				<el-pagination
+				<ElPagination
 					v-model:current-page="currentPage"
 					v-model:page-size="pageSize"
 					data-test-id="data-store-content-pagination"

--- a/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/ElDatePickerCellEditor.vue
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/ElDatePickerCellEditor.vue
@@ -38,7 +38,7 @@ defineExpose({
 
 <template>
 	<div ref="wrapperRef" class="datastore-datepicker-wrapper">
-		<el-date-picker
+		<ElDatePicker
 			id="datastore-datepicker"
 			ref="pickerRef"
 			v-model="dateValue"

--- a/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/ElDatePickerFilter.vue
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/ElDatePickerFilter.vue
@@ -38,7 +38,7 @@ defineExpose({
 
 <template>
 	<div ref="wrapperRef" class="datastore-date-filter-wrapper">
-		<el-date-picker
+		<ElDatePicker
 			ref="pickerRef"
 			v-model="dateValue"
 			type="datetime"

--- a/packages/frontend/editor-ui/src/features/insights/components/InsightsSummary.test.ts
+++ b/packages/frontend/editor-ui/src/features/insights/components/InsightsSummary.test.ts
@@ -14,7 +14,7 @@ vi.mock('vue-router', () => ({
 const renderComponent = createComponentRenderer(InsightsSummary, {
 	global: {
 		stubs: {
-			'router-link': {
+			RouterLink: {
 				template: '<a><slot /></a>',
 			},
 			N8nIcon: true,

--- a/packages/frontend/editor-ui/src/features/insights/components/InsightsSummary.vue
+++ b/packages/frontend/editor-ui/src/features/insights/components/InsightsSummary.vue
@@ -11,7 +11,7 @@ import { useI18n } from '@n8n/i18n';
 import { smartDecimal } from '@n8n/utils/number/smartDecimal';
 import { computed, useCssModule } from 'vue';
 import { I18nT } from 'vue-i18n';
-import { useRoute } from 'vue-router';
+import { RouterLink, useRoute } from 'vue-router';
 import { getTimeRangeLabels } from '../insights.utils';
 
 const props = defineProps<{
@@ -86,7 +86,7 @@ const trackTabClick = (insightType: keyof InsightsSummary) => {
 							</template>
 						</I18nT>
 					</template>
-					<router-link :to="to" :exact-active-class="$style.activeTab" @click="trackTabClick(id)">
+					<RouterLink :to="to" :exact-active-class="$style.activeTab" @click="trackTabClick(id)">
 						<strong>
 							<N8nTooltip placement="bottom" :disabled="id !== 'timeSaved'">
 								<template #content>
@@ -136,7 +136,7 @@ const trackTabClick = (insightType: keyof InsightsSummary) => {
 								</N8nTooltip>
 							</small>
 						</span>
-					</router-link>
+					</RouterLink>
 				</N8nTooltip>
 			</li>
 		</ul>

--- a/packages/frontend/editor-ui/src/features/insights/components/tables/InsightsTableWorkflows.test.ts
+++ b/packages/frontend/editor-ui/src/features/insights/components/tables/InsightsTableWorkflows.test.ts
@@ -110,7 +110,7 @@ describe('InsightsTableWorkflows', () => {
 			},
 			global: {
 				stubs: {
-					'router-link': {
+					RouterLink: {
 						template: '<a><slot /></a>',
 					},
 				},

--- a/packages/frontend/editor-ui/src/features/insights/components/tables/InsightsTableWorkflows.vue
+++ b/packages/frontend/editor-ui/src/features/insights/components/tables/InsightsTableWorkflows.vue
@@ -13,7 +13,7 @@ import { smartDecimal } from '@n8n/utils/number/smartDecimal';
 import { useTelemetry } from '@/composables/useTelemetry';
 import { VIEWS } from '@/constants';
 import { computed, defineAsyncComponent, ref, watch } from 'vue';
-import { type RouteLocationRaw, type LocationQueryRaw } from 'vue-router';
+import { type RouteLocationRaw, type LocationQueryRaw, RouterLink } from 'vue-router';
 
 const InsightsPaywall = defineAsyncComponent(
 	async () => await import('@/features/insights/components/InsightsPaywall.vue'),
@@ -169,7 +169,7 @@ watch(sortBy, (newValue) => {
 		>
 			<template #[`item.workflowName`]="{ item }">
 				<component
-					:is="item.workflowId ? 'router-link' : 'div'"
+					:is="item.workflowId ? RouterLink : 'div'"
 					v-bind="
 						item.workflowId
 							? {
@@ -188,13 +188,13 @@ watch(sortBy, (newValue) => {
 				</component>
 			</template>
 			<template #[`item.timeSaved`]="{ item, value }">
-				<router-link
+				<RouterLink
 					v-if="!item.timeSaved && item.workflowId"
 					:to="getWorkflowLink(item, { settings: 'true' })"
 					:class="$style.link"
 				>
 					{{ i18n.baseText('insights.dashboard.table.estimate') }}
-				</router-link>
+				</RouterLink>
 				<template v-else>
 					{{ value }}
 				</template>

--- a/packages/frontend/editor-ui/src/features/logs/components/MessageOptionAction.vue
+++ b/packages/frontend/editor-ui/src/features/logs/components/MessageOptionAction.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useAttrs } from 'vue';
-import { type IconName } from '@n8n/design-system/src/components/N8nIcon/icons';
+import { type IconName } from '@n8n/design-system/components/N8nIcon/icons';
 
 defineProps<{ label: string; icon: IconName; placement: 'left' | 'right' | 'top' | 'bottom' }>();
 
@@ -14,12 +14,12 @@ const onClick = () => {
 
 <template>
 	<div :class="$style.container">
-		<n8n-tooltip :placement="placement">
+		<N8nTooltip :placement="placement">
 			<template #content>
 				{{ label }}
 			</template>
-			<n8n-icon :class="$style.icon" :icon="icon" size="xsmall" @click="onClick" />
-		</n8n-tooltip>
+			<N8nIcon :class="$style.icon" :icon="icon" size="xsmall" @click="onClick" />
+		</N8nTooltip>
 	</div>
 </template>
 

--- a/packages/frontend/editor-ui/src/features/logs/components/MessageOptionTooltip.vue
+++ b/packages/frontend/editor-ui/src/features/logs/components/MessageOptionTooltip.vue
@@ -11,14 +11,14 @@ defineProps({
 
 <template>
 	<div :class="$style.container">
-		<n8n-tooltip :placement="placement">
+		<N8nTooltip :placement="placement">
 			<template #content>
 				<slot />
 			</template>
 			<span :class="$style.icon">
-				<n8n-icon icon="info" size="xsmall" />
+				<N8nIcon icon="info" size="xsmall" />
 			</span>
-		</n8n-tooltip>
+		</N8nTooltip>
 	</div>
 </template>
 

--- a/packages/frontend/editor-ui/src/features/mcpAccess/SettingsMCPView.vue
+++ b/packages/frontend/editor-ui/src/features/mcpAccess/SettingsMCPView.vue
@@ -146,14 +146,14 @@ onMounted(async () => {
 <template>
 	<div :class="$style.container">
 		<div :class="$style.headingContainer">
-			<n8n-heading size="2xlarge">{{ i18n.baseText('settings.mcp') }}</n8n-heading>
+			<N8nHeading size="2xlarge">{{ i18n.baseText('settings.mcp') }}</N8nHeading>
 		</div>
 		<div :class="$style.mainToggleContainer">
 			<div :class="$style.mainToggleInfo">
-				<n8n-text :bold="true">{{ i18n.baseText('settings.mcp.toggle.label') }}</n8n-text>
-				<n8n-text size="small" color="text-light">
+				<N8nText :bold="true">{{ i18n.baseText('settings.mcp.toggle.label') }}</N8nText>
+				<N8nText size="small" color="text-light">
 					{{ i18n.baseText('settings.mcp.toggle.description') }}
-				</n8n-text>
+				</N8nText>
 			</div>
 			<div :class="$style.mainTooggle" data-test-id="mcp-toggle-container">
 				<N8nTooltip
@@ -161,7 +161,7 @@ onMounted(async () => {
 					:disabled="isOwner"
 					placement="top"
 				>
-					<el-switch
+					<ElSwitch
 						:model-value="mcpStore.mcpAccessEnabled"
 						size="large"
 						data-test-id="mcp-access-toggle"
@@ -177,20 +177,20 @@ onMounted(async () => {
 			data-test-id="mcp-enabled-section"
 		>
 			<div>
-				<n8n-heading size="medium" :bold="true">
+				<N8nHeading size="medium" :bold="true">
 					{{ i18n.baseText('settings.mcp.connection.info.heading') }}
-				</n8n-heading>
+				</N8nHeading>
 				<MCPConnectionInstructions :base-url="rootStore.urlBaseEditor" />
 			</div>
 			<div :class="$style['workflow-list-container']" data-test-id="mcp-workflow-list">
 				<div v-if="workflowsLoading">
-					<n8n-loading
+					<N8nLoading
 						v-if="workflowsLoading"
 						:loading="workflowsLoading"
 						variant="h1"
 						class="mb-l"
 					/>
-					<n8n-loading
+					<N8nLoading
 						v-if="workflowsLoading"
 						:loading="workflowsLoading"
 						variant="p"
@@ -200,11 +200,11 @@ onMounted(async () => {
 				</div>
 				<div v-else class="mt-s mb-xl">
 					<div :class="[$style.header, 'mb-s']">
-						<n8n-heading size="medium" :bold="true">
+						<N8nHeading size="medium" :bold="true">
 							{{ i18n.baseText('settings.mcp.available.workflows.heading') }}
-						</n8n-heading>
+						</N8nHeading>
 					</div>
-					<n8n-action-box
+					<N8nActionBox
 						v-if="availableWorkflows.length === 0"
 						data-test-id="empty-workflow-list-box"
 						:heading="i18n.baseText('settings.mcp.empty.title')"
@@ -219,7 +219,7 @@ onMounted(async () => {
 						:items-length="availableWorkflows.length"
 					>
 						<template #[`item.name`]="{ item }">
-							<n8n-link
+							<N8nLink
 								:new-window="true"
 								:to="
 									router.resolve({
@@ -230,17 +230,17 @@ onMounted(async () => {
 								:theme="'text'"
 								:class="$style['table-link']"
 							>
-								<n8n-text data-test-id="mcp-workflow-name">{{ item.name }}</n8n-text>
-								<n8n-icon
+								<N8nText data-test-id="mcp-workflow-name">{{ item.name }}</N8nText>
+								<N8nIcon
 									icon="external-link"
 									:class="$style['link-icon']"
 									color="text-light"
-								></n8n-icon>
-							</n8n-link>
+								></N8nIcon>
+							</N8nLink>
 						</template>
 						<template #[`item.parentFolder`]="{ item }">
 							<span v-if="item.parentFolder" :class="$style['folder-cell']">
-								<n8n-link
+								<N8nLink
 									v-if="item.homeProject"
 									data-test-id="mcp-workflow-folder-link"
 									:to="`/projects/${item.homeProject.id}/folders/${item.parentFolder.id}/workflows`"
@@ -248,27 +248,27 @@ onMounted(async () => {
 									:class="$style['table-link']"
 									:new-window="true"
 								>
-									<n8n-text data-test-id="mcp-workflow-folder-name">
+									<N8nText data-test-id="mcp-workflow-folder-name">
 										{{ item.parentFolder.name }}
-									</n8n-text>
-									<n8n-icon
+									</N8nText>
+									<N8nIcon
 										icon="external-link"
 										:class="$style['link-icon']"
 										color="text-light"
-									></n8n-icon>
-								</n8n-link>
+									></N8nIcon>
+								</N8nLink>
 								<span v-else>
-									<n8n-icon v-if="item.parentFolder" icon="folder" :size="16" color="text-light" />
-									<n8n-text data-test-id="mcp-workflow-folder-name">
+									<N8nIcon v-if="item.parentFolder" icon="folder" :size="16" color="text-light" />
+									<N8nText data-test-id="mcp-workflow-folder-name">
 										{{ item.parentFolder.name }}
-									</n8n-text>
+									</N8nText>
 								</span>
 							</span>
-							<n8n-text v-else data-test-id="mcp-workflow-no-folder">-</n8n-text>
+							<N8nText v-else data-test-id="mcp-workflow-no-folder">-</N8nText>
 						</template>
 						<template #[`item.homeProject`]="{ item }">
 							<span v-if="item.homeProject" :class="$style['folder-cell']">
-								<n8n-link
+								<N8nLink
 									data-test-id="mcp-workflow-project-link"
 									:to="
 										router.resolve({
@@ -285,20 +285,20 @@ onMounted(async () => {
 										:icon="getProjectIcon(item)"
 										:border-less="true"
 									/>
-									<n8n-text data-test-id="mcp-workflow-project-name">
+									<N8nText data-test-id="mcp-workflow-project-name">
 										{{ getProjectName(item) }}
-									</n8n-text>
-									<n8n-icon
+									</N8nText>
+									<N8nIcon
 										icon="external-link"
 										:class="$style['link-icon']"
 										color="text-light"
-									></n8n-icon>
-								</n8n-link>
+									></N8nIcon>
+								</N8nLink>
 							</span>
-							<n8n-text v-else data-test-id="mcp-workflow-no-project">-</n8n-text>
+							<N8nText v-else data-test-id="mcp-workflow-no-project">-</N8nText>
 						</template>
 						<template #[`item.active`]="{ item }">
-							<n8n-icon
+							<N8nIcon
 								:icon="item.active ? 'check' : 'x'"
 								:size="16"
 								:color="item.active ? 'success' : 'danger'"

--- a/packages/frontend/editor-ui/src/features/mcpAccess/components/MCPConnectionInstructions.vue
+++ b/packages/frontend/editor-ui/src/features/mcpAccess/components/MCPConnectionInstructions.vue
@@ -64,7 +64,7 @@ const fullServerUrl = computed(() => {
 					</span>
 					<span :class="$style.url">
 						<code>{{ fullServerUrl }}</code>
-						<n8n-button
+						<N8nButton
 							v-if="isSupported"
 							type="tertiary"
 							:icon="copied ? 'check' : 'copy'"
@@ -79,7 +79,7 @@ const fullServerUrl = computed(() => {
 				<div :class="$style.item">
 					<span :class="$style.label">
 						{{ i18n.baseText('settings.mcp.instructions.apiKey.part1') }}
-						<n8n-link to="/settings/api">{{ i18n.baseText('generic.apiKey') }}</n8n-link
+						<N8nLink to="/settings/api">{{ i18n.baseText('generic.apiKey') }}</N8nLink
 						>.
 						{{ i18n.baseText('settings.mcp.instructions.apiKey.part2') }}
 					</span>
@@ -87,10 +87,10 @@ const fullServerUrl = computed(() => {
 			</li>
 		</ol>
 		<div :class="$style.connectionString">
-			<n8n-info-accordion :title="i18n.baseText('settings.mcp.instructions.json')">
+			<N8nInfoAccordion :title="i18n.baseText('settings.mcp.instructions.json')">
 				<template #customContent>
-					<n8n-markdown :content="connectionCode"></n8n-markdown>
-					<n8n-button
+					<N8nMarkdown :content="connectionCode"></N8nMarkdown>
+					<N8nButton
 						v-if="isSupported"
 						type="tertiary"
 						:icon="copied ? 'check' : 'copy'"
@@ -99,14 +99,14 @@ const fullServerUrl = computed(() => {
 						@click="copy(connectionString)"
 					/>
 				</template>
-			</n8n-info-accordion>
+			</N8nInfoAccordion>
 		</div>
-		<n8n-text size="small" class="mt-m">
+		<N8nText size="small" class="mt-m">
 			{{ i18n.baseText('settings.mcp.instructions.docs.part1') }}
 			<a :href="DOCS_URL" target="_blank">
 				{{ i18n.baseText('settings.mcp.instructions.docs.part2') }}
 			</a>
-		</n8n-text>
+		</N8nText>
 	</div>
 </template>
 

--- a/packages/frontend/editor-ui/src/views/CanvasAddButton.vue
+++ b/packages/frontend/editor-ui/src/views/CanvasAddButton.vue
@@ -27,7 +27,7 @@ const containerCssVars = computed(() => ({
 		:style="containerCssVars"
 		data-test-id="canvas-add-button"
 	>
-		<n8n-tooltip
+		<N8nTooltip
 			placement="top"
 			:visible="showTooltip"
 			:disabled="nodeCreatorStore.showScrim"
@@ -35,12 +35,12 @@ const containerCssVars = computed(() => ({
 			:show-after="700"
 		>
 			<button :class="$style.button" data-test-id="canvas-plus-button" @click="$emit('click')">
-				<n8n-icon icon="plus" size="large" />
+				<N8nIcon icon="plus" size="large" />
 			</button>
 			<template #content>
 				{{ i18n.baseText('nodeView.canvasAddButton.addATriggerNodeBeforeExecuting') }}
 			</template>
-		</n8n-tooltip>
+		</N8nTooltip>
 		<p :class="$style.label" v-text="i18n.baseText('nodeView.canvasAddButton.addFirstStep')" />
 	</div>
 </template>

--- a/packages/frontend/editor-ui/src/views/CredentialsView.vue
+++ b/packages/frontend/editor-ui/src/views/CredentialsView.vue
@@ -326,7 +326,7 @@ onMounted(() => {
 				:personal-project="personalProject"
 				resource-type="credentials"
 			/>
-			<n8n-action-box
+			<N8nActionBox
 				v-else
 				data-test-id="empty-resources-list"
 				emoji="👋"
@@ -354,7 +354,7 @@ onMounted(() => {
 							: i18n.baseText('credentials.empty.button.disabled.tooltip')
 					}}
 				</template>
-			</n8n-action-box>
+			</N8nActionBox>
 		</template>
 	</ResourcesListLayout>
 </template>

--- a/packages/frontend/editor-ui/src/views/ErrorView.vue
+++ b/packages/frontend/editor-ui/src/views/ErrorView.vue
@@ -21,20 +21,20 @@ function onButtonClick() {
 
 <template>
 	<div :class="$style.container">
-		<n8n-icon icon="triangle-alert" :class="$style.icon" />
+		<N8nIcon icon="triangle-alert" :class="$style.icon" />
 		<div :class="$style.message">
 			<div>
-				<n8n-heading size="2xlarge">
+				<N8nHeading size="2xlarge">
 					{{ i18n.baseText(messageKey) }}
-				</n8n-heading>
+				</N8nHeading>
 			</div>
 			<div>
-				<n8n-text v-if="errorCode" size="large">
+				<N8nText v-if="errorCode" size="large">
 					{{ errorCode }} {{ i18n.baseText('error') }}
-				</n8n-text>
+				</N8nText>
 			</div>
 		</div>
-		<n8n-button :label="i18n.baseText(redirectTextKey)" @click="onButtonClick" />
+		<N8nButton :label="i18n.baseText(redirectTextKey)" @click="onButtonClick" />
 	</div>
 </template>
 

--- a/packages/frontend/editor-ui/src/views/Evaluations.ee/EvaluationsRootView.vue
+++ b/packages/frontend/editor-ui/src/views/Evaluations.ee/EvaluationsRootView.vue
@@ -168,7 +168,7 @@ watch(
 				</div>
 			</div>
 		</template>
-		<router-view v-else-if="isReady" />
+		<RouterView v-else-if="isReady" />
 	</div>
 </template>
 

--- a/packages/frontend/editor-ui/src/views/Evaluations.ee/TestRunDetailView.vue
+++ b/packages/frontend/editor-ui/src/views/Evaluations.ee/TestRunDetailView.vue
@@ -206,16 +206,16 @@ onMounted(async () => {
 		<div :class="$style.header">
 			<button :class="$style.backButton" @click="router.back()">
 				<N8nIcon icon="arrow-left" />
-				<n8n-heading size="large" :bold="true">{{
+				<N8nHeading size="large" :bold="true">{{
 					locale.baseText('evaluation.listRuns.runListHeader', {
 						interpolate: {
 							name: workflowName,
 						},
 					})
-				}}</n8n-heading>
+				}}</N8nHeading>
 			</button>
 			<span :class="$style.headerSeparator">/</span>
-			<n8n-heading size="large" :bold="true">
+			<N8nHeading size="large" :bold="true">
 				{{
 					locale.baseText('evaluation.listRuns.testCasesListHeader', {
 						interpolate: {
@@ -223,9 +223,9 @@ onMounted(async () => {
 						},
 					})
 				}}
-			</n8n-heading>
+			</N8nHeading>
 		</div>
-		<n8n-callout v-if="run?.status === 'error'" theme="danger" icon="triangle-alert" class="mb-s">
+		<N8nCallout v-if="run?.status === 'error'" theme="danger" icon="triangle-alert" class="mb-s">
 			<N8nText size="small" :class="$style.capitalized">
 				{{
 					locale.baseText(
@@ -234,9 +234,9 @@ onMounted(async () => {
 					) ?? locale.baseText(`${getErrorBaseKey('UNKNOWN_ERROR')}` as BaseTextKey)
 				}}
 			</N8nText>
-		</n8n-callout>
+		</N8nCallout>
 
-		<el-scrollbar always :class="$style.scrollableSummary" class="mb-m">
+		<ElScrollbar always :class="$style.scrollableSummary" class="mb-m">
 			<div style="display: flex">
 				<div :class="$style.summaryCard">
 					<N8nText size="small" :class="$style.summaryCardTitle">
@@ -294,11 +294,11 @@ onMounted(async () => {
 					}}</N8nText>
 				</div>
 			</div>
-		</el-scrollbar>
+		</ElScrollbar>
 
 		<div :class="['mb-s', $style.runsHeader]">
 			<div>
-				<n8n-heading size="large" :bold="true"
+				<N8nHeading size="large" :bold="true"
 					>{{
 						locale.baseText('evaluation.listRuns.allTestCases', {
 							interpolate: {
@@ -306,10 +306,10 @@ onMounted(async () => {
 							},
 						})
 					}}
-				</n8n-heading>
+				</N8nHeading>
 			</div>
 			<div :class="$style.runsHeaderButtons">
-				<n8n-icon-button
+				<N8nIconButton
 					:icon="isAllExpanded ? 'chevrons-down-up' : 'chevrons-up-down'"
 					type="secondary"
 					size="medium"
@@ -325,7 +325,7 @@ onMounted(async () => {
 			</div>
 		</div>
 
-		<n8n-callout
+		<N8nCallout
 			v-if="
 				!isLoading &&
 				!inputColumns.length &&
@@ -339,10 +339,10 @@ onMounted(async () => {
 			<N8nText size="small" :class="$style.capitalized">
 				{{ locale.baseText('evaluation.runDetail.notice.useSetInputs') }}
 			</N8nText>
-		</n8n-callout>
+		</N8nCallout>
 
 		<div v-if="isLoading" :class="$style.loading">
-			<n8n-loading :loading="true" :rows="5" />
+			<N8nLoading :loading="true" :rows="5" />
 		</div>
 
 		<TestTableBase

--- a/packages/frontend/editor-ui/src/views/ForgotMyPasswordView.test.ts
+++ b/packages/frontend/editor-ui/src/views/ForgotMyPasswordView.test.ts
@@ -39,7 +39,7 @@ vi.mock('@/composables/useToast', () => {
 const renderComponent = createComponentRenderer(ForgotMyPasswordView, {
 	global: {
 		stubs: {
-			'router-link': {
+			RouterLink: {
 				template: '<a href="#"><slot /></a>',
 			},
 		},

--- a/packages/frontend/editor-ui/src/views/LoadingView.vue
+++ b/packages/frontend/editor-ui/src/views/LoadingView.vue
@@ -1,7 +1,7 @@
 <template>
 	<div :class="$style.wrapper" data-test-id="node-view-loader">
 		<div :class="$style.spinner">
-			<n8n-spinner />
+			<N8nSpinner />
 		</div>
 	</div>
 </template>

--- a/packages/frontend/editor-ui/src/views/MfaView.vue
+++ b/packages/frontend/editor-ui/src/views/MfaView.vue
@@ -197,26 +197,26 @@ onMounted(() => {
 <template>
 	<div :class="$style.container">
 		<Logo location="authView" :release-channel="releaseChannel" />
-		<n8n-card>
+		<N8nCard>
 			<div :class="$style.headerContainer">
-				<n8n-heading size="xlarge" color="text-dark">{{
+				<N8nHeading size="xlarge" color="text-dark">{{
 					showRecoveryCodeForm
 						? i18.baseText('mfa.recovery.modal.title')
 						: i18.baseText('mfa.code.modal.title')
-				}}</n8n-heading>
+				}}</N8nHeading>
 			</div>
 			<div :class="[$style.formContainer, reportError ? $style.formError : '']">
-				<n8n-form-inputs
+				<N8nFormInputs
 					v-if="formInputs"
+					ref="mfaFormRef"
 					data-test-id="mfa-login-form"
 					:inputs="formInputs"
 					:event-bus="formBus"
-					ref="mfaFormRef"
 					@input="onInput"
 					@submit="onSubmit"
 				/>
 				<div :class="$style.infoBox">
-					<n8n-text
+					<N8nText
 						v-if="!showRecoveryCodeForm && !reportError"
 						size="small"
 						color="text-base"
@@ -224,9 +224,9 @@ onMounted(() => {
 						>{{ i18.baseText('mfa.code.input.info') }}
 						<a data-test-id="mfa-enter-recovery-code-button" @click="onRecoveryCodeClick">{{
 							i18.baseText('mfa.code.input.info.action')
-						}}</a></n8n-text
+						}}</a></N8nText
 					>
-					<n8n-text v-if="reportError" color="danger" size="small"
+					<N8nText v-if="reportError" color="danger" size="small"
 						>{{ formError }}
 						<a
 							v-if="!showRecoveryCodeForm"
@@ -235,11 +235,11 @@ onMounted(() => {
 						>
 							{{ i18.baseText('mfa.recovery.input.info.action') }}</a
 						>
-					</n8n-text>
+					</N8nText>
 				</div>
 			</div>
 			<div>
-				<n8n-button
+				<N8nButton
 					float="right"
 					:loading="verifyingMfaCode"
 					:label="
@@ -251,7 +251,7 @@ onMounted(() => {
 					:disabled="!hasAnyChanges"
 					@click="onSaveClick"
 				/>
-				<n8n-button
+				<N8nButton
 					float="left"
 					:label="i18.baseText('mfa.button.back')"
 					size="large"
@@ -259,7 +259,7 @@ onMounted(() => {
 					@click="onBackClick"
 				/>
 			</div>
-		</n8n-card>
+		</N8nCard>
 	</div>
 </template>
 

--- a/packages/frontend/editor-ui/src/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/views/NodeView.vue
@@ -2076,8 +2076,8 @@ onBeforeUnmount(() => {
 	<div :class="$style.wrapper">
 		<WorkflowCanvas
 			v-if="editableWorkflow && editableWorkflowObject && !isLoading"
-			ref="canvas"
 			:id="editableWorkflow.id"
+			ref="canvas"
 			:workflow="editableWorkflow"
 			:workflow-object="editableWorkflowObject"
 			:fallback-nodes="fallbackNodes"

--- a/packages/frontend/editor-ui/src/views/ProjectSettings.vue
+++ b/packages/frontend/editor-ui/src/views/ProjectSettings.vue
@@ -8,7 +8,7 @@ import { useDebounceFn } from '@vueuse/core';
 import { useUsersStore } from '@/stores/users.store';
 import { useI18n } from '@n8n/i18n';
 import { type ResourceCounts, useProjectsStore } from '@/stores/projects.store';
-import type { Project, ProjectRelation } from '@/types/projects.types';
+import type { Project, ProjectRelation, ProjectMemberData } from '@/types/projects.types';
 import { useToast } from '@/composables/useToast';
 import { VIEWS } from '@/constants';
 import ProjectDeleteDialog from '@/components/Projects/ProjectDeleteDialog.vue';
@@ -22,7 +22,6 @@ import ProjectHeader from '@/components/Projects/ProjectHeader.vue';
 import { isIconOrEmoji, type IconOrEmoji } from '@n8n/design-system/components/N8nIconPicker/types';
 import type { TableOptions } from '@n8n/design-system/components/N8nDataTableServer';
 import type { UserAction } from '@n8n/design-system';
-import type { ProjectMemberData } from '@/types/projects.types';
 import { isProjectRole } from '@/utils/typeGuards';
 
 type FormDataDiff = {

--- a/packages/frontend/editor-ui/src/views/SettingsApiView.vue
+++ b/packages/frontend/editor-ui/src/views/SettingsApiView.vue
@@ -109,15 +109,15 @@ function onEdit(id: string) {
 <template>
 	<div :class="$style.container">
 		<div :class="$style.header">
-			<n8n-heading size="2xlarge">
+			<N8nHeading size="2xlarge">
 				{{ i18n.baseText('settings.api') }}
 				<span :style="{ fontSize: 'var(--font-size-s)', color: 'var(--color-text-light)' }">
 					({{ i18n.baseText('generic.beta') }})
 				</span>
-			</n8n-heading>
+			</N8nHeading>
 		</div>
 		<p v-if="isPublicApiEnabled && apiKeysSortByCreationDate.length" :class="$style.topHint">
-			<n8n-text>
+			<N8nText>
 				<I18nT keypath="settings.api.view.info" tag="span" scope="global">
 					<template #apiAction>
 						<a
@@ -136,21 +136,21 @@ function onEdit(id: string) {
 						/>
 					</template>
 				</I18nT>
-			</n8n-text>
+			</N8nText>
 		</p>
 
 		<div :class="$style.apiKeysContainer">
 			<template v-if="apiKeysSortByCreationDate.length">
-				<el-row
+				<ElRow
 					v-for="(apiKey, index) in apiKeysSortByCreationDate"
 					:key="apiKey.id"
 					:gutter="10"
 					:class="[{ [$style.destinationItem]: index !== apiKeysSortByCreationDate.length - 1 }]"
 				>
-					<el-col>
+					<ElCol>
 						<ApiKeyCard :api-key="apiKey" @delete="onDelete" @edit="onEdit" />
-					</el-col>
-				</el-row>
+					</ElCol>
+				</ElRow>
 			</template>
 		</div>
 
@@ -163,7 +163,7 @@ function onEdit(id: string) {
 				}}
 			</N8nText>
 			{{ ' ' }}
-			<n8n-link
+			<N8nLink
 				v-if="isSwaggerUIEnabled"
 				data-test-id="api-playground-link"
 				:to="apiDocsURL"
@@ -171,8 +171,8 @@ function onEdit(id: string) {
 				size="small"
 			>
 				{{ i18n.baseText('settings.api.view.apiPlayground') }}
-			</n8n-link>
-			<n8n-link
+			</N8nLink>
+			<N8nLink
 				v-else
 				data-test-id="api-endpoint-docs-link"
 				:to="apiDocsURL"
@@ -180,19 +180,19 @@ function onEdit(id: string) {
 				size="small"
 			>
 				{{ i18n.baseText(`settings.api.view.external-docs`) }}
-			</n8n-link>
+			</N8nLink>
 		</div>
 		<div class="mt-m text-right">
-			<n8n-button
+			<N8nButton
 				v-if="isPublicApiEnabled && apiKeysSortByCreationDate.length"
 				size="large"
 				@click="onCreateApiKey"
 			>
 				{{ i18n.baseText('settings.api.create.button') }}
-			</n8n-button>
+			</N8nButton>
 		</div>
 
-		<n8n-action-box
+		<N8nActionBox
 			v-if="!isPublicApiEnabled && cloudPlanStore.userIsTrialing"
 			data-test-id="public-api-upgrade-cta"
 			:heading="i18n.baseText('settings.api.trial.upgradePlan.title')"
@@ -201,7 +201,7 @@ function onEdit(id: string) {
 			@click:button="onUpgrade"
 		/>
 
-		<n8n-action-box
+		<N8nActionBox
 			v-if="isPublicApiEnabled && !apiKeysSortByCreationDate.length"
 			:button-text="
 				i18n.baseText(loading ? 'settings.api.create.button.loading' : 'settings.api.create.button')

--- a/packages/frontend/editor-ui/src/views/SettingsCommunityNodesView.vue
+++ b/packages/frontend/editor-ui/src/views/SettingsCommunityNodesView.vue
@@ -152,8 +152,8 @@ onBeforeUnmount(() => {
 <template>
 	<div :class="$style.container">
 		<div :class="$style.headingContainer">
-			<n8n-heading size="2xlarge">{{ i18n.baseText('settings.communityNodes') }}</n8n-heading>
-			<n8n-button
+			<N8nHeading size="2xlarge">{{ i18n.baseText('settings.communityNodes') }}</N8nHeading>
+			<N8nButton
 				v-if="
 					settingsStore.isUnverifiedPackagesEnabled &&
 					communityNodesStore.getInstalledPackages.length > 0 &&
@@ -175,7 +175,7 @@ onBeforeUnmount(() => {
 			v-else-if="communityNodesStore.getInstalledPackages.length === 0"
 			:class="$style.actionBoxContainer"
 		>
-			<n8n-action-box
+			<N8nActionBox
 				:heading="getEmptyStateTitle"
 				:description="getEmptyStateDescription"
 				:button-text="getEmptyStateButtonText"

--- a/packages/frontend/editor-ui/src/views/SettingsExternalSecrets.vue
+++ b/packages/frontend/editor-ui/src/views/SettingsExternalSecrets.vue
@@ -39,24 +39,24 @@ function goToUpgrade() {
 
 <template>
 	<div class="pb-3xl">
-		<n8n-heading size="2xlarge">{{ i18n.baseText('settings.externalSecrets.title') }}</n8n-heading>
+		<N8nHeading size="2xlarge">{{ i18n.baseText('settings.externalSecrets.title') }}</N8nHeading>
 		<div
 			v-if="externalSecretsStore.isEnterpriseExternalSecretsEnabled"
 			data-test-id="external-secrets-content-licensed"
 		>
-			<n8n-callout theme="secondary" class="mt-2xl mb-l">
+			<N8nCallout theme="secondary" class="mt-2xl mb-l">
 				{{ i18n.baseText('settings.externalSecrets.info') }}
 				<a :href="i18n.baseText('settings.externalSecrets.docs')" target="_blank">
 					{{ i18n.baseText('settings.externalSecrets.info.link') }}
 				</a>
-			</n8n-callout>
+			</N8nCallout>
 			<ExternalSecretsProviderCard
 				v-for="provider in sortedProviders"
 				:key="provider.name"
 				:provider="provider"
 			/>
 		</div>
-		<n8n-action-box
+		<N8nActionBox
 			v-else
 			class="mt-2xl mb-l"
 			data-test-id="external-secrets-content-unlicensed"
@@ -75,6 +75,6 @@ function goToUpgrade() {
 					</template>
 				</I18nT>
 			</template>
-		</n8n-action-box>
+		</N8nActionBox>
 	</div>
 </template>

--- a/packages/frontend/editor-ui/src/views/SettingsLdapView.vue
+++ b/packages/frontend/editor-ui/src/views/SettingsLdapView.vue
@@ -593,15 +593,15 @@ onMounted(async () => {
 <template>
 	<div v-if="!isLDAPFeatureEnabled">
 		<div :class="[$style.header, 'mb-2xl']">
-			<n8n-heading size="2xlarge">
+			<N8nHeading size="2xlarge">
 				{{ i18n.baseText('settings.ldap') }}
-			</n8n-heading>
+			</N8nHeading>
 		</div>
 
-		<n8n-info-tip type="note" theme="info" tooltip-placement="right" class="mb-l">
+		<N8nInfoTip type="note" theme="info" tooltip-placement="right" class="mb-l">
 			{{ i18n.baseText('settings.ldap.note') }}
-		</n8n-info-tip>
-		<n8n-action-box
+		</N8nInfoTip>
+		<N8nActionBox
 			:description="i18n.baseText('settings.ldap.disabled.description')"
 			:button-text="i18n.baseText('settings.ldap.disabled.buttonText')"
 			@click:button="goToUpgrade"
@@ -609,22 +609,22 @@ onMounted(async () => {
 			<template #heading>
 				<span>{{ i18n.baseText('settings.ldap.disabled.title') }}</span>
 			</template>
-		</n8n-action-box>
+		</N8nActionBox>
 	</div>
 	<div v-else>
 		<div :class="$style.container">
 			<div :class="$style.header">
-				<n8n-heading size="2xlarge">
+				<N8nHeading size="2xlarge">
 					{{ i18n.baseText('settings.ldap') }}
-				</n8n-heading>
+				</N8nHeading>
 			</div>
 			<div :class="$style.docsInfoTip">
-				<n8n-info-tip theme="info" type="note">
+				<N8nInfoTip theme="info" type="note">
 					<span v-n8n-html="i18n.baseText('settings.ldap.infoTip')"></span>
-				</n8n-info-tip>
+				</N8nInfoTip>
 			</div>
 			<div :class="$style.settingsForm">
-				<n8n-form-inputs
+				<N8nFormInputs
 					v-if="formInputs"
 					ref="ldapConfigFormRef"
 					:inputs="formInputs"
@@ -637,7 +637,7 @@ onMounted(async () => {
 				/>
 			</div>
 			<div>
-				<n8n-button
+				<N8nButton
 					v-if="loginEnabled"
 					:label="
 						loadingTestConnection
@@ -650,7 +650,7 @@ onMounted(async () => {
 					:loading="loadingTestConnection"
 					@click="onTestConnectionClick"
 				/>
-				<n8n-button
+				<N8nButton
 					:label="i18n.baseText('settings.ldap.save')"
 					size="large"
 					:disabled="!hasAnyChanges || !readyToSubmit"
@@ -659,9 +659,9 @@ onMounted(async () => {
 			</div>
 		</div>
 		<div v-if="loginEnabled">
-			<n8n-heading tag="h1" class="mb-xl mt-3xl" size="medium">{{
+			<N8nHeading tag="h1" class="mb-xl mt-3xl" size="medium">{{
 				i18n.baseText('settings.ldap.section.synchronization.title')
-			}}</n8n-heading>
+			}}</N8nHeading>
 			<div :class="$style.syncTable">
 				<ElTable
 					:key="tableKey"
@@ -703,7 +703,7 @@ onMounted(async () => {
 				</ElTable>
 			</div>
 			<div class="pb-3xl">
-				<n8n-button
+				<N8nButton
 					:label="i18n.baseText('settings.ldap.dryRun')"
 					type="secondary"
 					size="large"
@@ -712,7 +712,7 @@ onMounted(async () => {
 					:loading="loadingDryRun"
 					@click="onDryRunClick"
 				/>
-				<n8n-button
+				<N8nButton
 					:label="i18n.baseText('settings.ldap.synchronizeNow')"
 					size="large"
 					:disabled="hasAnyChanges || !readyToSubmit"

--- a/packages/frontend/editor-ui/src/views/SettingsLogStreamingView.vue
+++ b/packages/frontend/editor-ui/src/views/SettingsLogStreamingView.vue
@@ -170,29 +170,29 @@ async function onEdit(destinationId?: string) {
 	<div>
 		<div :class="$style.header">
 			<div class="mb-2xl">
-				<n8n-heading size="2xlarge">
+				<N8nHeading size="2xlarge">
 					{{ i18n.baseText(`settings.log-streaming.heading`) }}
-				</n8n-heading>
+				</N8nHeading>
 				<template v-if="environment !== 'production'">
 					<span class="ml-m">Disable License ({{ environment }})&nbsp;</span>
-					<el-switch v-model="disableLicense" size="large" data-test-id="disable-license-toggle" />
+					<ElSwitch v-model="disableLicense" size="large" data-test-id="disable-license-toggle" />
 				</template>
 			</div>
 		</div>
 		<template v-if="isLicensed">
 			<div class="mb-l">
-				<n8n-info-tip theme="info" type="note">
+				<N8nInfoTip theme="info" type="note">
 					<span v-n8n-html="i18n.baseText('settings.log-streaming.infoText')"></span>
-				</n8n-info-tip>
+				</N8nInfoTip>
 			</div>
 			<template v-if="storeHasItems()">
-				<el-row
+				<ElRow
 					v-for="item in sortedItemKeysByLabel"
 					:key="item.key"
 					:gutter="10"
 					:class="$style.destinationItem"
 				>
-					<el-col v-if="logStreamingStore.items[item.key]?.destination">
+					<ElCol v-if="logStreamingStore.items[item.key]?.destination">
 						<EventDestinationCard
 							:destination="logStreamingStore.items[item.key]?.destination"
 							:event-bus="eventBus"
@@ -200,33 +200,33 @@ async function onEdit(destinationId?: string) {
 							@remove="onRemove(logStreamingStore.items[item.key]?.destination?.id)"
 							@edit="onEdit(logStreamingStore.items[item.key]?.destination?.id)"
 						/>
-					</el-col>
-				</el-row>
+					</ElCol>
+				</ElRow>
 				<div class="mt-m text-right">
-					<n8n-button v-if="canManageLogStreaming" size="large" @click="addDestination">
+					<N8nButton v-if="canManageLogStreaming" size="large" @click="addDestination">
 						{{ i18n.baseText(`settings.log-streaming.add`) }}
-					</n8n-button>
+					</N8nButton>
 				</div>
 			</template>
 			<div v-else data-test-id="action-box-licensed">
-				<n8n-action-box
+				<N8nActionBox
 					:button-text="i18n.baseText(`settings.log-streaming.add`)"
 					@click:button="addDestination"
 				>
 					<template #heading>
 						<span v-n8n-html="i18n.baseText(`settings.log-streaming.addFirstTitle`)" />
 					</template>
-				</n8n-action-box>
+				</N8nActionBox>
 			</div>
 		</template>
 		<template v-else>
 			<div v-if="i18n.baseText('settings.log-streaming.infoText')" class="mb-l">
-				<n8n-info-tip theme="info" type="note">
+				<N8nInfoTip theme="info" type="note">
 					<span v-n8n-html="i18n.baseText('settings.log-streaming.infoText')"></span>
-				</n8n-info-tip>
+				</N8nInfoTip>
 			</div>
 			<div data-test-id="action-box-unlicensed">
-				<n8n-action-box
+				<N8nActionBox
 					:description="i18n.baseText('settings.log-streaming.actionBox.description')"
 					:button-text="i18n.baseText('settings.log-streaming.actionBox.button')"
 					@click:button="goToUpgrade"
@@ -234,7 +234,7 @@ async function onEdit(destinationId?: string) {
 					<template #heading>
 						<span v-n8n-html="i18n.baseText('settings.log-streaming.actionBox.title')" />
 					</template>
-				</n8n-action-box>
+				</N8nActionBox>
 			</div>
 		</template>
 	</div>

--- a/packages/frontend/editor-ui/src/views/SettingsPersonalView.vue
+++ b/packages/frontend/editor-ui/src/views/SettingsPersonalView.vue
@@ -325,20 +325,20 @@ onBeforeUnmount(() => {
 <template>
 	<div :class="$style.container" data-test-id="personal-settings-container">
 		<div :class="$style.header">
-			<n8n-heading size="2xlarge">{{
+			<N8nHeading size="2xlarge">{{
 				i18n.baseText('settings.personal.personalSettings')
-			}}</n8n-heading>
+			}}</N8nHeading>
 			<div v-if="currentUser" :class="$style.user">
 				<span :class="$style.username" data-test-id="current-user-name">
-					<n8n-text color="text-base" bold>{{ currentUser.fullName }}</n8n-text>
+					<N8nText color="text-base" bold>{{ currentUser.fullName }}</N8nText>
 					<N8nTooltip placement="bottom">
 						<template #content>{{ currentUserRole.description }}</template>
-						<n8n-text :class="$style.tooltip" color="text-light" data-test-id="current-user-role">{{
+						<N8nText :class="$style.tooltip" color="text-light" data-test-id="current-user-role">{{
 							currentUserRole.name
-						}}</n8n-text>
+						}}</N8nText>
 					</N8nTooltip>
 				</span>
-				<n8n-avatar
+				<N8nAvatar
 					:first-name="currentUser.firstName"
 					:last-name="currentUser.lastName"
 					size="large"
@@ -347,12 +347,12 @@ onBeforeUnmount(() => {
 		</div>
 		<div>
 			<div class="mb-s">
-				<n8n-heading size="large">{{
+				<N8nHeading size="large">{{
 					i18n.baseText('settings.personal.basicInformation')
-				}}</n8n-heading>
+				}}</N8nHeading>
 			</div>
 			<div data-test-id="personal-data-form">
-				<n8n-form-inputs
+				<N8nFormInputs
 					v-if="formInputs"
 					:inputs="formInputs"
 					:event-bus="formBus"
@@ -364,35 +364,35 @@ onBeforeUnmount(() => {
 		</div>
 		<div v-if="isPersonalSecurityEnabled">
 			<div class="mb-s">
-				<n8n-heading size="large">{{ i18n.baseText('settings.personal.security') }}</n8n-heading>
+				<N8nHeading size="large">{{ i18n.baseText('settings.personal.security') }}</N8nHeading>
 			</div>
 			<div class="mb-s">
-				<n8n-input-label :label="i18n.baseText('auth.password')">
-					<n8n-link data-test-id="change-password-link" @click="openPasswordModal">{{
+				<N8nInputLabel :label="i18n.baseText('auth.password')">
+					<N8nLink data-test-id="change-password-link" @click="openPasswordModal">{{
 						i18n.baseText('auth.changePassword')
-					}}</n8n-link>
-				</n8n-input-label>
+					}}</N8nLink>
+				</N8nInputLabel>
 			</div>
 			<div v-if="isMfaFeatureEnabled" data-test-id="mfa-section">
 				<div class="mb-xs">
-					<n8n-input-label :label="i18n.baseText('settings.personal.mfa.section.title')" />
-					<n8n-text :bold="false" :class="$style.infoText">
+					<N8nInputLabel :label="i18n.baseText('settings.personal.mfa.section.title')" />
+					<N8nText :bold="false" :class="$style.infoText">
 						{{
 							mfaDisabled
 								? i18n.baseText('settings.personal.mfa.button.disabled.infobox')
 								: i18n.baseText('settings.personal.mfa.button.enabled.infobox')
 						}}
-						<n8n-link :to="MFA_DOCS_URL" size="small" :bold="true">
+						<N8nLink :to="MFA_DOCS_URL" size="small" :bold="true">
 							{{ i18n.baseText('generic.learnMore') }}
-						</n8n-link>
-					</n8n-text>
+						</N8nLink>
+					</N8nText>
 				</div>
-				<n8n-notice
+				<N8nNotice
 					v-if="mfaDisabled && mfaEnforced"
 					:content="i18n.baseText('settings.personal.mfa.enforced')"
 				/>
 
-				<n8n-button
+				<N8nButton
 					v-if="mfaDisabled"
 					:class="$style.button"
 					type="tertiary"
@@ -400,7 +400,7 @@ onBeforeUnmount(() => {
 					data-test-id="enable-mfa-button"
 					@click="onMfaEnableClick"
 				/>
-				<n8n-button
+				<N8nButton
 					v-else
 					:class="$style.disableMfaButton"
 					type="tertiary"
@@ -412,32 +412,32 @@ onBeforeUnmount(() => {
 		</div>
 		<div>
 			<div class="mb-s">
-				<n8n-heading size="large">{{
+				<N8nHeading size="large">{{
 					i18n.baseText('settings.personal.personalisation')
-				}}</n8n-heading>
+				}}</N8nHeading>
 			</div>
 			<div>
-				<n8n-input-label :label="i18n.baseText('settings.personal.theme')">
-					<n8n-select
+				<N8nInputLabel :label="i18n.baseText('settings.personal.theme')">
+					<N8nSelect
 						v-model="currentSelectedTheme"
 						:class="$style.themeSelect"
 						data-test-id="theme-select"
 						size="small"
 						filterable
 					>
-						<n8n-option
+						<N8nOption
 							v-for="item in themeOptions"
 							:key="item.name"
 							:label="i18n.baseText(item.label)"
 							:value="item.name"
 						>
-						</n8n-option>
-					</n8n-select>
-				</n8n-input-label>
+						</N8nOption>
+					</N8nSelect>
+				</N8nInputLabel>
 			</div>
 		</div>
 		<div>
-			<n8n-button
+			<N8nButton
 				float="right"
 				:label="i18n.baseText('settings.personal.save')"
 				size="large"

--- a/packages/frontend/editor-ui/src/views/SettingsSourceControl.test.ts
+++ b/packages/frontend/editor-ui/src/views/SettingsSourceControl.test.ts
@@ -74,7 +74,7 @@ describe('SettingsSourceControl', () => {
 		const { container, getByTestId, getByText, queryByTestId, getByRole } = renderComponent({
 			pinia,
 			global: {
-				stubs: ['teleport'],
+				stubs: ['Teleport'],
 			},
 		});
 

--- a/packages/frontend/editor-ui/src/views/SettingsSourceControl.vue
+++ b/packages/frontend/editor-ui/src/views/SettingsSourceControl.vue
@@ -253,14 +253,14 @@ watch(connectionType, () => {
 
 <template>
 	<div>
-		<n8n-heading size="2xlarge" tag="h1">{{
+		<N8nHeading size="2xlarge" tag="h1">{{
 			locale.baseText('settings.sourceControl.title')
-		}}</n8n-heading>
+		}}</N8nHeading>
 		<div
 			v-if="sourceControlStore.isEnterpriseSourceControlEnabled"
 			data-test-id="source-control-content-licensed"
 		>
-			<n8n-callout theme="secondary" icon="info" class="mt-2xl mb-l">
+			<N8nCallout theme="secondary" icon="info" class="mt-2xl mb-l">
 				<I18nT keypath="settings.sourceControl.description" tag="span" scope="global">
 					<template #link>
 						<a :href="locale.baseText('settings.sourceControl.docs.url')" target="_blank">
@@ -268,16 +268,16 @@ watch(connectionType, () => {
 						</a>
 					</template>
 				</I18nT>
-			</n8n-callout>
-			<n8n-heading size="xlarge" tag="h2" class="mb-s">{{
+			</N8nCallout>
+			<N8nHeading size="xlarge" tag="h2" class="mb-s">{{
 				locale.baseText('settings.sourceControl.gitConfig')
-			}}</n8n-heading>
+			}}</N8nHeading>
 
 			<div v-if="!isConnected" :class="$style.group">
 				<label for="connectionType">{{
 					locale.baseText('settings.sourceControl.connectionType')
 				}}</label>
-				<n8n-form-input
+				<N8nFormInput
 					id="connectionType"
 					v-model="connectionType"
 					label=""
@@ -298,7 +298,7 @@ watch(connectionType, () => {
 					}}
 				</label>
 				<div :class="$style.groupFlex">
-					<n8n-form-input
+					<N8nFormInput
 						id="repoUrl"
 						v-model="sourceControlStore.preferences.repositoryUrl"
 						label=""
@@ -314,7 +314,7 @@ watch(connectionType, () => {
 						"
 						@validate="(value: boolean) => onValidate('repoUrl', value)"
 					/>
-					<n8n-button
+					<N8nButton
 						v-if="isConnected"
 						:class="$style.disconnectButton"
 						type="tertiary"
@@ -322,22 +322,22 @@ watch(connectionType, () => {
 						icon="trash-2"
 						data-test-id="source-control-disconnect-button"
 						@click="onDisconnect"
-						>{{ locale.baseText('settings.sourceControl.button.disconnect') }}</n8n-button
+						>{{ locale.baseText('settings.sourceControl.button.disconnect') }}</N8nButton
 					>
 				</div>
-				<n8n-notice v-if="!isConnected && connectionType === 'ssh'" type="info" class="mt-s">
+				<N8nNotice v-if="!isConnected && connectionType === 'ssh'" type="info" class="mt-s">
 					{{ locale.baseText('settings.sourceControl.sshFormatNotice') }}
-				</n8n-notice>
-				<n8n-notice v-if="!isConnected && connectionType === 'https'" type="info" class="mt-s">
+				</N8nNotice>
+				<N8nNotice v-if="!isConnected && connectionType === 'https'" type="info" class="mt-s">
 					{{ locale.baseText('settings.sourceControl.httpsFormatNotice') }}
-				</n8n-notice>
+				</N8nNotice>
 			</div>
 
 			<div v-if="connectionType === 'https' && !isConnected" :class="$style.group">
 				<label for="httpsUsername">{{
 					locale.baseText('settings.sourceControl.httpsUsername')
 				}}</label>
-				<n8n-form-input
+				<N8nFormInput
 					id="httpsUsername"
 					v-model="httpsUsername"
 					label=""
@@ -354,7 +354,7 @@ watch(connectionType, () => {
 				<label for="httpsPassword">{{
 					locale.baseText('settings.sourceControl.httpsPersonalAccessToken')
 				}}</label>
-				<n8n-form-input
+				<N8nFormInput
 					id="httpsPassword"
 					v-model="httpsPassword"
 					label=""
@@ -367,7 +367,7 @@ watch(connectionType, () => {
 					"
 					@validate="(value: boolean) => onValidate('httpsPassword', value)"
 				/>
-				<n8n-notice type="warning" class="mt-s">
+				<N8nNotice type="warning" class="mt-s">
 					<I18nT keypath="settings.sourceControl.httpsWarningNotice" tag="span" scope="global">
 						<template #strong>
 							<strong>{{
@@ -381,7 +381,7 @@ watch(connectionType, () => {
 							<code>public_repo</code>
 						</template>
 					</I18nT>
-				</n8n-notice>
+				</N8nNotice>
 			</div>
 
 			<div
@@ -390,7 +390,7 @@ watch(connectionType, () => {
 			>
 				<label>{{ locale.baseText('settings.sourceControl.sshKey') }}</label>
 				<div :class="{ [$style.sshInput]: !isConnected }">
-					<n8n-form-input
+					<N8nFormInput
 						v-if="!isConnected"
 						id="keyGeneratorType"
 						:class="$style.sshKeyTypeSelect"
@@ -412,7 +412,7 @@ watch(connectionType, () => {
 						:value="sourceControlStore.preferences.publicKey"
 						:copy-button-text="locale.baseText('generic.clickToCopy')"
 					/>
-					<n8n-button
+					<N8nButton
 						v-if="!isConnected"
 						size="large"
 						type="tertiary"
@@ -421,9 +421,9 @@ watch(connectionType, () => {
 						@click="refreshSshKey"
 					>
 						{{ locale.baseText('settings.sourceControl.refreshSshKey') }}
-					</n8n-button>
+					</N8nButton>
 				</div>
-				<n8n-notice type="info" class="mt-s">
+				<N8nNotice type="info" class="mt-s">
 					<I18nT keypath="settings.sourceControl.sshKeyDescription" tag="span" scope="global">
 						<template #link>
 							<a
@@ -433,28 +433,27 @@ watch(connectionType, () => {
 							>
 						</template>
 					</I18nT>
-				</n8n-notice>
+				</N8nNotice>
 			</div>
-
-			<n8n-button
+			<N8nButton
 				v-if="!isConnected"
 				size="large"
 				:disabled="!validForConnection"
 				:class="$style.connect"
 				data-test-id="source-control-connect-button"
 				@click="onConnect"
-				>{{ locale.baseText('settings.sourceControl.button.connect') }}</n8n-button
+				>{{ locale.baseText('settings.sourceControl.button.connect') }}</N8nButton
 			>
 
 			<div v-if="isConnected" data-test-id="source-control-connected-content">
 				<div :class="$style.group">
 					<hr />
-					<n8n-heading size="xlarge" tag="h2" class="mb-s">{{
+					<N8nHeading size="xlarge" tag="h2" class="mb-s">{{
 						locale.baseText('settings.sourceControl.instanceSettings')
-					}}</n8n-heading>
+					}}</N8nHeading>
 					<label>{{ locale.baseText('settings.sourceControl.branches') }}</label>
 					<div :class="$style.branchSelection">
-						<n8n-form-input
+						<N8nFormInput
 							id="branchName"
 							label=""
 							type="select"
@@ -468,13 +467,13 @@ watch(connectionType, () => {
 							@validate="(value: boolean) => onValidate('branchName', value)"
 							@update:model-value="onSelect"
 						/>
-						<n8n-tooltip placement="top">
+						<N8nTooltip placement="top">
 							<template #content>
 								<span>
 									{{ locale.baseText('settings.sourceControl.refreshBranches.tooltip') }}
 								</span>
 							</template>
-							<n8n-button
+							<N8nButton
 								size="small"
 								type="tertiary"
 								icon="refresh-cw"
@@ -483,9 +482,9 @@ watch(connectionType, () => {
 								data-test-id="source-control-refresh-branches-button"
 								@click="refreshBranches"
 							/>
-						</n8n-tooltip>
+						</N8nTooltip>
 					</div>
-					<n8n-checkbox
+					<N8nCheckbox
 						v-model="sourceControlStore.preferences.branchReadOnly"
 						:class="$style.readOnly"
 					>
@@ -494,26 +493,26 @@ watch(connectionType, () => {
 								<strong>{{ locale.baseText('settings.sourceControl.protected.bold') }}</strong>
 							</template>
 						</I18nT>
-					</n8n-checkbox>
+					</N8nCheckbox>
 				</div>
 				<div :class="$style.group">
 					<label>{{ locale.baseText('settings.sourceControl.color') }}</label>
 					<div>
-						<n8n-color-picker v-model="sourceControlStore.preferences.branchColor" size="small" />
+						<N8nColorPicker v-model="sourceControlStore.preferences.branchColor" size="small" />
 					</div>
 				</div>
 				<div :class="[$style.group, 'pt-s']">
-					<n8n-button
+					<N8nButton
 						size="large"
 						:disabled="!sourceControlStore.preferences.branchName"
 						data-test-id="source-control-save-settings-button"
 						@click="onSave"
-						>{{ locale.baseText('settings.sourceControl.button.save') }}</n8n-button
+						>{{ locale.baseText('settings.sourceControl.button.save') }}</N8nButton
 					>
 				</div>
 			</div>
 		</div>
-		<n8n-action-box
+		<N8nActionBox
 			v-else
 			data-test-id="source-control-content-unlicensed"
 			:class="$style.actionBox"
@@ -530,7 +529,7 @@ watch(connectionType, () => {
 					{{ locale.baseText('settings.sourceControl.actionBox.description.link') }}
 				</a>
 			</template>
-		</n8n-action-box>
+		</N8nActionBox>
 	</div>
 </template>
 

--- a/packages/frontend/editor-ui/src/views/SettingsSso.vue
+++ b/packages/frontend/editor-ui/src/views/SettingsSso.vue
@@ -336,14 +336,14 @@ async function onOidcSettingsSave() {
 <template>
 	<div class="pb-2xl">
 		<div :class="$style.heading">
-			<n8n-heading size="2xlarge">{{ i18n.baseText('settings.sso.title') }}</n8n-heading>
+			<N8nHeading size="2xlarge">{{ i18n.baseText('settings.sso.title') }}</N8nHeading>
 		</div>
-		<n8n-info-tip>
+		<N8nInfoTip>
 			{{ i18n.baseText('settings.sso.info') }}
 			<a href="https://docs.n8n.io/user-management/saml/" target="_blank">
 				{{ i18n.baseText('settings.sso.info.link') }}
 			</a>
-		</n8n-info-tip>
+		</N8nInfoTip>
 		<div
 			v-if="ssoStore.isEnterpriseSamlEnabled || ssoStore.isEnterpriseOidcEnabled"
 			data-test-id="sso-auth-protocol-select"
@@ -392,10 +392,10 @@ async function onOidcSettingsSave() {
 				<div :class="$style.group">
 					<label>{{ i18n.baseText('settings.sso.settings.ips.label') }}</label>
 					<div class="mt-2xs mb-s">
-						<n8n-radio-buttons v-model="ipsType" :options="ipsOptions" />
+						<N8nRadioButtons v-model="ipsType" :options="ipsOptions" />
 					</div>
 					<div v-if="ipsType === IdentityProviderSettingsType.URL">
-						<n8n-input
+						<N8nInput
 							v-model="metadataUrl"
 							type="text"
 							name="metadataUrl"
@@ -406,7 +406,7 @@ async function onOidcSettingsSave() {
 						<small>{{ i18n.baseText('settings.sso.settings.ips.url.help') }}</small>
 					</div>
 					<div v-if="ipsType === IdentityProviderSettingsType.XML">
-						<n8n-input
+						<N8nInput
 							v-model="metadata"
 							type="textarea"
 							name="metadata"
@@ -416,7 +416,7 @@ async function onOidcSettingsSave() {
 						<small>{{ i18n.baseText('settings.sso.settings.ips.xml.help') }}</small>
 					</div>
 					<div :class="$style.group">
-						<n8n-tooltip
+						<N8nTooltip
 							v-if="ssoStore.isEnterpriseSamlEnabled"
 							:disabled="ssoStore.isSamlLoginEnabled || ssoSettingsSaved"
 						>
@@ -425,26 +425,26 @@ async function onOidcSettingsSave() {
 									{{ i18n.baseText('settings.sso.activation.tooltip') }}
 								</span>
 							</template>
-							<el-switch
+							<ElSwitch
 								v-model="ssoStore.isSamlLoginEnabled"
 								data-test-id="sso-toggle"
 								:disabled="isToggleSsoDisabled"
 								:class="$style.switch"
 								:inactive-text="ssoActivatedLabel"
 							/>
-						</n8n-tooltip>
+						</N8nTooltip>
 					</div>
 				</div>
 				<div :class="$style.buttons">
-					<n8n-button
+					<N8nButton
 						:disabled="!isSaveEnabled"
 						size="large"
 						data-test-id="sso-save"
 						@click="onSave"
 					>
 						{{ i18n.baseText('settings.sso.settings.save') }}
-					</n8n-button>
-					<n8n-button
+					</N8nButton>
+					<N8nButton
 						:disabled="!isTestEnabled"
 						size="large"
 						type="tertiary"
@@ -452,14 +452,14 @@ async function onOidcSettingsSave() {
 						@click="onTest"
 					>
 						{{ i18n.baseText('settings.sso.settings.test') }}
-					</n8n-button>
+					</N8nButton>
 				</div>
 
 				<footer :class="$style.footer">
 					{{ i18n.baseText('settings.sso.settings.footer.hint') }}
 				</footer>
 			</div>
-			<n8n-action-box
+			<N8nActionBox
 				v-else
 				data-test-id="sso-content-unlicensed"
 				:class="$style.actionBox"
@@ -470,7 +470,7 @@ async function onOidcSettingsSave() {
 				<template #heading>
 					<span>{{ i18n.baseText('settings.sso.actionBox.title') }}</span>
 				</template>
-			</n8n-action-box>
+			</N8nActionBox>
 		</div>
 		<div v-if="authProtocol === SupportedProtocols.OIDC">
 			<div v-if="ssoStore.isEnterpriseOidcEnabled">
@@ -537,7 +537,7 @@ async function onOidcSettingsSave() {
 					<small>The prompt parameter to use when authenticating with the OIDC provider</small>
 				</div>
 				<div :class="$style.group">
-					<el-switch
+					<ElSwitch
 						v-model="ssoStore.isOidcLoginEnabled"
 						data-test-id="sso-oidc-toggle"
 						:class="$style.switch"
@@ -546,17 +546,17 @@ async function onOidcSettingsSave() {
 				</div>
 
 				<div :class="$style.buttons">
-					<n8n-button
+					<N8nButton
 						data-test-id="sso-oidc-save"
 						size="large"
 						:disabled="cannotSaveOidcSettings"
 						@click="onOidcSettingsSave"
 					>
 						{{ i18n.baseText('settings.sso.settings.save') }}
-					</n8n-button>
+					</N8nButton>
 				</div>
 			</div>
-			<n8n-action-box
+			<N8nActionBox
 				v-else
 				data-test-id="sso-content-unlicensed"
 				:class="$style.actionBox"
@@ -566,7 +566,7 @@ async function onOidcSettingsSave() {
 				<template #heading>
 					<span>{{ i18n.baseText('settings.sso.actionBox.title') }}</span>
 				</template>
-			</n8n-action-box>
+			</N8nActionBox>
 		</div>
 	</div>
 </template>

--- a/packages/frontend/editor-ui/src/views/SettingsUsageAndPlan.vue
+++ b/packages/frontend/editor-ui/src/views/SettingsUsageAndPlan.vue
@@ -156,11 +156,11 @@ const openCommunityRegisterModal = () => {
 
 <template>
 	<div class="settings-usage-and-plan">
-		<n8n-heading tag="h2" size="2xlarge">{{
+		<N8nHeading tag="h2" size="2xlarge">{{
 			locale.baseText('settings.usageAndPlan.title')
-		}}</n8n-heading>
+		}}</N8nHeading>
 		<div v-if="!usageStore.isLoading">
-			<n8n-heading tag="h3" :class="$style.title" size="large">
+			<N8nHeading tag="h3" :class="$style.title" size="large">
 				<I18nT keypath="settings.usageAndPlan.description" tag="span" scope="global">
 					<template #name>{{ badgedPlanName.name ?? usageStore.planName }}</template>
 					<template #type>
@@ -183,7 +183,7 @@ const openCommunityRegisterModal = () => {
 						<N8nBadge>{{ badgedPlanName.badge }}</N8nBadge>
 					</N8nTooltip>
 				</span>
-			</n8n-heading>
+			</N8nHeading>
 
 			<N8nNotice v-if="isCommunity && canUserRegisterCommunityPlus" class="mt-0" theme="warning">
 				<I18nT keypath="settings.usageAndPlan.callOut" scope="global">
@@ -199,9 +199,9 @@ const openCommunityRegisterModal = () => {
 			</N8nNotice>
 
 			<div :class="$style.quota">
-				<n8n-text size="medium" color="text-light">
+				<N8nText size="medium" color="text-light">
 					{{ locale.baseText('settings.usageAndPlan.activeWorkflows') }}
-				</n8n-text>
+				</N8nText>
 				<div :class="$style.chart">
 					<span v-if="usageStore.activeWorkflowTriggersLimit > 0" :class="$style.chartLine">
 						<span
@@ -229,7 +229,7 @@ const openCommunityRegisterModal = () => {
 			<N8nInfoTip>{{ locale.baseText('settings.usageAndPlan.activeWorkflows.hint') }}</N8nInfoTip>
 
 			<div :class="$style.buttons">
-				<n8n-button
+				<N8nButton
 					v-if="canUserActivateLicense"
 					:class="$style.buttonTertiary"
 					type="tertiary"
@@ -237,20 +237,20 @@ const openCommunityRegisterModal = () => {
 					@click="onAddActivationKey"
 				>
 					<span>{{ locale.baseText('settings.usageAndPlan.button.activation') }}</span>
-				</n8n-button>
-				<n8n-button v-if="usageStore.managementToken" size="large" @click="onManagePlan">
+				</N8nButton>
+				<N8nButton v-if="usageStore.managementToken" size="large" @click="onManagePlan">
 					<a :href="managePlanUrl" target="_blank">{{
 						locale.baseText('settings.usageAndPlan.button.manage')
 					}}</a>
-				</n8n-button>
-				<n8n-button v-else size="large" @click.prevent="onViewPlans">
+				</N8nButton>
+				<N8nButton v-else size="large" @click.prevent="onViewPlans">
 					<a :href="viewPlansUrl" target="_blank">{{
 						locale.baseText('settings.usageAndPlan.button.plans')
 					}}</a>
-				</n8n-button>
+				</N8nButton>
 			</div>
 
-			<el-dialog
+			<ElDialog
 				v-model="activationKeyModal"
 				width="480px"
 				top="0"
@@ -260,21 +260,21 @@ const openCommunityRegisterModal = () => {
 				@opened="onDialogOpened"
 			>
 				<template #default>
-					<n8n-input
+					<N8nInput
 						ref="activationKeyInput"
 						v-model="activationKey"
 						:placeholder="locale.baseText('settings.usageAndPlan.dialog.activation.label')"
 					/>
 				</template>
 				<template #footer>
-					<n8n-button type="secondary" @click="activationKeyModal = false">
+					<N8nButton type="secondary" @click="activationKeyModal = false">
 						{{ locale.baseText('settings.usageAndPlan.dialog.activation.cancel') }}
-					</n8n-button>
-					<n8n-button @click="onLicenseActivation">
+					</N8nButton>
+					<N8nButton @click="onLicenseActivation">
 						{{ locale.baseText('settings.usageAndPlan.dialog.activation.activate') }}
-					</n8n-button>
+					</N8nButton>
 				</template>
-			</el-dialog>
+			</ElDialog>
 		</div>
 	</div>
 </template>

--- a/packages/frontend/editor-ui/src/views/SettingsUsersView.vue
+++ b/packages/frontend/editor-ui/src/views/SettingsUsersView.vue
@@ -413,7 +413,7 @@ async function onUpdateMfaEnforced(value: boolean) {
 			</div>
 			<div :class="$style.settingsContainerAction">
 				<EnterpriseEdition :features="[EnterpriseEditionFeature.EnforceMFA]">
-					<el-switch
+					<ElSwitch
 						:model-value="settingsStore.isMFAEnforced"
 						size="large"
 						data-test-id="enable-force-mfa"
@@ -421,7 +421,7 @@ async function onUpdateMfaEnforced(value: boolean) {
 					/>
 					<template #fallback>
 						<N8nTooltip>
-							<el-switch :model-value="settingsStore.isMFAEnforced" size="large" :disabled="true" />
+							<ElSwitch :model-value="settingsStore.isMFAEnforced" size="large" :disabled="true" />
 							<template #content>
 								<I18nT :keypath="tooltipKey" tag="span" scope="global">
 									<template #action>

--- a/packages/frontend/editor-ui/src/views/SettingsView.vue
+++ b/packages/frontend/editor-ui/src/views/SettingsView.vue
@@ -37,7 +37,7 @@ onMounted(() => {
 					Because we're using nested routes the props are going to be bind to the top level route
 					so we need to pass them down to the child component
 				-->
-				<router-view name="settingsView" v-bind="$attrs" />
+				<RouterView name="settingsView" v-bind="$attrs" />
 			</div>
 		</div>
 	</div>

--- a/packages/frontend/editor-ui/src/views/SetupWorkflowFromTemplateView/SetupWorkflowFromTemplateView.vue
+++ b/packages/frontend/editor-ui/src/views/SetupWorkflowFromTemplateView/SetupWorkflowFromTemplateView.vue
@@ -91,7 +91,7 @@ onMounted(async () => {
 			<N8nHeading v-if="isReady" tag="h1" size="2xlarge"
 				>{{ i18n.baseText('templateSetup.title', { interpolate: { name: title } }) }}
 			</N8nHeading>
-			<n8n-loading v-else variant="h1" />
+			<N8nLoading v-else variant="h1" />
 		</template>
 
 		<template #content>
@@ -101,7 +101,7 @@ onMounted(async () => {
 						v-if="isReady"
 						:app-credentials="setupTemplateStore.appCredentials"
 					/>
-					<n8n-loading v-else variant="p" />
+					<N8nLoading v-else variant="p" />
 				</div>
 
 				<div>
@@ -127,8 +127,8 @@ onMounted(async () => {
 						/>
 					</ol>
 					<div v-else :class="$style.appCredentialsContainer">
-						<n8n-loading :class="$style.appCredential" variant="p" :rows="3" />
-						<n8n-loading :class="$style.appCredential" variant="p" :rows="3" />
+						<N8nLoading :class="$style.appCredential" variant="p" :rows="3" />
+						<N8nLoading :class="$style.appCredential" variant="p" :rows="3" />
 					</div>
 				</div>
 
@@ -137,12 +137,12 @@ onMounted(async () => {
 						i18n.baseText('templateSetup.skip')
 					}}</N8nLink>
 
-					<n8n-tooltip
+					<N8nTooltip
 						v-if="isReady"
 						:content="i18n.baseText('templateSetup.continue.button.fillRemaining')"
 						:disabled="setupTemplateStore.numFilledCredentials > 0"
 					>
-						<n8n-button
+						<N8nButton
 							size="large"
 							:label="i18n.baseText('templateSetup.continue.button')"
 							:disabled="
@@ -151,9 +151,9 @@ onMounted(async () => {
 							data-test-id="continue-button"
 							@click="setupTemplateStore.createWorkflow({ router })"
 						/>
-					</n8n-tooltip>
+					</N8nTooltip>
 					<div v-else>
-						<n8n-loading variant="button" />
+						<N8nLoading variant="button" />
 					</div>
 				</div>
 			</div>

--- a/packages/frontend/editor-ui/src/views/TemplatesCollectionView.vue
+++ b/packages/frontend/editor-ui/src/views/TemplatesCollectionView.vue
@@ -116,24 +116,24 @@ onMounted(async () => {
 		<template #header>
 			<div v-if="!notFoundError" :class="$style.wrapper">
 				<div :class="$style.title">
-					<n8n-heading v-if="collection && collection.name" tag="h1" size="2xlarge">
+					<N8nHeading v-if="collection && collection.name" tag="h1" size="2xlarge">
 						{{ collection.name }}
-					</n8n-heading>
-					<n8n-text v-if="collection && collection.name" color="text-base" size="small">
+					</N8nHeading>
+					<N8nText v-if="collection && collection.name" color="text-base" size="small">
 						{{ i18n.baseText('templates.collection') }}
-					</n8n-text>
-					<n8n-loading :loading="!collection || !collection.name" :rows="2" variant="h1" />
+					</N8nText>
+					<N8nLoading :loading="!collection || !collection.name" :rows="2" variant="h1" />
 				</div>
 			</div>
 			<div v-else :class="$style.notFound">
-				<n8n-text color="text-base">{{ i18n.baseText('templates.collectionsNotFound') }}</n8n-text>
+				<N8nText color="text-base">{{ i18n.baseText('templates.collectionsNotFound') }}</N8nText>
 			</div>
 		</template>
 		<template v-if="!notFoundError" #content>
 			<div :class="$style.wrapper">
 				<div :class="$style.mainContent">
 					<div v-if="loading || isFullTemplatesCollection(collection)" :class="$style.markdown">
-						<n8n-markdown
+						<N8nMarkdown
 							:content="
 								isFullTemplatesCollection(collection) && collection.description
 									? collection.description

--- a/packages/frontend/editor-ui/src/views/TemplatesSearchView.vue
+++ b/packages/frontend/editor-ui/src/views/TemplatesSearchView.vue
@@ -338,12 +338,12 @@ watch(workflows, (newWorkflows) => {
 		<template #header>
 			<div :class="$style.wrapper">
 				<div :class="$style.title">
-					<n8n-heading tag="h1" size="2xlarge">
+					<N8nHeading tag="h1" size="2xlarge">
 						{{ i18n.baseText('templates.heading') }}
-					</n8n-heading>
+					</N8nHeading>
 				</div>
 				<div :class="$style.button">
-					<n8n-button
+					<N8nButton
 						size="large"
 						type="secondary"
 						element="a"
@@ -368,7 +368,7 @@ watch(workflows, (newWorkflows) => {
 					/>
 				</div>
 				<div :class="$style.search">
-					<n8n-input
+					<N8nInput
 						:model-value="search"
 						:placeholder="i18n.baseText('templates.searchPlaceholder')"
 						clearable
@@ -377,19 +377,19 @@ watch(workflows, (newWorkflows) => {
 						@blur="trackSearch"
 					>
 						<template #prefix>
-							<n8n-icon icon="search" />
+							<N8nIcon icon="search" />
 						</template>
-					</n8n-input>
+					</N8nInput>
 					<div v-show="collections.length || loadingCollections" :class="$style.carouselContainer">
 						<div :class="$style.header">
-							<n8n-heading :bold="true" size="medium" color="text-light">
+							<N8nHeading :bold="true" size="medium" color="text-light">
 								{{ i18n.baseText('templates.collections') }}
 								<span
 									v-if="!loadingCollections"
 									data-test-id="collection-count-label"
 									v-text="`(${collections.length})`"
 								/>
-							</n8n-heading>
+							</N8nHeading>
 						</div>
 						<TemplatesInfoCarousel
 							:collections="collections"
@@ -406,9 +406,9 @@ watch(workflows, (newWorkflows) => {
 						@open-template="onOpenTemplate"
 					/>
 					<div v-if="endOfSearchMessage" :class="$style.endText">
-						<n8n-text size="medium" color="text-base">
+						<N8nText size="medium" color="text-base">
 							<span v-n8n-html="endOfSearchMessage" />
-						</n8n-text>
+						</N8nText>
 					</div>
 				</div>
 			</div>

--- a/packages/frontend/editor-ui/src/views/TemplatesWorkflowView.vue
+++ b/packages/frontend/editor-ui/src/views/TemplatesWorkflowView.vue
@@ -91,27 +91,27 @@ onMounted(async () => {
 		<template #header>
 			<div v-if="!notFoundError" :class="$style.wrapper">
 				<div :class="$style.title">
-					<n8n-heading v-if="template && template.name" tag="h1" size="2xlarge">{{
+					<N8nHeading v-if="template && template.name" tag="h1" size="2xlarge">{{
 						template.name
-					}}</n8n-heading>
-					<n8n-text v-if="template && template.name" color="text-base" size="small">
+					}}</N8nHeading>
+					<N8nText v-if="template && template.name" color="text-base" size="small">
 						{{ i18n.baseText('generic.workflow') }}
-					</n8n-text>
-					<n8n-loading :loading="!template || !template.name" :rows="2" variant="h1" />
+					</N8nText>
+					<N8nLoading :loading="!template || !template.name" :rows="2" variant="h1" />
 				</div>
 				<div :class="$style.button">
-					<n8n-button
+					<N8nButton
 						v-if="template"
 						data-test-id="use-template-button"
 						:label="i18n.baseText('template.buttons.useThisWorkflowButton')"
 						size="large"
 						@click="openTemplateSetup(templateId, $event)"
 					/>
-					<n8n-loading :loading="!template" :rows="1" variant="button" />
+					<N8nLoading :loading="!template" :rows="1" variant="button" />
 				</div>
 			</div>
 			<div v-else :class="$style.notFound">
-				<n8n-text color="text-base">{{ i18n.baseText('templates.workflowsNotFound') }}</n8n-text>
+				<N8nText color="text-base">{{ i18n.baseText('templates.workflowsNotFound') }}</N8nText>
 			</div>
 		</template>
 		<template v-if="!notFoundError" #content>
@@ -125,7 +125,7 @@ onMounted(async () => {
 			</div>
 			<div :class="$style.content">
 				<div :class="$style.markdown" data-test-id="template-description">
-					<n8n-markdown
+					<N8nMarkdown
 						:content="template?.description"
 						:images="template?.image"
 						:loading="loading"

--- a/packages/frontend/editor-ui/src/views/VariablesView.vue
+++ b/packages/frontend/editor-ui/src/views/VariablesView.vue
@@ -270,9 +270,9 @@ onMounted(() => {
 		@click:add="addEmptyVariableForm"
 	>
 		<template #header>
-			<n8n-heading size="2xlarge" class="mb-m">
+			<N8nHeading size="2xlarge" class="mb-m">
 				{{ i18n.baseText('variables.heading') }}
-			</n8n-heading>
+			</N8nHeading>
 		</template>
 		<template #add-button>
 			<N8nTooltip placement="top" :disabled="canCreateVariables">

--- a/packages/frontend/editor-ui/src/views/WorkerView.vue
+++ b/packages/frontend/editor-ui/src/views/WorkerView.vue
@@ -18,7 +18,7 @@ const goToUpgrade = () => {
 		v-if="settingsStore.isQueueModeEnabled && settingsStore.isWorkerViewAvailable"
 		data-test-id="worker-view-licensed"
 	/>
-	<n8n-action-box
+	<N8nActionBox
 		v-else
 		data-test-id="worker-view-unlicensed"
 		:class="$style.actionBox"
@@ -35,7 +35,7 @@ const goToUpgrade = () => {
 				{{ i18n.baseText('workerList.actionBox.description.link') }}
 			</a>
 		</template>
-	</n8n-action-box>
+	</N8nActionBox>
 </template>
 
 <style module lang="scss">

--- a/packages/frontend/editor-ui/src/views/WorkflowHistory.test.ts
+++ b/packages/frontend/editor-ui/src/views/WorkflowHistory.test.ts
@@ -50,8 +50,8 @@ const versionId = faker.string.nanoid();
 const renderComponent = createComponentRenderer(WorkflowHistoryPage, {
 	global: {
 		stubs: {
-			'workflow-history-content': true,
-			'workflow-history-list': defineComponent({
+			WorkflowHistoryContent: true,
+			WorkflowHistoryList: defineComponent({
 				props: {
 					id: {
 						type: String,

--- a/packages/frontend/editor-ui/src/views/WorkflowHistory.vue
+++ b/packages/frontend/editor-ui/src/views/WorkflowHistory.vue
@@ -331,9 +331,9 @@ watchEffect(async () => {
 <template>
 	<div :class="$style.view">
 		<div :class="$style.header">
-			<n8n-heading tag="h2" size="medium">
+			<N8nHeading tag="h2" size="medium">
 				{{ activeWorkflow?.name }}
-			</n8n-heading>
+			</N8nHeading>
 			<span v-if="activeWorkflow?.isArchived">
 				<N8nBadge class="ml-s" theme="tertiary" bold data-test-id="workflow-archived-tag">
 					{{ i18n.baseText('workflows.item.archived') }}
@@ -341,12 +341,12 @@ watchEffect(async () => {
 			</span>
 		</div>
 		<div :class="$style.corner">
-			<n8n-heading tag="h2" size="medium" bold>
+			<N8nHeading tag="h2" size="medium" bold>
 				{{ i18n.baseText('workflowHistory.title') }}
-			</n8n-heading>
-			<router-link :to="editorRoute" data-test-id="workflow-history-close-button">
-				<n8n-button type="tertiary" icon="x" size="small" text square />
-			</router-link>
+			</N8nHeading>
+			<RouterLink :to="editorRoute" data-test-id="workflow-history-close-button">
+				<N8nButton type="tertiary" icon="x" size="small" text square />
+			</RouterLink>
 		</div>
 		<div :class="$style.listComponentWrapper">
 			<WorkflowHistoryList

--- a/packages/frontend/editor-ui/src/views/WorkflowsView.test.ts
+++ b/packages/frontend/editor-ui/src/views/WorkflowsView.test.ts
@@ -500,7 +500,7 @@ describe('Folders', () => {
 			pinia,
 			global: {
 				stubs: {
-					'router-link': {
+					RouterLink: {
 						template: '<div data-test-id="folder-card"><slot /></div>',
 					},
 				},

--- a/packages/frontend/editor-ui/src/views/WorkflowsView.vue
+++ b/packages/frontend/editor-ui/src/views/WorkflowsView.vue
@@ -1932,7 +1932,7 @@ const onNameSubmit = async (name: string) => {
 		</template>
 		<template #breadcrumbs>
 			<div v-if="breadcrumbsLoading" :class="$style['breadcrumbs-loading']">
-				<n8n-loading :loading="breadcrumbsLoading" :rows="1" variant="p" />
+				<N8nLoading :loading="breadcrumbsLoading" :rows="1" variant="p" />
 			</div>
 			<div
 				v-else-if="showFolders && currentFolder"


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Standardized all Vue component tags to PascalCase across templates and tests and enabled lint enforcement. No user-facing changes; this aligns with N8N‑739309 to unify component naming.

- **Refactors**
  - Replaced kebab-case tags (n8n-*, el-*, router-link, transition) with PascalCase (N8n*, El*, RouterLink, Transition).
  - Updated unit test stubs/mocks to PascalCase.
  - Set ESLint vue/component-name-in-template-casing with registeredComponentsOnly: false to enforce globally.
  - Minor cleanups (e.g., simplified askAiEnabled, small template tweaks) without behavior changes.

- **Migration**
  - Use PascalCase for all component tags in new or existing code to pass ESLint.
  - Update test stubs/mocks to PascalCase where needed.

<!-- End of auto-generated description by cubic. -->

