### PR TITLE
n8n-auto-pr (N8N - 756773)

### DIFF
--- a/packages/frontend/editor-ui/src/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/views/NodeView.vue
@@ -849,10 +849,24 @@ async function onOpenRenameNodeModal(id: string) {
 		nameInput?.focus();
 		nameInput?.select();
 
+		let shouldSaveAfterRename = false;
+
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+				e.preventDefault();
+				shouldSaveAfterRename = true;
+				nameInput?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+			}
+		};
+		nameInput?.addEventListener('keydown', handleKeyDown);
+
 		const promptResponse = await promptResponsePromise;
+
+		nameInput?.removeEventListener('keydown', handleKeyDown);
 
 		if (promptResponse.action === MODAL_CONFIRM) {
 			await renameNode(currentName, promptResponse.value, { trackHistory: true });
+			if (shouldSaveAfterRename) await onSaveWorkflow();
 		}
 	} catch (e) {}
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fix Ctrl/Cmd+S while renaming a node so it confirms the rename and saves the workflow in one step. Addresses Linear N8N-756773.

- **Bug Fixes**
  - Capture Ctrl/Cmd+S in the rename input, prevent default, confirm with Enter, then trigger onSaveWorkflow.

<!-- End of auto-generated description by cubic. -->

