### PR TITLE
n8n-auto-pr (N8N - 755227)

### DIFF
--- a/packages/@n8n/db/src/repositories/execution.repository.ts
+++ b/packages/@n8n/db/src/repositories/execution.repository.ts
@@ -30,7 +30,7 @@ import type {
 	ExecutionSummary,
 	IRunExecutionData,
 } from 'n8n-workflow';
-import { ExecutionCancelledError, UnexpectedError } from 'n8n-workflow';
+import { ManualExecutionCancelledError, UnexpectedError } from 'n8n-workflow';
 
 import { ExecutionDataRepository } from './execution-data.repository';
 import {
@@ -796,7 +796,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 	}
 
 	async stopDuringRun(execution: IExecutionResponse) {
-		const error = new ExecutionCancelledError(execution.id);
+		const error = new ManualExecutionCancelledError(execution.id);
 
 		execution.data ??= { resultData: { runData: {} } };
 		execution.data.resultData.error = {

--- a/packages/cli/src/__tests__/workflow-runner.test.ts
+++ b/packages/cli/src/__tests__/workflow-runner.test.ts
@@ -22,6 +22,7 @@ import {
 	type IWorkflowExecuteAdditionalData,
 	Workflow,
 	ExecutionError,
+	TimeoutExecutionCancelledError,
 } from 'n8n-workflow';
 import PCancelable from 'p-cancelable';
 
@@ -424,7 +425,7 @@ describe('workflow timeout with startedAt', () => {
 
 		// ASSERT
 		// The execution should be stopped immediately because the timeout has already elapsed
-		expect(mockStopExecution).toHaveBeenCalledWith('1');
+		expect(mockStopExecution).toHaveBeenCalledWith('1', expect.any(TimeoutExecutionCancelledError));
 	});
 
 	it('should use original timeout logic when startedAt is not provided', async () => {
@@ -471,6 +472,63 @@ describe('workflow timeout with startedAt', () => {
 		// ASSERT
 		// The execution should not be stopped immediately (original timeout logic)
 		expect(mockStopExecution).not.toHaveBeenCalled();
+	});
+
+	it('should call stopExecution when the timeout callback is executed', async () => {
+		// ARRANGE
+		const activeExecutions = Container.get(ActiveExecutions);
+		jest.spyOn(activeExecutions, 'add').mockResolvedValue('1');
+		jest.spyOn(activeExecutions, 'attachWorkflowExecution').mockReturnValueOnce();
+		const permissionChecker = Container.get(CredentialsPermissionChecker);
+		jest.spyOn(permissionChecker, 'check').mockResolvedValueOnce();
+
+		const mockStopExecution = jest.spyOn(activeExecutions, 'stopExecution');
+
+		// Mock config to return a workflow timeout of 10 seconds
+		Container.get(GlobalConfig).executions.timeout = 10;
+
+		let timeoutCallback: (() => void) | undefined;
+		jest.spyOn(global, 'setTimeout').mockImplementation((fn) => {
+			if (typeof fn === 'function') {
+				timeoutCallback = fn;
+			}
+			return {} as NodeJS.Timeout;
+		});
+
+		const data = mock<IWorkflowExecutionDataProcess>({
+			workflowData: {
+				nodes: [],
+				settings: { executionTimeout: 10 }, // 10 seconds timeout
+			},
+			executionData: undefined,
+			executionMode: 'webhook',
+		});
+
+		const mockHooks = mock<core.ExecutionLifecycleHooks>();
+		jest
+			.spyOn(ExecutionLifecycleHooks, 'getLifecycleHooksForRegularMain')
+			.mockReturnValue(mockHooks);
+
+		const mockAdditionalData = mock<IWorkflowExecuteAdditionalData>();
+		jest.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue(mockAdditionalData);
+
+		const manualExecutionService = Container.get(ManualExecutionService);
+		jest.spyOn(manualExecutionService, 'runManually').mockReturnValue(
+			new PCancelable(() => {
+				return mock<IRun>();
+			}),
+		);
+
+		// ACT
+		await runner.run(data);
+
+		// Execute the timeout callback
+		expect(timeoutCallback).toBeDefined();
+		timeoutCallback!();
+
+		// ASSERT
+		// The execution should be stopped when the timeout callback is executed
+		expect(mockStopExecution).toHaveBeenCalledWith('1', expect.any(TimeoutExecutionCancelledError));
 	});
 });
 

--- a/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
@@ -10,6 +10,7 @@ import {
 	NodeConnectionTypes,
 	metricRequiresModelConnection,
 	DEFAULT_EVALUATION_METRIC,
+	ManualExecutionCancelledError,
 } from 'n8n-workflow';
 import type {
 	IDataObject,
@@ -280,7 +281,10 @@ export class TestRunnerService {
 
 		// Listen to the abort signal to stop the execution in case test run is cancelled
 		abortSignal.addEventListener('abort', () => {
-			this.activeExecutions.stopExecution(executionId);
+			this.activeExecutions.stopExecution(
+				executionId,
+				new ManualExecutionCancelledError(executionId),
+			);
 		});
 
 		// Wait for the execution to finish

--- a/packages/cli/src/executions/__tests__/execution.service.test.ts
+++ b/packages/cli/src/executions/__tests__/execution.service.test.ts
@@ -1,7 +1,7 @@
 import { mockInstance } from '@n8n/backend-test-utils';
 import type { IExecutionResponse, ExecutionRepository } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
-import { WorkflowOperationError } from 'n8n-workflow';
+import { ManualExecutionCancelledError, WorkflowOperationError } from 'n8n-workflow';
 
 import type { ActiveExecutions } from '@/active-executions';
 import type { ConcurrencyControlService } from '@/concurrency/concurrency-control.service';
@@ -125,7 +125,10 @@ describe('ExecutionService', () => {
 				 * Assert
 				 */
 				expect(concurrencyControl.remove).not.toHaveBeenCalled();
-				expect(activeExecutions.stopExecution).toHaveBeenCalledWith(execution.id);
+				expect(activeExecutions.stopExecution).toHaveBeenCalledWith(
+					execution.id,
+					expect.any(ManualExecutionCancelledError),
+				);
 				expect(waitTracker.stopExecution).not.toHaveBeenCalled();
 				expect(executionRepository.stopDuringRun).toHaveBeenCalledWith(execution);
 			});
@@ -152,7 +155,10 @@ describe('ExecutionService', () => {
 				 * Assert
 				 */
 				expect(concurrencyControl.remove).not.toHaveBeenCalled();
-				expect(activeExecutions.stopExecution).toHaveBeenCalledWith(execution.id);
+				expect(activeExecutions.stopExecution).toHaveBeenCalledWith(
+					execution.id,
+					expect.any(ManualExecutionCancelledError),
+				);
 				expect(waitTracker.stopExecution).toHaveBeenCalledWith(execution.id);
 				expect(executionRepository.stopDuringRun).toHaveBeenCalledWith(execution);
 			});
@@ -221,7 +227,10 @@ describe('ExecutionService', () => {
 					 * Assert
 					 */
 					expect(stopInRegularModeSpy).not.toHaveBeenCalled();
-					expect(activeExecutions.stopExecution).toHaveBeenCalledWith(execution.id);
+					expect(activeExecutions.stopExecution).toHaveBeenCalledWith(
+						execution.id,
+						expect.any(ManualExecutionCancelledError),
+					);
 					expect(executionRepository.stopDuringRun).toHaveBeenCalledWith(execution);
 
 					expect(concurrencyControl.remove).not.toHaveBeenCalled();

--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -26,6 +26,7 @@ import type {
 } from 'n8n-workflow';
 import {
 	ExecutionStatusList,
+	ManualExecutionCancelledError,
 	UnexpectedError,
 	UserError,
 	Workflow,
@@ -528,7 +529,10 @@ export class ExecutionService {
 		}
 
 		if (this.activeExecutions.has(execution.id)) {
-			this.activeExecutions.stopExecution(execution.id);
+			this.activeExecutions.stopExecution(
+				execution.id,
+				new ManualExecutionCancelledError(execution.id),
+			);
 		}
 
 		if (this.waitTracker.has(execution.id)) {
@@ -540,7 +544,10 @@ export class ExecutionService {
 
 	private async stopInScalingMode(execution: IExecutionResponse) {
 		if (this.activeExecutions.has(execution.id)) {
-			this.activeExecutions.stopExecution(execution.id);
+			this.activeExecutions.stopExecution(
+				execution.id,
+				new ManualExecutionCancelledError(execution.id),
+			);
 		}
 
 		if (this.waitTracker.has(execution.id)) {

--- a/packages/cli/src/scaling/__tests__/scaling.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/scaling.service.test.ts
@@ -5,7 +5,7 @@ import { Container } from '@n8n/di';
 import * as BullModule from 'bull';
 import { mock } from 'jest-mock-extended';
 import { InstanceSettings } from 'n8n-core';
-import { ApplicationError, ExecutionCancelledError } from 'n8n-workflow';
+import { ApplicationError, ManualExecutionCancelledError } from 'n8n-workflow';
 
 import type { ActiveExecutions } from '@/active-executions';
 
@@ -296,7 +296,7 @@ describe('ScalingService', () => {
 
 			expect(job.progress).toHaveBeenCalledWith({ kind: 'abort-job' });
 			expect(job.discard).toHaveBeenCalled();
-			expect(job.moveToFailed).toHaveBeenCalledWith(new ExecutionCancelledError('123'), true);
+			expect(job.moveToFailed).toHaveBeenCalledWith(new ManualExecutionCancelledError('123'), true);
 			expect(result).toBe(true);
 		});
 

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -10,8 +10,8 @@ import {
 	sleep,
 	jsonStringify,
 	ensureError,
-	ExecutionCancelledError,
 	UnexpectedError,
+	ManualExecutionCancelledError,
 } from 'n8n-workflow';
 import type { IExecuteResponsePromiseData } from 'n8n-workflow';
 import assert, { strict } from 'node:assert';
@@ -230,7 +230,7 @@ export class ScalingService {
 			if (await job.isActive()) {
 				await job.progress({ kind: 'abort-job' }); // being processed by worker
 				await job.discard(); // prevent retries
-				await job.moveToFailed(new ExecutionCancelledError(job.data.executionId), true); // remove from queue
+				await job.moveToFailed(new ManualExecutionCancelledError(job.data.executionId), true); // remove from queue
 				return true;
 			}
 

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -17,7 +17,12 @@ import type {
 	WorkflowExecuteMode,
 	IWorkflowExecutionDataProcess,
 } from 'n8n-workflow';
-import { ExecutionCancelledError, Workflow } from 'n8n-workflow';
+import {
+	ExecutionCancelledError,
+	ManualExecutionCancelledError,
+	TimeoutExecutionCancelledError,
+	Workflow,
+} from 'n8n-workflow';
 import PCancelable from 'p-cancelable';
 
 import { ActiveExecutions } from '@/active-executions';
@@ -316,10 +321,16 @@ export class WorkflowRunner {
 					timeout = Math.max(timeout - (now - data.startedAt.getTime()), 0);
 				}
 				if (timeout === 0) {
-					this.activeExecutions.stopExecution(executionId);
+					this.activeExecutions.stopExecution(
+						executionId,
+						new TimeoutExecutionCancelledError(executionId),
+					);
 				} else {
 					executionTimeout = setTimeout(() => {
-						void this.activeExecutions.stopExecution(executionId);
+						void this.activeExecutions.stopExecution(
+							executionId,
+							new TimeoutExecutionCancelledError(executionId),
+						);
 					}, timeout);
 				}
 			}
@@ -407,7 +418,7 @@ export class WorkflowRunner {
 					// We use "getLifecycleHooksForScalingWorker" as "getLifecycleHooksForScalingMain" does not contain the
 					// "workflowExecuteAfter" which we require.
 					const lifecycleHooks = getLifecycleHooksForScalingWorker(data, executionId);
-					const error = new ExecutionCancelledError(executionId);
+					const error = new ManualExecutionCancelledError(executionId);
 					await this.processError(
 						error,
 						new Date(),

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/supply-data-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/supply-data-context.test.ts
@@ -16,7 +16,7 @@ import type {
 	NodeConnectionType,
 	IRunData,
 } from 'n8n-workflow';
-import { ApplicationError, ExecutionCancelledError, NodeConnectionTypes } from 'n8n-workflow';
+import { ApplicationError, ManualExecutionCancelledError, NodeConnectionTypes } from 'n8n-workflow';
 
 import { describeCommonTests } from './shared-tests';
 import { SupplyDataContext } from '../supply-data-context';
@@ -256,7 +256,7 @@ describe('SupplyDataContext', () => {
 
 	describe('addExecutionDataFunctions', () => {
 		it('should preserve canceled status when execution is aborted and output has error', async () => {
-			const errorData = new ExecutionCancelledError('Execution was aborted');
+			const errorData = new ManualExecutionCancelledError('Execution was aborted');
 			const abortedSignal = mock<AbortSignal>({ aborted: true });
 			const mockHooks = {
 				runHook: jest.fn().mockResolvedValue(undefined),

--- a/packages/workflow/src/errors/execution-cancelled.error.ts
+++ b/packages/workflow/src/errors/execution-cancelled.error.ts
@@ -1,10 +1,32 @@
 import { ExecutionBaseError } from './abstract/execution-base.error';
 
-export class ExecutionCancelledError extends ExecutionBaseError {
+export abstract class ExecutionCancelledError extends ExecutionBaseError {
+	// NOTE: prefer one of the more specific
 	constructor(executionId: string) {
 		super('The execution was cancelled', {
 			level: 'warning',
 			extra: { executionId },
 		});
+	}
+}
+
+export class ManualExecutionCancelledError extends ExecutionCancelledError {
+	constructor(executionId: string) {
+		super(executionId);
+		this.message = 'The execution was cancelled manually';
+	}
+}
+
+export class TimeoutExecutionCancelledError extends ExecutionCancelledError {
+	constructor(executionId: string) {
+		super(executionId);
+		this.message = 'The execution was cancelled because it timed out';
+	}
+}
+
+export class SystemShutdownExecutionCancelledError extends ExecutionCancelledError {
+	constructor(executionId: string) {
+		super(executionId);
+		this.message = 'The execution was cancelled because the system is shutting down';
 	}
 }

--- a/packages/workflow/src/errors/index.ts
+++ b/packages/workflow/src/errors/index.ts
@@ -4,7 +4,12 @@ export { UnexpectedError, type UnexpectedErrorOptions } from './base/unexpected.
 export { UserError, type UserErrorOptions } from './base/user.error';
 export { ApplicationError } from '@n8n/errors';
 export { ExpressionError } from './expression.error';
-export { ExecutionCancelledError } from './execution-cancelled.error';
+export {
+	ExecutionCancelledError,
+	ManualExecutionCancelledError,
+	SystemShutdownExecutionCancelledError,
+	TimeoutExecutionCancelledError,
+} from './execution-cancelled.error';
 export { NodeApiError } from './node-api.error';
 export { NodeOperationError } from './node-operation.error';
 export { WorkflowConfigurationError } from './workflow-configuration.error';

--- a/packages/workflow/src/utils.ts
+++ b/packages/workflow/src/utils.ts
@@ -5,7 +5,7 @@ import FormData from 'form-data';
 import merge from 'lodash/merge';
 
 import { ALPHABET } from './constants';
-import { ExecutionCancelledError } from './errors/execution-cancelled.error';
+import { ManualExecutionCancelledError } from './errors/execution-cancelled.error';
 import type { BinaryFileType, IDisplayOptions, INodeProperties, JsonObject } from './interfaces';
 import * as LoggerProxy from './logger-proxy';
 
@@ -211,7 +211,7 @@ export const sleep = async (ms: number): Promise<void> =>
 export const sleepWithAbort = async (ms: number, abortSignal?: AbortSignal): Promise<void> =>
 	await new Promise((resolve, reject) => {
 		if (abortSignal?.aborted) {
-			reject(new ExecutionCancelledError(''));
+			reject(new ManualExecutionCancelledError(''));
 			return;
 		}
 
@@ -219,7 +219,7 @@ export const sleepWithAbort = async (ms: number, abortSignal?: AbortSignal): Pro
 
 		const abortHandler = () => {
 			clearTimeout(timeout);
-			reject(new ExecutionCancelledError(''));
+			reject(new ManualExecutionCancelledError(''));
 		};
 
 		abortSignal?.addEventListener('abort', abortHandler, { once: true });

--- a/packages/workflow/test/utils.test.ts
+++ b/packages/workflow/test/utils.test.ts
@@ -1,6 +1,6 @@
 import { ALPHABET } from '../src/constants';
 import { ApplicationError } from '@n8n/errors';
-import { ExecutionCancelledError } from '../src/errors/execution-cancelled.error';
+import { ManualExecutionCancelledError } from '../src/errors/execution-cancelled.error';
 import {
 	jsonParse,
 	jsonStringify,
@@ -415,7 +415,7 @@ describe('sleepWithAbort', () => {
 		abortController.abort();
 
 		await expect(sleepWithAbort(1000, abortController.signal)).rejects.toThrow(
-			ExecutionCancelledError,
+			ManualExecutionCancelledError,
 		);
 	});
 
@@ -427,7 +427,7 @@ describe('sleepWithAbort', () => {
 
 		const start = Date.now();
 		await expect(sleepWithAbort(1000, abortController.signal)).rejects.toThrow(
-			ExecutionCancelledError,
+			ManualExecutionCancelledError,
 		);
 		const end = Date.now();
 		const elapsed = end - start;
@@ -454,7 +454,7 @@ describe('sleepWithAbort', () => {
 		const sleepPromise = sleepWithAbort(1000, abortController.signal);
 		setTimeout(() => abortController.abort(), 50);
 
-		await expect(sleepPromise).rejects.toThrow(ExecutionCancelledError);
+		await expect(sleepPromise).rejects.toThrow(ManualExecutionCancelledError);
 
 		// clearTimeout should have been called to clean up
 		expect(clearTimeoutSpy).toHaveBeenCalled();


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add explicit cancellation reasons across the execution lifecycle to improve clarity and downstream handling. Addresses Linear 755227 by introducing specific errors for manual cancel, timeout, and system shutdown, and propagating them through the engine, services, and persistence.

- New Features
  - Added ManualExecutionCancelledError, TimeoutExecutionCancelledError, and SystemShutdownExecutionCancelledError, and export them from workflow errors.
  - ActiveExecutions.stopExecution now requires a specific ExecutionCancelledError; all call sites updated (manual cancel, timeout, shutdown).
  - WorkflowRunner applies TimeoutExecutionCancelledError on immediate/scheduled timeouts; WorkflowExecute tracks timedOut and sets status to canceled with the correct error; repository stopDuringRun stores ManualExecutionCancelledError.

- Migration
  - Update calls to ActiveExecutions.stopExecution(executionId, error) to pass a specific cancellation error.
  - Replace generic ExecutionCancelledError usage with ManualExecutionCancelledError unless canceling due to timeout or shutdown.

<!-- End of auto-generated description by cubic. -->

