### PR TITLE
n8n-auto-pr (N8N - 757087)

### DIFF
--- a/packages/@n8n/db/src/entities/variables.ts
+++ b/packages/@n8n/db/src/entities/variables.ts
@@ -1,6 +1,7 @@
-import { Column, Entity } from '@n8n/typeorm';
+import { Column, Entity, ManyToOne } from '@n8n/typeorm';
 
 import { WithStringId } from './abstract-entity';
+import { Project } from './project';
 
 @Entity()
 export class Variables extends WithStringId {
@@ -12,4 +13,11 @@ export class Variables extends WithStringId {
 
 	@Column('text')
 	value: string;
+
+	// If null, it's a global variable
+	@ManyToOne('Project', {
+		onDelete: 'CASCADE',
+		nullable: true,
+	})
+	project: Project | null;
 }

--- a/packages/@n8n/db/src/migrations/dsl/index.ts
+++ b/packages/@n8n/db/src/migrations/dsl/index.ts
@@ -47,6 +47,7 @@ export const createSchemaBuilder = (tablePrefix: string, queryRunner: QueryRunne
 		columnName: string,
 		reference: [string, string],
 		customConstraintName?: string,
+		onDelete?: 'RESTRICT' | 'CASCADE' | 'NO ACTION' | 'SET NULL',
 	) =>
 		new AddForeignKey(
 			tableName,
@@ -55,6 +56,7 @@ export const createSchemaBuilder = (tablePrefix: string, queryRunner: QueryRunne
 			tablePrefix,
 			queryRunner,
 			customConstraintName,
+			onDelete,
 		),
 
 	dropForeignKey: (

--- a/packages/@n8n/db/src/migrations/dsl/table.ts
+++ b/packages/@n8n/db/src/migrations/dsl/table.ts
@@ -145,6 +145,7 @@ abstract class ForeignKeyOperation extends TableOperation {
 		prefix: string,
 		queryRunner: QueryRunner,
 		customConstraintName?: string,
+		onDelete?: string,
 	) {
 		super(tableName, prefix, queryRunner);
 
@@ -153,6 +154,7 @@ abstract class ForeignKeyOperation extends TableOperation {
 			columnNames: [columnName],
 			referencedTableName: `${prefix}${referencedTableName}`,
 			referencedColumnNames: [referencedColumnName],
+			onDelete,
 		});
 	}
 }

--- a/packages/@n8n/db/src/migrations/mysqldb/1758794506893-AddProjectIdToVariableTable.ts
+++ b/packages/@n8n/db/src/migrations/mysqldb/1758794506893-AddProjectIdToVariableTable.ts
@@ -1,0 +1,92 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+const VARIABLES_TABLE_NAME = 'variables';
+const UNIQUE_PROJECT_KEY_INDEX_NAME = 'variables_project_key_unique';
+const UNIQUE_GLOBAL_KEY_INDEX_NAME = 'variables_global_key_unique';
+const PROJECT_ID_FOREIGN_KEY_NAME = 'variables_projectId_foreign';
+
+/**
+ * Adds a projectId column to the variables table to support project-scoped variables.
+ * In MySQL, also adds a generated column (globalKey) to enforce uniqueness
+ * for global variables (where projectId is null).
+ */
+export class AddProjectIdToVariableTable1758794506893 implements ReversibleMigration {
+	async up({
+		schemaBuilder: { addColumns, column, dropIndex, addForeignKey },
+		queryRunner,
+		escape,
+	}: MigrationContext) {
+		const variablesTableName = escape.tableName(VARIABLES_TABLE_NAME);
+
+		// Drop the old unique index on key
+		await dropIndex(VARIABLES_TABLE_NAME, ['key'], { customIndexName: 'key' });
+
+		// Add projectId and globalKey columns
+		await addColumns(VARIABLES_TABLE_NAME, [column('projectId').varchar(36)]);
+
+		// Add generated column for global uniqueness
+		// Null values are considered unique in MySQL, so we create a generated column
+		// that contains the key when projectId is null, and null otherwise.
+		await queryRunner.query(`
+			ALTER TABLE ${variablesTableName}
+			ADD COLUMN globalKey VARCHAR(255) GENERATED ALWAYS AS (
+				CASE WHEN projectId IS NULL THEN \`key\` ELSE NULL END
+			) STORED;
+		`);
+
+		// Add foreign key to project
+		// Create it after the generated column to avoid limits of mysql
+		// https://dev.mysql.com/doc/refman/8.4/en/create-table-foreign-keys.html
+		// "A foreign key constraint on a stored generated column cannot use CASCADE"
+		await addForeignKey(
+			VARIABLES_TABLE_NAME,
+			'projectId',
+			['project', 'id'],
+			PROJECT_ID_FOREIGN_KEY_NAME,
+		);
+
+		// Unique index for project-specific variables
+		await queryRunner.query(`
+			CREATE UNIQUE INDEX ${UNIQUE_PROJECT_KEY_INDEX_NAME}
+			ON ${variablesTableName} (projectId, \`key\`);
+		`);
+
+		// Unique index for global variables
+		await queryRunner.query(`
+			CREATE UNIQUE INDEX ${UNIQUE_GLOBAL_KEY_INDEX_NAME}
+			ON ${variablesTableName} (globalKey);
+		`);
+	}
+
+	// Down migration do not use typeorm helpers
+	// to prevent error with generated columns
+	// because typeorm tries to fetch the column details from typeorm metadata
+	async down({ queryRunner, escape }: MigrationContext) {
+		const variablesTableName = escape.tableName(VARIABLES_TABLE_NAME);
+
+		// Delete the rows with a non-null projectId (data loss)
+		await queryRunner.query(`DELETE FROM ${variablesTableName} WHERE projectId IS NOT NULL;`);
+
+		// Drop the generated column index
+		await queryRunner.query(`DROP INDEX ${UNIQUE_GLOBAL_KEY_INDEX_NAME} ON ${variablesTableName};`);
+
+		// Drop the generated column
+		await queryRunner.query(`ALTER TABLE ${variablesTableName} DROP COLUMN globalKey;`);
+
+		// Drop the project id column, foreign key and its associated index
+		await queryRunner.query(
+			`ALTER TABLE ${variablesTableName} DROP FOREIGN KEY ${PROJECT_ID_FOREIGN_KEY_NAME};`,
+		);
+
+		await queryRunner.query(
+			`DROP INDEX ${UNIQUE_PROJECT_KEY_INDEX_NAME} ON ${variablesTableName};`,
+		);
+
+		await queryRunner.query(`ALTER TABLE ${variablesTableName} DROP COLUMN projectId;`);
+
+		// Reset the original unique index on key
+		await queryRunner.query(
+			`ALTER TABLE ${variablesTableName} ADD CONSTRAINT \`key\` UNIQUE (\`key\`);`,
+		);
+	}
+}

--- a/packages/@n8n/db/src/migrations/mysqldb/index.ts
+++ b/packages/@n8n/db/src/migrations/mysqldb/index.ts
@@ -46,6 +46,7 @@ import { MigrateTestDefinitionKeyToString1731582748663 } from './1731582748663-M
 import { CreateTestMetricTable1732271325258 } from './1732271325258-CreateTestMetricTable';
 import { AddStatsColumnsToTestRun1736172058779 } from './1736172058779-AddStatsColumnsToTestRun';
 import { FixTestDefinitionPrimaryKey1739873751194 } from './1739873751194-FixTestDefinitionPrimaryKey';
+import { AddProjectIdToVariableTable1758794506893 } from './1758794506893-AddProjectIdToVariableTable';
 import { CreateLdapEntities1674509946020 } from '../common/1674509946020-CreateLdapEntities';
 import { PurgeInvalidWorkflowConnections1675940580449 } from '../common/1675940580449-PurgeInvalidWorkflowConnections';
 import { RemoveResetPasswordColumns1690000000030 } from '../common/1690000000030-RemoveResetPasswordColumns';
@@ -201,4 +202,5 @@ export const mysqlMigrations: Migration[] = [
 	ReplaceDataStoreTablesWithDataTables1754475614602,
 	LinkRoleToProjectRelationTable1753953244168,
 	AddTimestampsToRoleAndRoleIndexes1756906557570,
+	AddProjectIdToVariableTable1758794506893,
 ];

--- a/packages/@n8n/db/src/migrations/postgresdb/1758794506893-AddProjectIdToVariableTable.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/1758794506893-AddProjectIdToVariableTable.ts
@@ -1,0 +1,76 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+const VARIABLES_TABLE_NAME = 'variables';
+const UNIQUE_PROJECT_KEY_INDEX_NAME = 'variables_project_key_unique';
+const UNIQUE_GLOBAL_KEY_INDEX_NAME = 'variables_global_key_unique';
+
+/**
+ * Adds a projectId column to the variables table to support project-scoped variables.
+ * Also updates the unique constraints to allow the same key to be used in different projects,
+ * while still enforcing uniqueness for global variables (where projectId is null).
+ */
+export class AddProjectIdToVariableTable1758794506893 implements ReversibleMigration {
+	async up({
+		schemaBuilder: { addColumns, column, addForeignKey },
+		queryRunner,
+		tablePrefix,
+		escape,
+	}: MigrationContext) {
+		const variablesTableName = escape.tableName(VARIABLES_TABLE_NAME);
+
+		// Drop the remaining redundant index created on 1690000000000-MigrateIntegerKeysToString
+		await queryRunner.query(`DROP INDEX IF EXISTS "pk_${tablePrefix}variables_id";`);
+
+		// Drop the unique index on key to allow multiple projects to have variables with the same key
+		await queryRunner.query(
+			`ALTER TABLE ${variablesTableName} DROP CONSTRAINT ${tablePrefix}variables_key_key;`,
+		);
+
+		await addColumns(VARIABLES_TABLE_NAME, [column('projectId').varchar(36)]);
+		await addForeignKey(VARIABLES_TABLE_NAME, 'projectId', ['project', 'id'], undefined, 'CASCADE');
+
+		// Create index for unique project key (projectId not null)
+		await queryRunner.query(`
+      CREATE UNIQUE INDEX "${UNIQUE_PROJECT_KEY_INDEX_NAME}"
+      ON ${variablesTableName} ("projectId", "key")
+			WHERE "projectId" IS NOT NULL;
+    `);
+
+		// Create index for global variables (projectId is null)
+		await queryRunner.query(`
+      CREATE UNIQUE INDEX "${UNIQUE_GLOBAL_KEY_INDEX_NAME}"
+      ON ${variablesTableName} (key)
+      WHERE "projectId" IS NULL;
+    `);
+	}
+
+	async down({
+		schemaBuilder: { dropColumns, dropIndex, dropForeignKey },
+		queryRunner,
+		tablePrefix,
+		escape,
+	}: MigrationContext) {
+		const variablesTableName = escape.tableName(VARIABLES_TABLE_NAME);
+
+		// Drop the two indexes created in the up migration
+		await dropIndex(VARIABLES_TABLE_NAME, ['projectId', 'key'], {
+			customIndexName: UNIQUE_PROJECT_KEY_INDEX_NAME,
+		});
+		await dropIndex(VARIABLES_TABLE_NAME, ['key'], {
+			customIndexName: UNIQUE_GLOBAL_KEY_INDEX_NAME,
+		});
+
+		// Delete the rows with a non-null projectId
+		await queryRunner.query(`DELETE FROM ${variablesTableName} WHERE "projectId" IS NOT NULL;`);
+
+		// Remove foreign key constraints and drop the projectId column
+		await dropForeignKey(VARIABLES_TABLE_NAME, 'projectId', ['project', 'id']);
+		await dropColumns(VARIABLES_TABLE_NAME, ['projectId']);
+
+		// Recreate the original unique index on key
+		await queryRunner.query(`
+			ALTER TABLE ${variablesTableName}
+			ADD CONSTRAINT ${tablePrefix}variables_key_key UNIQUE ("key");
+		`);
+	}
+}

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -45,6 +45,7 @@ import { AddActivatedAtUserSetting1717498465931 } from './1717498465931-AddActiv
 import { FixExecutionMetadataSequence1721377157740 } from './1721377157740-FixExecutionMetadataSequence';
 import { MigrateTestDefinitionKeyToString1731582748663 } from './1731582748663-MigrateTestDefinitionKeyToString';
 import { UpdateParentFolderIdColumn1740445074052 } from './1740445074052-UpdateParentFolderIdColumn';
+import { AddProjectIdToVariableTable1758794506893 } from './1758794506893-AddProjectIdToVariableTable';
 import { CreateLdapEntities1674509946020 } from '../common/1674509946020-CreateLdapEntities';
 import { PurgeInvalidWorkflowConnections1675940580449 } from '../common/1675940580449-PurgeInvalidWorkflowConnections';
 import { RemoveResetPasswordColumns1690000000030 } from '../common/1690000000030-RemoveResetPasswordColumns';
@@ -199,4 +200,5 @@ export const postgresMigrations: Migration[] = [
 	ReplaceDataStoreTablesWithDataTables1754475614602,
 	LinkRoleToProjectRelationTable1753953244168,
 	AddTimestampsToRoleAndRoleIndexes1756906557570,
+	AddProjectIdToVariableTable1758794506893,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/1758794506893-AddProjectIdToVariableTable.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/1758794506893-AddProjectIdToVariableTable.ts
@@ -1,0 +1,96 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+const VARIABLES_TABLE_NAME = 'variables';
+const VARIABLES_TEMP_TABLE_NAME = 'variables_temp';
+const UNIQUE_PROJECT_KEY_INDEX_NAME = 'variables_project_key_unique';
+const UNIQUE_GLOBAL_KEY_INDEX_NAME = 'variables_global_key_unique';
+/**
+ * Adds a projectId column to the variables table to support project-scoped variables.
+ * Also updates the unique constraints to allow the same key to be used in different projects,
+ * while still enforcing uniqueness for global variables (where projectId is null).
+ */
+export class AddProjectIdToVariableTable1758794506893 implements ReversibleMigration {
+	async up({
+		schemaBuilder: { createTable, column, createIndex, dropTable },
+		queryRunner,
+		escape,
+		copyTable,
+	}: MigrationContext) {
+		const variablesTableName = escape.tableName(VARIABLES_TABLE_NAME);
+		const tempVariablesTableName = escape.tableName(VARIABLES_TEMP_TABLE_NAME);
+
+		await createTable(VARIABLES_TEMP_TABLE_NAME)
+			.withColumns(
+				column('id').varchar(36).primary.notNull,
+				column('key').text.notNull,
+				column('type').text.notNull.default("'string'"),
+				column('value').text,
+				column('projectId').varchar(36),
+			)
+			.withForeignKey('projectId', { tableName: 'project', columnName: 'id', onDelete: 'CASCADE' });
+
+		// Create unique index for project variables (projectId not null)
+		await createIndex(
+			VARIABLES_TEMP_TABLE_NAME,
+			['projectId', 'key'],
+			true,
+			UNIQUE_PROJECT_KEY_INDEX_NAME,
+		);
+
+		// Create unique index for global variables (projectId is null)
+		await queryRunner.query(
+			`CREATE UNIQUE INDEX "${UNIQUE_GLOBAL_KEY_INDEX_NAME}"
+			 ON ${tempVariablesTableName} ("key")
+			 WHERE projectId IS NULL`,
+		);
+
+		// Copy data from old table to new table
+		await copyTable(
+			VARIABLES_TABLE_NAME,
+			VARIABLES_TEMP_TABLE_NAME,
+			['id', 'key', 'type', 'value'],
+			['id', 'key', 'type', 'value'],
+		);
+
+		// Drop old table
+		await dropTable(VARIABLES_TABLE_NAME);
+
+		await queryRunner.query(
+			`ALTER TABLE ${tempVariablesTableName} RENAME TO ${variablesTableName};`,
+		);
+	}
+
+	async down({
+		schemaBuilder: { createTable, column, createIndex, dropTable },
+		queryRunner,
+		escape,
+	}: MigrationContext) {
+		const variablesTableName = escape.tableName(VARIABLES_TABLE_NAME);
+		const tempVariablesTableName = escape.tableName(VARIABLES_TEMP_TABLE_NAME);
+
+		// Create temp table with the old schema (no projectId)
+		await createTable(VARIABLES_TEMP_TABLE_NAME).withColumns(
+			column('id').varchar(36).primary.notNull,
+			column('key').text.notNull,
+			column('type').text.notNull.default("'string'"),
+			column('value').text,
+		);
+
+		// Copy data from current table into temp table (dropping projectId)
+		// We only copy rows where projectId is null to avoid unique constraint violations
+
+		await queryRunner.query(
+			`INSERT INTO ${tempVariablesTableName} (id, "key", type, value) SELECT id, "key", type, value FROM ${variablesTableName} WHERE projectId IS NULL;`,
+		);
+
+		// Drop current table
+		await dropTable(VARIABLES_TABLE_NAME);
+
+		// Rename temp table back to original name
+		await queryRunner.query(
+			`ALTER TABLE ${tempVariablesTableName} RENAME TO ${variablesTableName};`,
+		);
+
+		// Recreate original unique index on key
+		await createIndex(VARIABLES_TABLE_NAME, ['key'], true);
+	}
+}

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -95,6 +95,7 @@ import { ReplaceDataStoreTablesWithDataTables1754475614602 } from '../common/175
 import { AddTimestampsToRoleAndRoleIndexes1756906557570 } from '../common/1756906557570-AddTimestampsToRoleAndRoleIndexes';
 import type { Migration } from '../migration-types';
 import { LinkRoleToProjectRelationTable1753953244168 } from './../common/1753953244168-LinkRoleToProjectRelationTable';
+import { AddProjectIdToVariableTable1758794506893 } from './1758794506893-AddProjectIdToVariableTable';
 
 const sqliteMigrations: Migration[] = [
 	InitialMigration1588102412422,
@@ -193,6 +194,7 @@ const sqliteMigrations: Migration[] = [
 	ReplaceDataStoreTablesWithDataTables1754475614602,
 	LinkRoleToProjectRelationTable1753953244168,
 	AddTimestampsToRoleAndRoleIndexes1756906557570,
+	AddProjectIdToVariableTable1758794506893,
 ];
 
 export { sqliteMigrations };

--- a/packages/cli/src/environments.ee/variables/__tests__/variables.integration.test.ts
+++ b/packages/cli/src/environments.ee/variables/__tests__/variables.integration.test.ts
@@ -1,0 +1,94 @@
+import { createTeamProject, testDb } from '@n8n/backend-test-utils';
+import { VariablesRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
+
+let variablesRepository: VariablesRepository;
+
+beforeAll(async () => {
+	await testDb.init();
+	variablesRepository = Container.get(VariablesRepository);
+});
+
+beforeEach(async () => {
+	await variablesRepository.delete({});
+});
+
+afterAll(async () => {
+	await testDb.terminate();
+});
+
+describe('Variable entity', () => {
+	test('can create multiple variables with the same key in different scopes', async () => {
+		// ARRANGE
+		const project = await createTeamProject();
+
+		// Create a global variable
+		const variable1 = variablesRepository.create({
+			key: 'test',
+			value: 'value1',
+			type: 'string',
+		});
+
+		// Create a project variable with the same key
+		const variable2 = variablesRepository.create({
+			key: 'test',
+			value: 'value2',
+			type: 'string',
+			project: {
+				id: project.id,
+			},
+		});
+
+		await variablesRepository.save(variable1);
+		await variablesRepository.save(variable2);
+	});
+
+	test('cannot create multiple variables with the same key in the same project', async () => {
+		// ARRANGE
+		const project = await createTeamProject();
+
+		// Create a project variable
+		const variable1 = variablesRepository.create({
+			key: 'test',
+			value: 'value1',
+			type: 'string',
+			project: {
+				id: project.id,
+			},
+		});
+
+		// Create another project variable with the same key
+		const variable2 = variablesRepository.create({
+			key: 'test',
+			value: 'value2',
+			type: 'string',
+			project: {
+				id: project.id,
+			},
+		});
+
+		// ACT
+		await variablesRepository.save(variable1);
+		await expect(variablesRepository.save(variable2)).rejects.toThrow();
+	});
+
+	test('cannot create multiple global variables with the same key', async () => {
+		// Create a global variable
+		const variable1 = variablesRepository.create({
+			key: 'test',
+			value: 'value1',
+			type: 'string',
+		});
+
+		// Create another global variable with the same key
+		const variable2 = variablesRepository.create({
+			key: 'test',
+			value: 'value2',
+			type: 'string',
+		});
+
+		// ACT
+		await variablesRepository.save(variable1);
+		await expect(variablesRepository.save(variable2)).rejects.toThrow();
+	});
+});


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds project-scoped variables by adding an optional projectId to the variables entity. Keys are now unique per project and for global variables, allowing the same key in different projects. Addresses N8N-757087.

- **New Features**
  - Optional projectId on variables with onDelete: CASCADE.
  - Uniqueness: (projectId, key) for project variables; key for global variables.

- **Migration**
  - MySQL: drops old unique index, adds projectId, uses generated globalKey column, adds unique indexes.
  - Postgres: adds projectId (CASCADE) and replaces unique key with partial indexes for scoped/global.
  - SQLite: rebuilds table to add projectId, foreign key, and unique indexes.
  - DSL updated to accept onDelete for foreign keys.
  - Down migrations delete project-scoped rows before reverting schema.

<!-- End of auto-generated description by cubic. -->

