### PR TITLE
n8n-auto-pr (N8N - 757709)

### DIFF
--- a/packages/workflow/test/workflow-data-proxy-env-provider.test.ts
+++ b/packages/workflow/test/workflow-data-proxy-env-provider.test.ts
@@ -57,9 +57,9 @@ describe('createEnvProvider', () => {
 		vi.useFakeTimers({ now: new Date() });
 
 		const originalProcess = global.process;
-		// @ts-expect-error process is read-only
-		global.process = undefined;
 		try {
+			// @ts-expect-error process is read-only
+			global.process = undefined;
 			const proxy = createEnvProvider(1, 1, createEnvProviderState());
 
 			expect(() => proxy.someEnvVar).toThrowError(
@@ -70,22 +70,27 @@ describe('createEnvProvider', () => {
 			);
 		} finally {
 			global.process = originalProcess;
+			vi.useRealTimers();
 		}
-
-		vi.useRealTimers();
 	});
 
 	it('should throw ExpressionError when env access is blocked', () => {
-		process.env.N8N_BLOCK_ENV_ACCESS_IN_NODE = 'true';
-		const proxy = createEnvProvider(1, 1, createEnvProviderState());
+		vi.useFakeTimers({ now: new Date() });
 
-		expect(() => proxy.someEnvVar).toThrowError(
-			new ExpressionError('access to env vars denied', {
-				causeDetailed:
-					'If you need access please contact the administrator to remove the environment variable ‘N8N_BLOCK_ENV_ACCESS_IN_NODE‘',
-				runIndex: 1,
-				itemIndex: 1,
-			}),
-		);
+		try {
+			process.env.N8N_BLOCK_ENV_ACCESS_IN_NODE = 'true';
+			const proxy = createEnvProvider(1, 1, createEnvProviderState());
+
+			expect(() => proxy.someEnvVar).toThrowError(
+				new ExpressionError('access to env vars denied', {
+					causeDetailed:
+						'If you need access please contact the administrator to remove the environment variable ‘N8N_BLOCK_ENV_ACCESS_IN_NODE‘',
+					runIndex: 1,
+					itemIndex: 1,
+				}),
+			);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 });


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes flaky tests in workflow-data-proxy-env-provider by properly scoping fake timers and restoring globals, improving test stability. No runtime behavior changes.

- **Bug Fixes**
  - Wrap global.process override in try/finally and restore it after assertions.
  - Use vi.useFakeTimers in tests and ensure vi.useRealTimers is always called in finally.
  - Apply the same timer handling to the env access blocked test.

<!-- End of auto-generated description by cubic. -->

