### PR TITLE
n8n-auto-pr (N8N - 746817)

### DIFF
--- a/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocator.vue
+++ b/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocator.vue
@@ -620,6 +620,12 @@ function onInputChange(value: INodeParameterResourceLocator['value']): void {
 	emit('update:modelValue', params);
 }
 
+function onInputMouseDown(event: MouseEvent): void {
+	if (isListMode.value) {
+		event.preventDefault();
+	}
+}
+
 function onModeSelected(value: string): void {
 	if (typeof props.modelValue !== 'object') {
 		emit('update:modelValue', { __rl: true, value: props.modelValue, mode: value });
@@ -1094,7 +1100,7 @@ function removeOverride() {
 									@update:model-value="onInputChange"
 									@focus="onInputFocus"
 									@blur="onInputBlur"
-									@mousedown.prevent
+									@mousedown="onInputMouseDown"
 								>
 									<template v-if="isListMode" #suffix>
 										<i


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes Resource Locator input selection when not in list mode by only preventing mousedown in list mode. Restores normal text selection and cursor placement outside list mode, addressing N8N-746817.

<!-- End of auto-generated description by cubic. -->

