### PR TITLE
n8n-auto-pr (N8N - 756592)

### DIFF
--- a/packages/frontend/editor-ui/src/components/CommunityPlusEnrollmentModal.test.ts
+++ b/packages/frontend/editor-ui/src/components/CommunityPlusEnrollmentModal.test.ts
@@ -33,6 +33,14 @@ vi.mock('@/composables/useTelemetry', () => {
 	};
 });
 
+vi.mock('@/composables/useWorkflowState', async () => {
+	const actual = await vi.importActual('@/composables/useWorkflowState');
+	return {
+		...actual,
+		injectWorkflowState: vi.fn(),
+	};
+});
+
 const renderComponent = createComponentRenderer(CommunityPlusEnrollmentModal, {
 	global: {
 		stubs: {

--- a/packages/frontend/editor-ui/src/components/InputPanel.test.ts
+++ b/packages/frontend/editor-ui/src/components/InputPanel.test.ts
@@ -12,6 +12,7 @@ import {
 } from 'n8n-workflow';
 import { setActivePinia } from 'pinia';
 import { mockedStore } from '../__tests__/utils';
+import { useWorkflowState } from '@/composables/useWorkflowState';
 
 vi.mock('vue-router', () => {
 	return {
@@ -54,6 +55,7 @@ const render = (props: Partial<Props> = {}, pinData?: INodeExecutionData[], runD
 
 	const workflow = createTestWorkflow({ nodes, connections });
 	const workflowStore = useWorkflowsStore();
+	const workflowState = useWorkflowState();
 
 	workflowStore.setWorkflow(workflow);
 
@@ -62,7 +64,7 @@ const render = (props: Partial<Props> = {}, pinData?: INodeExecutionData[], runD
 	}
 
 	if (runData) {
-		workflowStore.setWorkflowExecutionData({
+		workflowState.setWorkflowExecutionData({
 			id: '',
 			workflowData: {
 				id: '',

--- a/packages/frontend/editor-ui/src/components/NodeExecuteButton.test.ts
+++ b/packages/frontend/editor-ui/src/components/NodeExecuteButton.test.ts
@@ -23,6 +23,7 @@ import { usePinnedData } from '@/composables/usePinnedData';
 import { useMessage } from '@/composables/useMessage';
 import { useToast } from '@/composables/useToast';
 import * as buttonParameterUtils from '@/components/ButtonParameter/utils';
+import { useWorkflowState } from '@/composables/useWorkflowState';
 
 vi.mock('vue-router', () => ({
 	useRouter: () => ({}),
@@ -276,7 +277,7 @@ describe('NodeExecuteButton', () => {
 	it('stops execution when clicking button while workflow is running', async () => {
 		workflowsStore.isWorkflowRunning = true;
 		nodeTypesStore.isTriggerNode = () => true;
-		workflowsStore.setActiveExecutionId('test-execution-id');
+		useWorkflowState().setActiveExecutionId('test-execution-id');
 		workflowsStore.isNodeExecuting.mockReturnValue(true);
 		workflowsStore.getNodeByName.mockReturnValue(
 			mockNode({ name: 'test-node', type: SET_NODE_TYPE }),

--- a/packages/frontend/editor-ui/src/components/WorkflowSettings.vue
+++ b/packages/frontend/editor-ui/src/components/WorkflowSettings.vue
@@ -24,6 +24,7 @@ import { getResourcePermissions } from '@n8n/permissions';
 import { useI18n } from '@n8n/i18n';
 import { useTelemetry } from '@/composables/useTelemetry';
 import { useDebounce } from '@/composables/useDebounce';
+import { injectWorkflowState } from '@/composables/useWorkflowState';
 
 import { ElCol, ElRow, ElSwitch } from 'element-plus';
 import { N8nButton, N8nIcon, N8nInput, N8nOption, N8nSelect, N8nTooltip } from '@n8n/design-system';
@@ -38,6 +39,7 @@ const rootStore = useRootStore();
 const settingsStore = useSettingsStore();
 const sourceControlStore = useSourceControlStore();
 const workflowsStore = useWorkflowsStore();
+const workflowState = injectWorkflowState();
 const workflowsEEStore = useWorkflowsEEStore();
 
 const isLoading = ref(true);
@@ -365,7 +367,7 @@ const saveSettings = async () => {
 
 	const oldSettings = deepCopy(workflowsStore.workflowSettings);
 
-	workflowsStore.setWorkflowSettings(localWorkflowSettings);
+	workflowState.setWorkflowSettings(localWorkflowSettings);
 
 	isLoading.value = false;
 

--- a/packages/frontend/editor-ui/src/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasOperations.test.ts
@@ -8,7 +8,6 @@ import type {
 	WorkflowExecuteMode,
 } from 'n8n-workflow';
 import { NodeConnectionTypes, NodeHelpers, UserError } from 'n8n-workflow';
-import { useCanvasOperations } from '@/composables/useCanvasOperations';
 import type { CanvasConnection, CanvasNode } from '@/types';
 import { CanvasConnectionMode } from '@/types';
 import type {
@@ -57,6 +56,11 @@ import type { CanvasLayoutEvent } from './useCanvasLayout';
 import { useTelemetry } from './useTelemetry';
 import { useToast } from '@/composables/useToast';
 import * as nodeHelpers from '@/composables/useNodeHelpers';
+import {
+	injectWorkflowState,
+	useWorkflowState,
+	type WorkflowState,
+} from '@/composables/useWorkflowState';
 
 import { TelemetryHelpers } from 'n8n-workflow';
 import { useRouter } from 'vue-router';
@@ -74,6 +78,8 @@ vi.mock('vue-router', () => ({
 		replace: mockRouterReplace,
 	}),
 }));
+
+import { useCanvasOperations } from '@/composables/useCanvasOperations';
 
 vi.mock('n8n-workflow', async (importOriginal) => {
 	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
@@ -118,6 +124,14 @@ vi.mock('@/composables/useToast', () => {
 	};
 });
 
+vi.mock('@/composables/useWorkflowState', async () => {
+	const actual = await vi.importActual('@/composables/useWorkflowState');
+	return {
+		...actual,
+		injectWorkflowState: vi.fn(),
+	};
+});
+
 describe('useCanvasOperations', () => {
 	const workflowId = 'test';
 	const initialState = {
@@ -140,9 +154,14 @@ describe('useCanvasOperations', () => {
 		},
 	};
 
+	let workflowState: WorkflowState;
+
 	beforeEach(() => {
 		const pinia = createTestingPinia({ initialState });
 		setActivePinia(pinia);
+
+		workflowState = useWorkflowState();
+		vi.mocked(injectWorkflowState).mockReturnValue(workflowState);
 
 		vi.clearAllMocks();
 	});
@@ -2976,13 +2995,14 @@ describe('useCanvasOperations', () => {
 					credentialsUpdated: credentialsUpdatedRef,
 				};
 			});
+			const resetStateSpy = vi.spyOn(workflowState, 'resetState');
 
 			nodeCreatorStore.setNodeCreatorState = vi.fn();
 			nodeCreatorStore.setShowScrim = vi.fn();
 			workflowsStore.removeTestWebhook = vi.fn();
 			workflowsStore.resetWorkflow = vi.fn();
 			workflowsStore.resetState = vi.fn();
-			workflowsStore.setActiveExecutionId = vi.fn();
+			const setActiveExecutionId = vi.spyOn(workflowState, 'setActiveExecutionId');
 			uiStore.resetLastInteractedWith = vi.fn();
 			executionsStore.activeExecution = null;
 
@@ -3017,9 +3037,9 @@ describe('useCanvasOperations', () => {
 			expect(nodeCreatorStore.setShowScrim).toHaveBeenCalledWith(false);
 			expect(workflowsStore.removeTestWebhook).toHaveBeenCalledWith('workflow-id');
 			expect(workflowsStore.resetWorkflow).toHaveBeenCalled();
-			expect(workflowsStore.resetState).toHaveBeenCalled();
+			expect(resetStateSpy).toHaveBeenCalled();
 			expect(workflowsStore.currentWorkflowExecutions).toEqual([]);
-			expect(workflowsStore.setActiveExecutionId).toHaveBeenCalledWith(undefined);
+			expect(setActiveExecutionId).toHaveBeenCalledWith(undefined);
 			expect(uiStore.resetLastInteractedWith).toHaveBeenCalled();
 			expect(uiStore.stateIsDirty).toBe(false);
 			expect(executionsStore.activeExecution).toBeNull();
@@ -3142,6 +3162,8 @@ describe('useCanvasOperations', () => {
 		it('should initialize workspace and set execution data when execution is found', async () => {
 			const workflowsStore = mockedStore(useWorkflowsStore);
 			const uiStore = mockedStore(useUIStore);
+			const setWorkflowExecutionData = vi.spyOn(workflowState, 'setWorkflowExecutionData');
+
 			const { openExecution } = useCanvasOperations();
 
 			const executionId = '123';
@@ -3159,7 +3181,7 @@ describe('useCanvasOperations', () => {
 
 			const result = await openExecution(executionId);
 
-			expect(workflowsStore.setWorkflowExecutionData).toHaveBeenCalledWith(executionData);
+			expect(setWorkflowExecutionData).toHaveBeenCalledWith(executionData);
 			expect(uiStore.stateIsDirty).toBe(false);
 			expect(result).toEqual(executionData);
 		});
@@ -3605,6 +3627,8 @@ describe('useCanvasOperations', () => {
 				renameNode: vi.fn(),
 			});
 
+			const setWorkflowName = vi.spyOn(workflowState, 'setWorkflowName');
+
 			const canvasOperations = useCanvasOperations();
 			const workflowDataWithName = {
 				name: 'Test Workflow Name',
@@ -3614,7 +3638,7 @@ describe('useCanvasOperations', () => {
 
 			await canvasOperations.importWorkflowData(workflowDataWithName, 'file');
 
-			expect(workflowsStore.setWorkflowName).toHaveBeenCalledWith({
+			expect(setWorkflowName).toHaveBeenCalledWith({
 				newName: 'Test Workflow Name',
 				setStateDirty: true,
 			});

--- a/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
@@ -105,6 +105,7 @@ import { deepCopy, NodeConnectionTypes, NodeHelpers, TelemetryHelpers } from 'n8
 import { computed, nextTick, ref } from 'vue';
 import { useClipboard } from '@/composables/useClipboard';
 import { useUniqueNodeName } from '@/composables/useUniqueNodeName';
+import { injectWorkflowState } from '@/composables/useWorkflowState';
 import { isPresent } from '../utils/typesUtils';
 import { useProjectsStore } from '@/stores/projects.store';
 import type { CanvasLayoutEvent } from './useCanvasLayout';
@@ -153,6 +154,7 @@ type AddNodeOptions = AddNodesBaseOptions & {
 export function useCanvasOperations() {
 	const rootStore = useRootStore();
 	const workflowsStore = useWorkflowsStore();
+	const workflowState = injectWorkflowState();
 	const credentialsStore = useCredentialsStore();
 	const historyStore = useHistoryStore();
 	const uiStore = useUIStore();
@@ -1659,9 +1661,9 @@ export function useCanvasOperations() {
 
 		// Reset editable workflow state
 		workflowsStore.resetWorkflow();
-		workflowsStore.resetState();
+		workflowState.resetState();
 		workflowsStore.currentWorkflowExecutions = [];
-		workflowsStore.setActiveExecutionId(undefined);
+		workflowState.setActiveExecutionId(undefined);
 
 		// Reset actions
 		uiStore.resetLastInteractedWith();
@@ -2018,7 +2020,7 @@ export function useCanvasOperations() {
 			}
 
 			if (workflowData.name) {
-				workflowsStore.setWorkflowName({ newName: workflowData.name, setStateDirty: true });
+				workflowState.setWorkflowName({ newName: workflowData.name, setStateDirty: true });
 			}
 
 			return workflowData;
@@ -2220,7 +2222,7 @@ export function useCanvasOperations() {
 
 		initializeWorkspace(data.workflowData);
 
-		workflowsStore.setWorkflowExecutionData(data);
+		workflowState.setWorkflowExecutionData(data);
 
 		if (!['manual', 'evaluation'].includes(data.mode)) {
 			workflowsStore.setWorkflowPinData({});

--- a/packages/frontend/editor-ui/src/composables/useExecutionDebugging.ts
+++ b/packages/frontend/editor-ui/src/composables/useExecutionDebugging.ts
@@ -3,6 +3,7 @@ import { useRouter } from 'vue-router';
 import { useI18n } from '@n8n/i18n';
 import { useMessage } from '@/composables/useMessage';
 import { useToast } from '@/composables/useToast';
+import { injectWorkflowState } from '@/composables/useWorkflowState';
 import {
 	DEBUG_PAYWALL_MODAL_KEY,
 	EnterpriseEditionFeature,
@@ -27,6 +28,7 @@ export const useExecutionDebugging = () => {
 	const message = useMessage();
 	const toast = useToast();
 	const workflowsStore = useWorkflowsStore();
+	const workflowState = injectWorkflowState();
 	const settingsStore = useSettingsStore();
 	const uiStore = useUIStore();
 
@@ -98,8 +100,8 @@ export const useExecutionDebugging = () => {
 		}
 
 		// Set execution data
-		workflowsStore.resetAllNodesIssues();
-		workflowsStore.setWorkflowExecutionData(execution);
+		workflowState.resetAllNodesIssues();
+		workflowState.setWorkflowExecutionData(execution);
 
 		// Pin data of all nodes which do not have a parent node
 		const pinnableNodes = workflowNodes.filter(

--- a/packages/frontend/editor-ui/src/composables/useNodeDirtiness.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useNodeDirtiness.test.ts
@@ -13,6 +13,7 @@ import { createTestingPinia } from '@pinia/testing';
 import { NodeConnectionTypes, type IConnections, type IRunData } from 'n8n-workflow';
 import { defineComponent } from 'vue';
 import { createRouter, createWebHistory, type RouteLocationNormalizedLoaded } from 'vue-router';
+import { useWorkflowState } from './useWorkflowState';
 
 describe(useNodeDirtiness, () => {
 	let nodeTypeStore: ReturnType<typeof useNodeTypesStore>;
@@ -126,7 +127,8 @@ describe(useNodeDirtiness, () => {
 
 			const runAt = new Date(+WORKFLOW_UPDATED_AT + 1000);
 
-			workflowsStore.setWorkflowExecutionData({
+			const workflowState = useWorkflowState();
+			workflowState.setWorkflowExecutionData({
 				id: workflowsStore.workflow.id,
 				finished: true,
 				mode: 'manual',
@@ -434,7 +436,8 @@ describe(useNodeDirtiness, () => {
 			});
 		}
 
-		workflowsStore.setWorkflowExecutionData({
+		const workflowState = useWorkflowState();
+		workflowState.setWorkflowExecutionData({
 			id: workflow.id,
 			finished: true,
 			mode: 'manual',

--- a/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/executionFinished.test.ts
+++ b/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/executionFinished.test.ts
@@ -9,6 +9,7 @@ import type { ITaskData } from 'n8n-workflow';
 import { EVALUATION_TRIGGER_NODE_TYPE } from 'n8n-workflow';
 import type { INodeUi } from '@/Interface';
 import type { Router } from 'vue-router';
+import type { WorkflowState } from '@/composables/useWorkflowState';
 import { mockedStore } from '@/__tests__/utils';
 import { useWorkflowsStore } from '@/stores/workflows.store';
 import { createTestingPinia } from '@pinia/testing';
@@ -201,6 +202,7 @@ describe('executionFinished', () => {
 			},
 			{
 				router: mock<Router>(),
+				workflowState: mock<WorkflowState>(),
 			},
 		);
 

--- a/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/executionRecovered.ts
+++ b/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/executionRecovered.ts
@@ -10,10 +10,11 @@ import {
 } from './executionFinished';
 import { useWorkflowsStore } from '@/stores/workflows.store';
 import type { useRouter } from 'vue-router';
+import type { WorkflowState } from '@/composables/useWorkflowState';
 
 export async function executionRecovered(
 	{ data }: ExecutionRecovered,
-	options: { router: ReturnType<typeof useRouter> },
+	options: { router: ReturnType<typeof useRouter>; workflowState: WorkflowState },
 ) {
 	const workflowsStore = useWorkflowsStore();
 	const uiStore = useUIStore();
@@ -39,8 +40,8 @@ export async function executionRecovered(
 	} else if (execution.status === 'error' || execution.status === 'canceled') {
 		handleExecutionFinishedWithErrorOrCanceled(execution, runExecutionData);
 	} else {
-		handleExecutionFinishedWithOther(false);
+		handleExecutionFinishedWithOther(options.workflowState, false);
 	}
 
-	setRunExecutionData(execution, runExecutionData);
+	setRunExecutionData(execution, runExecutionData, options.workflowState);
 }

--- a/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/executionStarted.ts
+++ b/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/executionStarted.ts
@@ -1,18 +1,22 @@
 import type { ExecutionStarted } from '@n8n/api-types/push/execution';
 import { useWorkflowsStore } from '@/stores/workflows.store';
 import { parse } from 'flatted';
+import type { WorkflowState } from '@/composables/useWorkflowState';
 
 /**
  * Handles the 'executionStarted' event, which happens when a workflow is executed.
  */
-export async function executionStarted({ data }: ExecutionStarted) {
+export async function executionStarted(
+	{ data }: ExecutionStarted,
+	options: { workflowState: WorkflowState },
+) {
 	const workflowsStore = useWorkflowsStore();
 
 	// No workflow execution is ongoing, so we can ignore this event
 	if (typeof workflowsStore.activeExecutionId === 'undefined') {
 		return;
 	} else if (workflowsStore.activeExecutionId === null) {
-		workflowsStore.setActiveExecutionId(data.executionId);
+		options.workflowState.setActiveExecutionId(data.executionId);
 	}
 
 	if (workflowsStore.workflowExecutionData?.data && data.flattedRunData) {

--- a/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/testWebhookDeleted.ts
+++ b/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/testWebhookDeleted.ts
@@ -1,14 +1,18 @@
 import type { TestWebhookDeleted } from '@n8n/api-types/push/webhook';
 import { useWorkflowsStore } from '@/stores/workflows.store';
+import type { WorkflowState } from '@/composables/useWorkflowState';
 
 /**
  * Handles the 'testWebhookDeleted' push message, which is sent when a test webhook is deleted.
  */
-export async function testWebhookDeleted({ data }: TestWebhookDeleted) {
+export async function testWebhookDeleted(
+	{ data }: TestWebhookDeleted,
+	options: { workflowState: WorkflowState },
+) {
 	const workflowsStore = useWorkflowsStore();
 
 	if (data.workflowId === workflowsStore.workflowId) {
 		workflowsStore.executionWaitingForWebhook = false;
-		workflowsStore.setActiveExecutionId(undefined);
+		options.workflowState.setActiveExecutionId(undefined);
 	}
 }

--- a/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/testWebhookReceived.ts
+++ b/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/testWebhookReceived.ts
@@ -1,14 +1,18 @@
 import type { TestWebhookReceived } from '@n8n/api-types/push/webhook';
 import { useWorkflowsStore } from '@/stores/workflows.store';
+import type { WorkflowState } from '@/composables/useWorkflowState';
 
 /**
  * Handles the 'testWebhookReceived' push message, which is sent when a test webhook is received.
  */
-export async function testWebhookReceived({ data }: TestWebhookReceived) {
+export async function testWebhookReceived(
+	{ data }: TestWebhookReceived,
+	options: { workflowState: WorkflowState },
+) {
 	const workflowsStore = useWorkflowsStore();
 
 	if (data.workflowId === workflowsStore.workflowId) {
 		workflowsStore.executionWaitingForWebhook = false;
-		workflowsStore.setActiveExecutionId(data.executionId ?? null);
+		options.workflowState.setActiveExecutionId(data.executionId ?? null);
 	}
 }

--- a/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/workflowFailedToActivate.ts
+++ b/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/workflowFailedToActivate.ts
@@ -1,9 +1,13 @@
 import type { WorkflowFailedToActivate } from '@n8n/api-types/push/workflow';
 import { useToast } from '@/composables/useToast';
+import type { WorkflowState } from '@/composables/useWorkflowState';
 import { useI18n } from '@n8n/i18n';
 import { useWorkflowsStore } from '@/stores/workflows.store';
 
-export async function workflowFailedToActivate({ data }: WorkflowFailedToActivate) {
+export async function workflowFailedToActivate(
+	{ data }: WorkflowFailedToActivate,
+	options: { workflowState: WorkflowState },
+) {
 	const workflowsStore = useWorkflowsStore();
 
 	if (workflowsStore.workflowId !== data.workflowId) {
@@ -11,7 +15,7 @@ export async function workflowFailedToActivate({ data }: WorkflowFailedToActivat
 	}
 
 	workflowsStore.setWorkflowInactive(data.workflowId);
-	workflowsStore.setActive(false);
+	options.workflowState.setActive(false);
 
 	const toast = useToast();
 	const i18n = useI18n();

--- a/packages/frontend/editor-ui/src/composables/usePushConnection/usePushConnection.test.ts
+++ b/packages/frontend/editor-ui/src/composables/usePushConnection/usePushConnection.test.ts
@@ -7,6 +7,7 @@ import type { TestWebhookReceived } from '@n8n/api-types/push/webhook';
 import type { BuilderCreditsPushMessage } from '@n8n/api-types/push/builder-credits';
 import { useRouter } from 'vue-router';
 import type { OnPushMessageHandler } from '@/stores/pushConnection.store';
+import { createPinia, setActivePinia } from 'pinia';
 
 const removeEventListener = vi.fn();
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -45,6 +46,7 @@ vi.mock('vue-router', async () => {
 		useRouter: vi.fn().mockReturnValue({
 			push: vi.fn(),
 		}),
+		useRoute: vi.fn(),
 	};
 });
 
@@ -53,6 +55,8 @@ describe('usePushConnection composable', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+
+		setActivePinia(createPinia());
 
 		const router = useRouter();
 		pushConnection = usePushConnection({ router });
@@ -87,7 +91,7 @@ describe('usePushConnection composable', () => {
 
 		// Verify that the correct handler was called.
 		expect(testWebhookReceived).toHaveBeenCalledTimes(1);
-		expect(testWebhookReceived).toHaveBeenCalledWith(testEvent);
+		expect(testWebhookReceived).toHaveBeenCalledWith(testEvent, expect.any(Object));
 	});
 
 	it('should call removeEventListener when terminate is called', () => {

--- a/packages/frontend/editor-ui/src/composables/usePushConnection/usePushConnection.ts
+++ b/packages/frontend/editor-ui/src/composables/usePushConnection/usePushConnection.ts
@@ -21,11 +21,22 @@ import {
 	workflowActivated,
 	workflowDeactivated,
 } from '@/composables/usePushConnection/handlers';
+import { useWorkflowState, type WorkflowState } from '@/composables/useWorkflowState';
 import { createEventQueue } from '@n8n/utils/event-queue';
 import type { useRouter } from 'vue-router';
 
-export function usePushConnection(options: { router: ReturnType<typeof useRouter> }) {
+export function usePushConnection({
+	router,
+	workflowState,
+}: {
+	router: ReturnType<typeof useRouter>;
+	workflowState?: WorkflowState;
+}) {
 	const pushStore = usePushConnectionStore();
+	const options = {
+		router,
+		workflowState: workflowState ?? useWorkflowState(),
+	};
 
 	const { enqueue } = createEventQueue<PushMessage>(processEvent);
 
@@ -49,9 +60,9 @@ export function usePushConnection(options: { router: ReturnType<typeof useRouter
 	async function processEvent(event: PushMessage) {
 		switch (event.type) {
 			case 'testWebhookDeleted':
-				return await testWebhookDeleted(event);
+				return await testWebhookDeleted(event, options);
 			case 'testWebhookReceived':
-				return await testWebhookReceived(event);
+				return await testWebhookReceived(event, options);
 			case 'reloadNodeType':
 				return await reloadNodeType(event);
 			case 'removeNodeType':
@@ -65,13 +76,13 @@ export function usePushConnection(options: { router: ReturnType<typeof useRouter
 			case 'nodeExecuteAfterData':
 				return await nodeExecuteAfterData(event);
 			case 'executionStarted':
-				return await executionStarted(event);
+				return await executionStarted(event, options);
 			case 'sendWorkerStatusMessage':
 				return await sendWorkerStatusMessage(event);
 			case 'sendConsoleMessage':
 				return await sendConsoleMessage(event);
 			case 'workflowFailedToActivate':
-				return await workflowFailedToActivate(event);
+				return await workflowFailedToActivate(event, options);
 			case 'executionFinished':
 				return await executionFinished(event, options);
 			case 'executionRecovered':

--- a/packages/frontend/editor-ui/src/composables/useRunWorkflow.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useRunWorkflow.test.ts
@@ -14,6 +14,11 @@ import type {
 } from 'n8n-workflow';
 
 import { useRunWorkflow } from '@/composables/useRunWorkflow';
+import {
+	injectWorkflowState,
+	useWorkflowState,
+	type WorkflowState,
+} from '@/composables/useWorkflowState';
 import type { IExecutionResponse, IStartRunData } from '@/Interface';
 import type { WorkflowData } from '@n8n/rest-api-client/api/workflows';
 import { useWorkflowsStore } from '@/stores/workflows.store';
@@ -37,7 +42,6 @@ vi.mock('@/stores/workflows.store', () => {
 		subWorkflowExecutionError: null,
 		getWorkflowRunData: null,
 		workflowExecutionData: null,
-		setWorkflowExecutionData: vi.fn(),
 		activeExecutionId: undefined,
 		previousExecutionId: undefined,
 		nodesIssuesExist: false,
@@ -56,9 +60,13 @@ vi.mock('@/stores/workflows.store', () => {
 		incomingConnectionsByNodeName: vi.fn(),
 		outgoingConnectionsByNodeName: vi.fn(),
 		markExecutionAsStopped: vi.fn(),
-		setActiveExecutionId: vi.fn((id: string | null | undefined) => {
-			storeState.activeExecutionId = id;
-		}),
+		private: {
+			setWorkflowSettings: vi.fn(),
+			setActiveExecutionId: vi.fn((id: string | null | undefined) => {
+				storeState.activeExecutionId = id;
+			}),
+			setWorkflowName: vi.fn(),
+		},
 	};
 
 	return {
@@ -132,6 +140,16 @@ vi.mock('vue-router', async (importOriginal) => {
 	};
 });
 
+vi.mock('@/composables/useWorkflowState', async () => {
+	const actual = await vi.importActual('@/composables/useWorkflowState');
+	return {
+		...actual,
+		injectWorkflowState: vi.fn(),
+	};
+});
+
+let workflowState: WorkflowState;
+
 describe('useRunWorkflow({ router })', () => {
 	let pushConnectionStore: ReturnType<typeof usePushConnectionStore>;
 	let uiStore: ReturnType<typeof useUIStore>;
@@ -150,12 +168,18 @@ describe('useRunWorkflow({ router })', () => {
 		workflowsStore = useWorkflowsStore();
 		agentRequestStore = useAgentRequestStore();
 
+		workflowState = vi.mocked(useWorkflowState());
+		// vi.mocked(workflowState.setActiveExecutionId).mockImplementation((id: string | null | undefined) => {
+		// 	workflowsStore.activeExecutionId = id;
+		// }
+		vi.mocked(injectWorkflowState).mockReturnValue(workflowState);
+
 		router = useRouter();
 		workflowHelpers = useWorkflowHelpers();
 	});
 
 	afterEach(() => {
-		vi.mocked(workflowsStore).setActiveExecutionId(undefined);
+		workflowState.setActiveExecutionId(undefined);
 		vi.clearAllMocks();
 	});
 
@@ -171,6 +195,7 @@ describe('useRunWorkflow({ router })', () => {
 		});
 
 		it('should successfully run a workflow', async () => {
+			const setActiveExecutionId = vi.spyOn(workflowState, 'setActiveExecutionId');
 			const { runWorkflowApi } = useRunWorkflow({ router });
 
 			vi.mocked(pushConnectionStore).isConnected = true;
@@ -181,8 +206,8 @@ describe('useRunWorkflow({ router })', () => {
 			const response = await runWorkflowApi({} as IStartRunData);
 
 			expect(response).toEqual(mockResponse);
-			expect(workflowsStore.setActiveExecutionId).toHaveBeenNthCalledWith(1, null);
-			expect(workflowsStore.setActiveExecutionId).toHaveBeenNthCalledWith(2, '123');
+			expect(setActiveExecutionId).toHaveBeenNthCalledWith(1, null);
+			expect(setActiveExecutionId).toHaveBeenNthCalledWith(2, '123');
 			expect(workflowsStore.executionWaitingForWebhook).toBe(false);
 		});
 
@@ -202,13 +227,14 @@ describe('useRunWorkflow({ router })', () => {
 		});
 
 		it('should handle workflow run failure', async () => {
+			const setActiveExecutionId = vi.spyOn(workflowState, 'setActiveExecutionId');
 			const { runWorkflowApi } = useRunWorkflow({ router });
 
 			vi.mocked(pushConnectionStore).isConnected = true;
 			vi.mocked(workflowsStore).runWorkflow.mockRejectedValue(new Error('Failed to run workflow'));
 
 			await expect(runWorkflowApi({} as IStartRunData)).rejects.toThrow('Failed to run workflow');
-			expect(workflowsStore.setActiveExecutionId).toHaveBeenCalledWith(undefined);
+			expect(setActiveExecutionId).toHaveBeenCalledWith(undefined);
 		});
 
 		it('should set waitingForWebhook if response indicates waiting', async () => {
@@ -399,7 +425,7 @@ describe('useRunWorkflow({ router })', () => {
 
 		it('should return undefined if UI action "workflowRunning" is active', async () => {
 			const { runWorkflow } = useRunWorkflow({ router });
-			vi.mocked(workflowsStore).setActiveExecutionId('123');
+			workflowState.setActiveExecutionId('123');
 			const result = await runWorkflow({});
 			expect(result).toBeUndefined();
 		});
@@ -746,6 +772,9 @@ describe('useRunWorkflow({ router })', () => {
 			vi.mocked(workflowHelpers).getWorkflowDataToSave.mockResolvedValue(workflowData);
 			vi.mocked(workflowsStore).getWorkflowRunData = mockRunData;
 			vi.mocked(agentRequestStore).getAgentRequest.mockReturnValue(agentRequest);
+
+			const setWorkflowExecutionData = vi.spyOn(workflowState, 'setWorkflowExecutionData');
+
 			// ACT
 			const result = await runWorkflow({ destinationNode: 'Test node' });
 
@@ -771,8 +800,8 @@ describe('useRunWorkflow({ router })', () => {
 				workflowData,
 			});
 			expect(result).toEqual(mockExecutionResponse);
-			expect(workflowsStore.setWorkflowExecutionData).toHaveBeenCalledTimes(1);
-			expect(workflowsStore.setWorkflowExecutionData).toHaveBeenCalledWith(dataCaptor);
+			expect(setWorkflowExecutionData).toHaveBeenCalledTimes(1);
+			expect(setWorkflowExecutionData).toHaveBeenCalledWith(dataCaptor);
 			expect(dataCaptor.value).toMatchObject({ data: { resultData: { runData: mockRunData } } });
 		});
 
@@ -794,13 +823,15 @@ describe('useRunWorkflow({ router })', () => {
 			);
 			vi.mocked(workflowsStore).getWorkflowRunData = mockRunData;
 
+			const setWorkflowExecutionData = vi.spyOn(workflowState, 'setWorkflowExecutionData');
+
 			// ACT
 			const result = await runWorkflow({ destinationNode: 'some node name' });
 
 			// ASSERT
 			expect(result).toEqual(mockExecutionResponse);
-			expect(workflowsStore.setWorkflowExecutionData).toHaveBeenCalledTimes(1);
-			expect(workflowsStore.setWorkflowExecutionData).toHaveBeenCalledWith(dataCaptor);
+			expect(setWorkflowExecutionData).toHaveBeenCalledTimes(1);
+			expect(setWorkflowExecutionData).toHaveBeenCalledWith(dataCaptor);
 			expect(dataCaptor.value).toMatchObject({ data: { resultData: { runData: mockRunData } } });
 		});
 
@@ -842,13 +873,15 @@ describe('useRunWorkflow({ router })', () => {
 				nodes: [],
 			} as unknown as WorkflowData);
 
+			const setWorkflowExecutionData = vi.spyOn(workflowState, 'setWorkflowExecutionData');
+
 			// Simulate failed execution start
 			vi.mocked(workflowsStore).runWorkflow.mockRejectedValueOnce(new Error());
 
 			await runWorkflow({});
 
 			expect(workflowsStore.runWorkflow).toHaveBeenCalledTimes(1);
-			expect(workflowsStore.setWorkflowExecutionData).lastCalledWith(null);
+			expect(setWorkflowExecutionData).lastCalledWith(null);
 		});
 	});
 
@@ -1001,7 +1034,7 @@ describe('useRunWorkflow({ router })', () => {
 			const getExecutionSpy = vi.spyOn(workflowsStore, 'getExecution');
 
 			workflowsStore.activeWorkflows = ['test-wf-id'];
-			workflowsStore.setActiveExecutionId('test-exec-id');
+			workflowState.setActiveExecutionId('test-exec-id');
 			workflowsStore.executionWaitingForWebhook = false;
 
 			getExecutionSpy.mockResolvedValue(executionData);

--- a/packages/frontend/editor-ui/src/composables/useRunWorkflow.ts
+++ b/packages/frontend/editor-ui/src/composables/useRunWorkflow.ts
@@ -47,6 +47,7 @@ import { useCanvasOperations } from './useCanvasOperations';
 import { useAgentRequestStore } from '@n8n/stores/useAgentRequestStore';
 import { useWorkflowSaving } from './useWorkflowSaving';
 import { computed } from 'vue';
+import { injectWorkflowState } from './useWorkflowState';
 
 export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof useRouter> }) {
 	const nodeHelpers = useNodeHelpers();
@@ -62,6 +63,7 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 	const rootStore = useRootStore();
 	const pushConnectionStore = usePushConnectionStore();
 	const workflowsStore = useWorkflowsStore();
+	const workflowState = injectWorkflowState();
 	const executionsStore = useExecutionsStore();
 	const { dirtinessByName } = useNodeDirtiness();
 	const { startChat } = useCanvasOperations();
@@ -93,24 +95,24 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 		workflowsStore.subWorkflowExecutionError = null;
 
 		// Set the execution as started, but still waiting for the execution to be retrieved
-		workflowsStore.setActiveExecutionId(null);
+		workflowState.setActiveExecutionId(null);
 
 		let response: IExecutionPushResponse;
 		try {
 			response = await workflowsStore.runWorkflow(runData);
 		} catch (error) {
-			workflowsStore.setActiveExecutionId(undefined);
+			workflowState.setActiveExecutionId(undefined);
 			throw error;
 		}
 
 		const workflowExecutionIdIsNew = workflowsStore.previousExecutionId !== response.executionId;
 		const workflowExecutionIdIsPending = workflowsStore.activeExecutionId === null;
 		if (response.executionId && workflowExecutionIdIsNew && workflowExecutionIdIsPending) {
-			workflowsStore.setActiveExecutionId(response.executionId);
+			workflowState.setActiveExecutionId(response.executionId);
 		}
 
 		if (response.waitingForWebhook === true && workflowsStore.nodesIssuesExist) {
-			workflowsStore.setActiveExecutionId(undefined);
+			workflowState.setActiveExecutionId(undefined);
 			throw new Error(i18n.baseText('workflowRun.showError.resolveOutstandingIssues'));
 		}
 
@@ -369,7 +371,7 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 					...workflowData,
 				} as IWorkflowDb,
 			};
-			workflowsStore.setWorkflowExecutionData(executionData);
+			workflowState.setWorkflowExecutionData(executionData);
 			nodeHelpers.updateNodesExecutionIssues();
 
 			workflowHelpers.setDocumentTitle(workflowObject.value.name as string, 'EXECUTING');
@@ -406,7 +408,7 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 
 			return runWorkflowApiResponse;
 		} catch (error) {
-			workflowsStore.setWorkflowExecutionData(null);
+			workflowState.setWorkflowExecutionData(null);
 			workflowHelpers.setDocumentTitle(workflowObject.value.name as string, 'ERROR');
 			toast.showError(error, i18n.baseText('workflowRun.showError.title'));
 			return undefined;
@@ -495,7 +497,7 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 					startedAt: execution.startedAt,
 					stoppedAt: execution.stoppedAt,
 				} as IExecutionResponse;
-				workflowsStore.setWorkflowExecutionData(executedData);
+				workflowState.setWorkflowExecutionData(executedData);
 				toast.showMessage({
 					title: i18n.baseText('nodeView.showMessage.stopExecutionCatch.title'),
 					message: i18n.baseText('nodeView.showMessage.stopExecutionCatch.message'),

--- a/packages/frontend/editor-ui/src/composables/useWorkflowHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useWorkflowHelpers.test.ts
@@ -20,9 +20,23 @@ import type { AssignmentCollectionValue, IConnections } from 'n8n-workflow';
 import * as apiWebhooks from '@n8n/rest-api-client/api/webhooks';
 import { mockedStore } from '@/__tests__/utils';
 import { SLACK_TRIGGER_NODE_TYPE } from '../constants';
+import {
+	injectWorkflowState,
+	useWorkflowState,
+	type WorkflowState,
+} from '@/composables/useWorkflowState';
+
+vi.mock('@/composables/useWorkflowState', async () => {
+	const actual = await vi.importActual('@/composables/useWorkflowState');
+	return {
+		...actual,
+		injectWorkflowState: vi.fn(),
+	};
+});
 
 describe('useWorkflowHelpers', () => {
 	let workflowsStore: ReturnType<typeof mockedStore<typeof useWorkflowsStore>>;
+	let workflowState: WorkflowState;
 	let workflowsEEStore: ReturnType<typeof useWorkflowsEEStore>;
 	let tagsStore: ReturnType<typeof useTagsStore>;
 	let uiStore: ReturnType<typeof useUIStore>;
@@ -30,6 +44,10 @@ describe('useWorkflowHelpers', () => {
 	beforeAll(() => {
 		setActivePinia(createTestingPinia());
 		workflowsStore = mockedStore(useWorkflowsStore);
+
+		workflowState = useWorkflowState();
+		vi.mocked(injectWorkflowState).mockReturnValue(workflowState);
+
 		workflowsEEStore = useWorkflowsEEStore();
 		tagsStore = useTagsStore();
 		uiStore = useUIStore();
@@ -212,17 +230,17 @@ describe('useWorkflowHelpers', () => {
 				tags: [],
 			});
 			const addWorkflowSpy = vi.spyOn(workflowsStore, 'addWorkflow');
-			const setActiveSpy = vi.spyOn(workflowsStore, 'setActive');
-			const setWorkflowIdSpy = vi.spyOn(workflowsStore, 'setWorkflowId');
-			const setWorkflowNameSpy = vi.spyOn(workflowsStore, 'setWorkflowName');
-			const setWorkflowSettingsSpy = vi.spyOn(workflowsStore, 'setWorkflowSettings');
+			const setActiveSpy = vi.spyOn(workflowState, 'setActive');
+			const setWorkflowIdSpy = vi.spyOn(workflowState, 'setWorkflowId');
+			const setWorkflowNameSpy = vi.spyOn(workflowState, 'setWorkflowName');
+			const setWorkflowSettingsSpy = vi.spyOn(workflowState, 'setWorkflowSettings');
 			const setWorkflowPinDataSpy = vi.spyOn(workflowsStore, 'setWorkflowPinData');
 			const setWorkflowVersionIdSpy = vi.spyOn(workflowsStore, 'setWorkflowVersionId');
 			const setWorkflowMetadataSpy = vi.spyOn(workflowsStore, 'setWorkflowMetadata');
 			const setWorkflowScopesSpy = vi.spyOn(workflowsStore, 'setWorkflowScopes');
 			const setUsedCredentialsSpy = vi.spyOn(workflowsStore, 'setUsedCredentials');
 			const setWorkflowSharedWithSpy = vi.spyOn(workflowsEEStore, 'setWorkflowSharedWith');
-			const setWorkflowTagIdsSpy = vi.spyOn(workflowsStore, 'setWorkflowTagIds');
+			const setWorkflowTagIdsSpy = vi.spyOn(workflowState, 'setWorkflowTagIds');
 			const upsertTagsSpy = vi.spyOn(tagsStore, 'upsertTags');
 
 			initState(workflowData);
@@ -283,7 +301,7 @@ describe('useWorkflowHelpers', () => {
 				meta: {},
 				scopes: [],
 			});
-			const setWorkflowTagIdsSpy = vi.spyOn(workflowsStore, 'setWorkflowTagIds');
+			const setWorkflowTagIdsSpy = vi.spyOn(workflowState, 'setWorkflowTagIds');
 			const upsertTagsSpy = vi.spyOn(tagsStore, 'upsertTags');
 
 			initState(workflowData);

--- a/packages/frontend/editor-ui/src/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/composables/useWorkflowHelpers.ts
@@ -64,6 +64,7 @@ import { useTagsStore } from '@/stores/tags.store';
 import { useWorkflowsEEStore } from '@/stores/workflows.ee.store';
 import { findWebhook } from '@n8n/rest-api-client/api/webhooks';
 import type { ExpressionLocalResolveContext } from '@/types/expressions';
+import { injectWorkflowState } from '@/composables/useWorkflowState';
 
 export type ResolveParameterOptions = {
 	targetItem?: TargetItem;
@@ -533,6 +534,7 @@ export function useWorkflowHelpers() {
 	const nodeTypesStore = useNodeTypesStore();
 	const rootStore = useRootStore();
 	const workflowsStore = useWorkflowsStore();
+	const workflowState = injectWorkflowState();
 	const workflowsEEStore = useWorkflowsEEStore();
 	const uiStore = useUIStore();
 	const nodeHelpers = useNodeHelpers();
@@ -876,7 +878,7 @@ export function useWorkflowHelpers() {
 		workflowsStore.setWorkflowVersionId(workflow.versionId);
 
 		if (isCurrentWorkflow) {
-			workflowsStore.setActive(!!workflow.active);
+			workflowState.setActive(!!workflow.active);
 			uiStore.stateIsDirty = false;
 		}
 
@@ -966,14 +968,14 @@ export function useWorkflowHelpers() {
 
 	function initState(workflowData: IWorkflowDb) {
 		workflowsStore.addWorkflow(workflowData);
-		workflowsStore.setActive(workflowData.active || false);
+		workflowState.setActive(workflowData.active || false);
 		workflowsStore.setIsArchived(workflowData.isArchived);
-		workflowsStore.setWorkflowId(workflowData.id);
-		workflowsStore.setWorkflowName({
+		workflowState.setWorkflowId(workflowData.id);
+		workflowState.setWorkflowName({
 			newName: workflowData.name,
 			setStateDirty: uiStore.stateIsDirty,
 		});
-		workflowsStore.setWorkflowSettings(workflowData.settings ?? {});
+		workflowState.setWorkflowSettings(workflowData.settings ?? {});
 		workflowsStore.setWorkflowPinData(workflowData.pinData ?? {});
 		workflowsStore.setWorkflowVersionId(workflowData.versionId);
 		workflowsStore.setWorkflowMetadata(workflowData.meta);
@@ -992,7 +994,7 @@ export function useWorkflowHelpers() {
 
 		const tags = (workflowData.tags ?? []) as ITag[];
 		const tagIds = tags.map((tag) => tag.id);
-		workflowsStore.setWorkflowTagIds(tagIds || []);
+		workflowState.setWorkflowTagIds(tagIds || []);
 		tagsStore.upsertTags(tags);
 	}
 

--- a/packages/frontend/editor-ui/src/composables/useWorkflowSaving.ts
+++ b/packages/frontend/editor-ui/src/composables/useWorkflowSaving.ts
@@ -27,6 +27,7 @@ import { useNodeHelpers } from './useNodeHelpers';
 import { tryToParseNumber } from '@/utils/typesUtils';
 import { useTemplatesStore } from '@/stores/templates.store';
 import { useFocusPanelStore } from '@/stores/focusPanel.store';
+import { useWorkflowState } from './useWorkflowState';
 
 export function useWorkflowSaving({ router }: { router: ReturnType<typeof useRouter> }) {
 	const uiStore = useUIStore();
@@ -34,6 +35,7 @@ export function useWorkflowSaving({ router }: { router: ReturnType<typeof useRou
 	const message = useMessage();
 	const i18n = useI18n();
 	const workflowsStore = useWorkflowsStore();
+	const workflowState = useWorkflowState();
 	const focusPanelStore = useFocusPanelStore();
 	const nodeTypesStore = useNodeTypesStore();
 	const toast = useToast();
@@ -228,13 +230,13 @@ export function useWorkflowSaving({ router }: { router: ReturnType<typeof useRou
 			workflowsStore.setWorkflowVersionId(workflowData.versionId);
 
 			if (name) {
-				workflowsStore.setWorkflowName({ newName: workflowData.name, setStateDirty: false });
+				workflowState.setWorkflowName({ newName: workflowData.name, setStateDirty: false });
 			}
 
 			if (tags) {
 				const createdTags = (workflowData.tags || []) as ITag[];
 				const tagIds = createdTags.map((tag: ITag): string => tag.id);
-				workflowsStore.setWorkflowTagIds(tagIds);
+				workflowState.setWorkflowTagIds(tagIds);
 			}
 
 			uiStore.stateIsDirty = false;
@@ -385,11 +387,11 @@ export function useWorkflowSaving({ router }: { router: ReturnType<typeof useRou
 				}
 			}
 
-			workflowsStore.setActive(workflowData.active || false);
-			workflowsStore.setWorkflowId(workflowData.id);
+			workflowState.setActive(workflowData.active || false);
+			workflowState.setWorkflowId(workflowData.id);
 			workflowsStore.setWorkflowVersionId(workflowData.versionId);
-			workflowsStore.setWorkflowName({ newName: workflowData.name, setStateDirty: false });
-			workflowsStore.setWorkflowSettings((workflowData.settings as IWorkflowSettings) || {});
+			workflowState.setWorkflowName({ newName: workflowData.name, setStateDirty: false });
+			workflowState.setWorkflowSettings((workflowData.settings as IWorkflowSettings) || {});
 			uiStore.stateIsDirty = false;
 			Object.keys(changedNodes).forEach((nodeName) => {
 				const changes = {
@@ -402,7 +404,7 @@ export function useWorkflowSaving({ router }: { router: ReturnType<typeof useRou
 
 			const createdTags = (workflowData.tags || []) as ITag[];
 			const tagIds = createdTags.map((tag: ITag) => tag.id);
-			workflowsStore.setWorkflowTagIds(tagIds);
+			workflowState.setWorkflowTagIds(tagIds);
 
 			const templateId = router.currentRoute.value.query.templateId;
 			if (templateId) {

--- a/packages/frontend/editor-ui/src/composables/useWorkflowState.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useWorkflowState.test.ts
@@ -1,0 +1,29 @@
+import { useWorkflowsStore } from '@/stores/workflows.store';
+import { useWorkflowState, type WorkflowState } from './useWorkflowState';
+import { createPinia, setActivePinia } from 'pinia';
+
+describe('useWorkflowState', () => {
+	let workflowsStore: ReturnType<typeof useWorkflowsStore>;
+	let workflowState: WorkflowState;
+	beforeEach(() => {
+		setActivePinia(createPinia());
+
+		workflowsStore = useWorkflowsStore();
+		workflowState = useWorkflowState();
+	});
+
+	describe('setWorkflowName()', () => {
+		it('should set the workflow name correctly', () => {
+			workflowState.setWorkflowName({
+				newName: 'New Workflow Name',
+				setStateDirty: false,
+			});
+			expect(workflowsStore.workflow.name).toBe('New Workflow Name');
+		});
+
+		it('should propagate name to workflowObject for pre-exec expressions', () => {
+			workflowState.setWorkflowName({ newName: 'WF Title', setStateDirty: false });
+			expect(workflowsStore.workflowObject.name).toBe('WF Title');
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/composables/useWorkflowState.ts
+++ b/packages/frontend/editor-ui/src/composables/useWorkflowState.ts
@@ -1,0 +1,124 @@
+import { PLACEHOLDER_EMPTY_WORKFLOW_ID, WorkflowStateKey } from '@/constants';
+import type { IExecutionResponse } from '@/Interface';
+import { useUIStore } from '@/stores/ui.store';
+import { useWorkflowsStore } from '@/stores/workflows.store';
+import { getPairedItemsMapping } from '@/utils/pairedItemUtils';
+import type { IWorkflowSettings } from 'n8n-workflow';
+import { inject } from 'vue';
+
+export function useWorkflowState() {
+	const ws = useWorkflowsStore();
+	const uiStore = useUIStore();
+
+	function removeAllConnections(data: { setStateDirty: boolean }): void {
+		if (data?.setStateDirty) {
+			uiStore.stateIsDirty = true;
+		}
+
+		ws.workflow.connections = {};
+		ws.workflowObject.setConnections({});
+	}
+
+	function removeAllNodes(data: { setStateDirty: boolean; removePinData: boolean }): void {
+		if (data.setStateDirty) {
+			uiStore.stateIsDirty = true;
+		}
+
+		if (data.removePinData) {
+			ws.workflow.pinData = {};
+		}
+
+		ws.workflow.nodes.splice(0, ws.workflow.nodes.length);
+		ws.workflowObject.setNodes(ws.workflow.nodes);
+		ws.nodeMetadata = {};
+	}
+
+	function setWorkflowExecutionData(workflowResultData: IExecutionResponse | null) {
+		if (workflowResultData?.data?.waitTill) {
+			delete workflowResultData.data.resultData.runData[
+				workflowResultData.data.resultData.lastNodeExecuted as string
+			];
+		}
+		ws.workflowExecutionData = workflowResultData;
+		ws.workflowExecutionPairedItemMappings = getPairedItemsMapping(workflowResultData);
+		ws.workflowExecutionResultDataLastUpdate = Date.now();
+		ws.workflowExecutionStartedData = undefined;
+	}
+
+	function resetAllNodesIssues(): boolean {
+		ws.workflow.nodes.forEach((node) => {
+			node.issues = undefined;
+		});
+		return true;
+	}
+
+	function setActive(active: boolean) {
+		ws.workflow.active = active;
+	}
+
+	function setWorkflowId(id?: string) {
+		ws.workflow.id = !id || id === 'new' ? PLACEHOLDER_EMPTY_WORKFLOW_ID : id;
+		ws.workflowObject.id = ws.workflow.id;
+	}
+
+	function setWorkflowName(data: { newName: string; setStateDirty: boolean }) {
+		ws.private.setWorkflowName(data);
+	}
+
+	function setWorkflowSettings(workflowSettings: IWorkflowSettings) {
+		ws.private.setWorkflowSettings(workflowSettings);
+	}
+
+	function setWorkflowTagIds(tags: string[]) {
+		ws.workflow.tags = tags;
+	}
+
+	function setActiveExecutionId(id: string | null | undefined) {
+		ws.private.setActiveExecutionId(id);
+	}
+
+	function resetState() {
+		removeAllConnections({ setStateDirty: false });
+		removeAllNodes({ setStateDirty: false, removePinData: true });
+
+		setWorkflowExecutionData(null);
+		resetAllNodesIssues();
+
+		setActive(ws.defaults.active);
+		setWorkflowId(PLACEHOLDER_EMPTY_WORKFLOW_ID);
+		setWorkflowName({ newName: '', setStateDirty: false });
+		setWorkflowSettings({ ...ws.defaults.settings });
+		setWorkflowTagIds([]);
+
+		setActiveExecutionId(undefined);
+		ws.executingNode.length = 0;
+		ws.executionWaitingForWebhook = false;
+	}
+
+	return {
+		resetState,
+		removeAllConnections,
+		removeAllNodes,
+		setWorkflowExecutionData,
+		resetAllNodesIssues,
+		setActive,
+		setWorkflowId,
+		setWorkflowName,
+		setWorkflowSettings,
+		setWorkflowTagIds,
+		setActiveExecutionId,
+	};
+}
+
+export type WorkflowState = ReturnType<typeof useWorkflowState>;
+
+export function injectWorkflowState() {
+	return inject(
+		WorkflowStateKey,
+		() => {
+			console.error('Attempted to inject workflowState outside of NodeView tree');
+			return useWorkflowState();
+		},
+		true,
+	);
+}

--- a/packages/frontend/editor-ui/src/constants.ts
+++ b/packages/frontend/editor-ui/src/constants.ts
@@ -15,6 +15,7 @@ import type { ExpressionLocalResolveContext } from './types/expressions';
 import { DATA_STORE_MODULE_NAME } from './features/dataStore/constants';
 import type { TelemetryContext } from './types/telemetry';
 import type { IconName } from '@n8n/design-system/src/components/N8nIcon/icons';
+import type { WorkflowState } from './composables/useWorkflowState';
 
 export const MAX_WORKFLOW_SIZE = 1024 * 1024 * 16; // Workflow size limit in bytes
 export const MAX_EXPECTED_REQUEST_SIZE = 2048; // Expected maximum workflow request metadata (i.e. headers) size in bytes
@@ -1029,6 +1030,7 @@ export const ExpressionLocalResolveContextSymbol: InjectionKey<
 	ComputedRef<ExpressionLocalResolveContext | undefined>
 > = Symbol('ExpressionLocalResolveContext');
 export const TelemetryContextSymbol: InjectionKey<TelemetryContext> = Symbol('TelemetryContext');
+export const WorkflowStateKey: InjectionKey<WorkflowState> = Symbol('WorkflowState');
 
 export const APP_MODALS_ELEMENT_ID = 'app-modals';
 export const CODEMIRROR_TOOLTIP_CONTAINER_ELEMENT_ID = 'cm-tooltip-container';

--- a/packages/frontend/editor-ui/src/features/logs/composables/useChatState.ts
+++ b/packages/frontend/editor-ui/src/features/logs/composables/useChatState.ts
@@ -18,6 +18,7 @@ import { restoreChatHistory } from '@/features/logs/logs.utils';
 import type { INodeParameters } from 'n8n-workflow';
 import { isChatNode } from '@/utils/aiUtils';
 import { constructChatWebsocketUrl } from '@n8n/chat/utils';
+import { injectWorkflowState } from '@/composables/useWorkflowState';
 
 type IntegratedChat = Omit<Chat, 'sendMessage'> & {
 	sendMessage: (text: string, files: File[]) => Promise<void>;
@@ -37,6 +38,7 @@ interface ChatState {
 export function useChatState(isReadOnly: boolean): ChatState {
 	const locale = useI18n();
 	const workflowsStore = useWorkflowsStore();
+	const workflowState = injectWorkflowState();
 	const rootStore = useRootStore();
 	const logsStore = useLogsStore();
 	const router = useRouter();
@@ -214,7 +216,7 @@ export function useChatState(isReadOnly: boolean): ChatState {
 	}
 
 	function refreshSession() {
-		workflowsStore.setWorkflowExecutionData(null);
+		workflowState.setWorkflowExecutionData(null);
 		nodeHelpers.updateNodesExecutionIssues();
 		logsStore.resetChatSessionId();
 		logsStore.resetMessages();

--- a/packages/frontend/editor-ui/src/features/logs/composables/useLogsExecutionData.ts
+++ b/packages/frontend/editor-ui/src/features/logs/composables/useLogsExecutionData.ts
@@ -15,6 +15,7 @@ import type { LatestNodeInfo, LogEntry } from '../logs.types';
 import { isChatNode } from '@/utils/aiUtils';
 import { LOGS_EXECUTION_DATA_THROTTLE_DURATION, PLACEHOLDER_EMPTY_WORKFLOW_ID } from '@/constants';
 import { useThrottleFn } from '@vueuse/core';
+import { injectWorkflowState } from '@/composables/useWorkflowState';
 
 // useThrottle with reactive timeout support
 function useThrottle<T>(state: Ref<T>, timeout: ComputedRef<number>) {
@@ -31,6 +32,7 @@ function useThrottle<T>(state: Ref<T>, timeout: ComputedRef<number>) {
 export function useLogsExecutionData(isEnabled: ComputedRef<boolean>) {
 	const nodeHelpers = useNodeHelpers();
 	const workflowsStore = useWorkflowsStore();
+	const workflowState = injectWorkflowState();
 	const toast = useToast();
 
 	const state = ref<
@@ -95,7 +97,7 @@ export function useLogsExecutionData(isEnabled: ComputedRef<boolean>) {
 
 	function resetExecutionData() {
 		state.value = undefined;
-		workflowsStore.setWorkflowExecutionData(null);
+		workflowState.setWorkflowExecutionData(null);
 		nodeHelpers.updateNodesExecutionIssues();
 	}
 

--- a/packages/frontend/editor-ui/src/stores/builder.store.ts
+++ b/packages/frontend/editor-ui/src/stores/builder.store.ts
@@ -28,6 +28,7 @@ import type { WorkflowDataUpdate } from '@n8n/rest-api-client/api/workflows';
 import pick from 'lodash/pick';
 import { jsonParse } from 'n8n-workflow';
 import { useToast } from '@/composables/useToast';
+import { injectWorkflowState } from '@/composables/useWorkflowState';
 import { useNodeTypesStore } from './nodeTypes.store';
 import { useCredentialsStore } from './credentials.store';
 import { getAuthTypeForNodeCredential, getMainAuthField } from '@/utils/nodeTypesUtils';
@@ -51,6 +52,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 	const settings = useSettingsStore();
 	const rootStore = useRootStore();
 	const workflowsStore = useWorkflowsStore();
+	const workflowState = injectWorkflowState();
 	const uiStore = useUIStore();
 	const credentialsStore = useCredentialsStore();
 	const nodeTypesStore = useNodeTypesStore();
@@ -498,8 +500,8 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 		const { nodePositions, existingNodeIds } = captureCurrentWorkflowState();
 
 		// Clear existing workflow
-		workflowsStore.removeAllConnections({ setStateDirty: false });
-		workflowsStore.removeAllNodes({ setStateDirty: false, removePinData: true });
+		workflowState.removeAllConnections({ setStateDirty: false });
+		workflowState.removeAllNodes({ setStateDirty: false, removePinData: true });
 
 		// For the initial generation, we want to apply auto-generated workflow name
 		// but only if the workflow has default name
@@ -508,7 +510,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 			initialGeneration.value &&
 			workflowsStore.workflow.name.startsWith(DEFAULT_NEW_WORKFLOW_NAME)
 		) {
-			workflowsStore.setWorkflowName({ newName: workflowData.name, setStateDirty: false });
+			workflowState.setWorkflowName({ newName: workflowData.name, setStateDirty: false });
 		}
 
 		// Restore positions for nodes that still exist and identify new nodes

--- a/packages/frontend/editor-ui/src/stores/workflows.store.test.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.test.ts
@@ -36,6 +36,7 @@ import {
 	mockNodeTypeDescription,
 } from '@/__tests__/mocks';
 import { waitFor } from '@testing-library/vue';
+import { useWorkflowState } from '@/composables/useWorkflowState';
 
 vi.mock('@/stores/ndv.store', () => ({
 	useNDVStore: vi.fn(() => ({
@@ -265,7 +266,7 @@ describe('useWorkflowsStore', () => {
 		});
 
 		it('should return false for an existing workflow', () => {
-			workflowsStore.setWorkflowId('123');
+			useWorkflowState().setWorkflowId('123');
 			expect(workflowsStore.isNewWorkflow).toBe(false);
 		});
 	});
@@ -545,18 +546,6 @@ describe('useWorkflowsStore', () => {
 
 			expect(workflowsApi.getWorkflows).toHaveBeenCalled();
 			expect(Object.values(workflowsStore.workflowsById)).toEqual(mockWorkflows);
-		});
-	});
-
-	describe('setWorkflowName()', () => {
-		it('should set the workflow name correctly', () => {
-			workflowsStore.setWorkflowName({ newName: 'New Workflow Name', setStateDirty: false });
-			expect(workflowsStore.workflow.name).toBe('New Workflow Name');
-		});
-
-		it('should propagate name to workflowObject for pre-exec expressions', () => {
-			workflowsStore.setWorkflowName({ newName: 'WF Title', setStateDirty: false });
-			expect(workflowsStore.workflowObject.name).toBe('WF Title');
 		});
 	});
 
@@ -849,7 +838,7 @@ describe('useWorkflowsStore', () => {
 		});
 
 		it('should add node success run data', () => {
-			workflowsStore.setWorkflowExecutionData(executionResponse);
+			useWorkflowState().setWorkflowExecutionData(executionResponse);
 
 			workflowsStore.nodesByName[successEvent.nodeName] = mock<INodeUi>({
 				type: 'n8n-nodes-base.manualTrigger',
@@ -873,7 +862,7 @@ describe('useWorkflowsStore', () => {
 
 		it('should add node error event and track errored executions', async () => {
 			workflowsStore.workflow.pinData = {};
-			workflowsStore.setWorkflowExecutionData(executionResponse);
+			useWorkflowState().setWorkflowExecutionData(executionResponse);
 			workflowsStore.addNode({
 				parameters: {},
 				id: '554c7ff4-7ee2-407c-8931-e34234c5056a',
@@ -963,7 +952,7 @@ describe('useWorkflowsStore', () => {
 					},
 				},
 			};
-			workflowsStore.setWorkflowExecutionData(runWithExistingRunData);
+			useWorkflowState().setWorkflowExecutionData(runWithExistingRunData);
 
 			workflowsStore.nodesByName[successEvent.nodeName] = mock<INodeUi>({
 				type: 'n8n-nodes-base.manualTrigger',
@@ -1018,7 +1007,7 @@ describe('useWorkflowsStore', () => {
 					},
 				},
 			};
-			workflowsStore.setWorkflowExecutionData(runWithExistingRunData);
+			useWorkflowState().setWorkflowExecutionData(runWithExistingRunData);
 
 			workflowsStore.nodesByName[successEvent.nodeName] = mock<INodeUi>({
 				type: 'n8n-nodes-base.manualTrigger',

--- a/packages/frontend/editor-ui/src/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/views/NodeView.vue
@@ -13,6 +13,7 @@ import {
 	h,
 	onBeforeUnmount,
 	useTemplateRef,
+	provide,
 } from 'vue';
 import { onBeforeRouteLeave, useRoute, useRouter } from 'vue-router';
 import WorkflowCanvas from '@/components/canvas/WorkflowCanvas.vue';
@@ -67,6 +68,7 @@ import {
 	NDV_UI_OVERHAUL_EXPERIMENT,
 	WORKFLOW_SETTINGS_MODAL_KEY,
 	ABOUT_MODAL_KEY,
+	WorkflowStateKey,
 } from '@/constants';
 import { useSourceControlStore } from '@/stores/sourceControl.store';
 import { useNodeCreatorStore } from '@/stores/nodeCreator.store';
@@ -140,6 +142,7 @@ import { useReadyToRunWorkflowsStore } from '@/experiments/readyToRunWorkflows/s
 import { useKeybindings } from '@/composables/useKeybindings';
 import { type ContextMenuAction } from '@/composables/useContextMenuItems';
 import { useExperimentalNdvStore } from '@/components/canvas/experimental/experimentalNdv.store';
+import { useWorkflowState } from '@/composables/useWorkflowState';
 import { useParentFolder } from '@/composables/useParentFolder';
 
 import { N8nCallout, N8nCanvasThinkingPill } from '@n8n/design-system';
@@ -204,6 +207,9 @@ const logsStore = useLogsStore();
 const aiTemplatesStarterCollectionStore = useAITemplatesStarterCollectionStore();
 const readyToRunWorkflowsStore = useReadyToRunWorkflowsStore();
 const experimentalNdvStore = useExperimentalNdvStore();
+
+const workflowState = useWorkflowState();
+provide(WorkflowStateKey, workflowState);
 
 const { addBeforeUnloadEventBindings, removeBeforeUnloadEventBindings } = useBeforeUnload({
 	route,
@@ -1861,7 +1867,7 @@ onBeforeRouteLeave(async (to, from, next) => {
 			}
 
 			// Make sure workflow id is empty when leaving the editor
-			workflowsStore.setWorkflowId(PLACEHOLDER_EMPTY_WORKFLOW_ID);
+			workflowState.setWorkflowId(PLACEHOLDER_EMPTY_WORKFLOW_ID);
 
 			return true;
 		},

--- a/packages/frontend/editor-ui/src/views/SettingsLogStreamingView.vue
+++ b/packages/frontend/editor-ui/src/views/SettingsLogStreamingView.vue
@@ -15,6 +15,7 @@ import { createEventBus } from '@n8n/utils/event-bus';
 import { useDocumentTitle } from '@/composables/useDocumentTitle';
 import { useI18n } from '@n8n/i18n';
 import { usePageRedirectionHelper } from '@/composables/usePageRedirectionHelper';
+import { injectWorkflowState } from '@/composables/useWorkflowState';
 
 import { ElCol, ElRow, ElSwitch } from 'element-plus';
 import { N8nActionBox, N8nButton, N8nHeading, N8nInfoTip } from '@n8n/design-system';
@@ -23,6 +24,7 @@ const environment = process.env.NODE_ENV;
 const settingsStore = useSettingsStore();
 const logStreamingStore = useLogStreamingStore();
 const workflowsStore = useWorkflowsStore();
+const workflowState = injectWorkflowState();
 const uiStore = useUIStore();
 const credentialsStore = useCredentialsStore();
 const documentTitle = useDocumentTitle();
@@ -95,7 +97,7 @@ function forceUpdateInstance() {
 }
 
 function onBusClosing() {
-	workflowsStore.removeAllNodes({ setStateDirty: false, removePinData: true });
+	workflowState.removeAllNodes({ setStateDirty: false, removePinData: true });
 	uiStore.stateIsDirty = false;
 }
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Extracted workflow editing and execution state into a new injectable composable (useWorkflowState) and replaced direct store mutations across the editor, improving consistency, decoupling, and testability.

- **Refactors**
  - Added useWorkflowState with methods for execution data, active execution ID, name, settings, tags, ID, active state, reset, and node cleanup.
  - Provided WorkflowState via WorkflowStateKey in NodeView; consumed via injectWorkflowState in composables and views (canvas ops, run workflow, execution debugging, logs, chat, builder, settings).
  - Updated push connection handlers to accept workflowState (testWebhook, executionStarted/Finished/Recovered, workflowFailedToActivate) via usePushConnection options.
  - Moved select workflows.store internals to store.private (setWorkflowSettings, setWorkflowName, setActiveExecutionId) and shifted editor mutations to workflowState.

- **Migration**
  - Provide WorkflowState in the editor root (NodeView) and inject it where needed.
  - Replace workflowsStore calls with workflowState:
    - setWorkflowExecutionData, resetAllNodesIssues, setActiveExecutionId, setWorkflowName, setWorkflowSettings, setWorkflowTagIds, setWorkflowId, setActive, removeAllNodes, removeAllConnections, resetState.
  - Pass workflowState to usePushConnection and downstream handlers where execution state changes occur.

<!-- End of auto-generated description by cubic. -->

