### PR TITLE
n8n-auto-pr (N8N - 753695)

### DIFF
--- a/packages/cli/src/commands/webhook.ts
+++ b/packages/cli/src/commands/webhook.ts
@@ -10,6 +10,8 @@ import { WebhookServer } from '@/webhooks/webhook-server';
 import { DeprecationService } from '@/deprecation/deprecation.service';
 
 import { BaseCommand } from './base-command';
+import { MessageEventBus } from '@/eventbus/message-event-bus/message-event-bus';
+import { LogStreamingEventRelay } from '@/events/relays/log-streaming.event-relay';
 
 @Command({
 	name: 'webhook',
@@ -75,6 +77,11 @@ export class Webhook extends BaseCommand {
 		this.logger.debug('Data deduplication service init complete');
 		await this.initExternalHooks();
 		this.logger.debug('External hooks init complete');
+
+		await Container.get(MessageEventBus).initialize({
+			webhookProcessorId: this.instanceSettings.hostId,
+		});
+		Container.get(LogStreamingEventRelay).init();
 
 		await this.moduleRegistry.initModules();
 	}

--- a/packages/cli/src/eventbus/message-event-bus/message-event-bus.ts
+++ b/packages/cli/src/eventbus/message-event-bus/message-event-bus.ts
@@ -52,6 +52,7 @@ export interface MessageWithCallback {
 export interface MessageEventBusInitializeOptions {
 	skipRecoveryPass?: boolean;
 	workerId?: string;
+	webhookProcessorId?: string;
 }
 
 @Service()
@@ -113,10 +114,12 @@ export class MessageEventBus extends EventEmitter {
 		}
 
 		this.logger.debug('Initializing event writer');
-		if (options?.workerId) {
-			// only add 'worker' to log file name since the ID changes on every start and we
+		if (options?.workerId || options?.webhookProcessorId) {
+			// only add 'worker' or 'webhook-processor' to log file name since the ID changes on every start and we
 			// would not be able to recover the log files from the previous run not knowing it
-			const logBaseName = this.globalConfig.eventBus.logWriter.logBaseName + '-worker';
+			const logBaseName =
+				this.globalConfig.eventBus.logWriter.logBaseName +
+				(options.workerId ? '-worker' : '-webhook-processor');
 			this.logWriter = await MessageEventBusLogWriter.getInstance({
 				logBaseName,
 			});


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Enables log streaming in webhook processors so logs are captured and relayed during webhook execution. Also separates event bus log files for webhook processors from worker runs.

- **New Features**
  - Initialize MessageEventBus in webhook command with webhookProcessorId.
  - Start LogStreamingEventRelay for webhook processors.
  - Use '-webhook-processor' log base name to keep logs distinct and recoverable.

<!-- End of auto-generated description by cubic. -->

